### PR TITLE
fix(landing): stabilize hero layout and scroll animations

### DIFF
--- a/_layouts/landing.html
+++ b/_layouts/landing.html
@@ -47,13 +47,13 @@ layout: root
 <!-- ================================ -->
 <!-- HERO SECTION                     -->
 <!-- ================================ -->
-<div class="bg-primary text-white position-relative overflow-hidden">
+<div class="bg-primary text-white position-relative overflow-hidden landing-hero">
     <div class="container-xl py-5 px-4 px-md-5">
         <div class="row align-items-center min-vh-50 g-4 g-lg-5">
-            <div class="col-lg-6 order-1">
-                <h1 class="display-4 fw-bold mb-3 animate-on-scroll">{{ page.title }}</h1>
-                <p class="lead mb-4 animate-on-scroll" style="animation-delay: 0.1s;">{{ page.description }}</p>
-                <div class="d-flex flex-column flex-md-row gap-3 animate-on-scroll" style="animation-delay: 0.2s;">
+            <div class="col-lg-6 order-1 landing-hero-copy">
+                <h1 class="display-4 fw-bold mb-3">{{ page.title }}</h1>
+                <p class="lead mb-4">{{ page.description }}</p>
+                <div class="d-flex flex-column flex-md-row gap-3 flex-wrap">
                     <a href="#get-started" class="btn btn-light btn-lg">
                         <i class="bi bi-rocket-takeoff me-2"></i>Get Started
                     </a>
@@ -67,11 +67,25 @@ layout: root
             </div>
             <div class="col-lg-6 text-center order-2">
                 {% if page.hero_image %}
-                <img src="{{ page.hero_image }}" alt="{{ page.title }}" class="img-fluid rounded shadow-lg animate-on-scroll" loading="eager" style="animation-delay: 0.3s;">
+                <div class="landing-hero-media ratio ratio-4x3 mx-auto shadow-lg rounded overflow-hidden">
+                    <img
+                        src="{{ page.hero_image | relative_url }}"
+                        alt="{{ page.title }}"
+                        class="w-100 h-100"
+                        width="800"
+                        height="600"
+                        loading="eager"
+                        decoding="async"
+                        fetchpriority="high"
+                        style="object-fit: contain;"
+                    >
+                </div>
                 {% else %}
-                <div class="bg-secondary rounded p-5 text-body animate-on-scroll">
-                    <i class="bi bi-code-square display-1"></i>
-                    <p class="mt-3 mb-0">Jekyll Theme</p>
+                <div class="landing-hero-media ratio ratio-4x3 mx-auto shadow-lg rounded overflow-hidden">
+                    <div class="position-absolute top-0 start-0 w-100 h-100 d-flex flex-column align-items-center justify-content-center bg-secondary bg-opacity-25 text-body rounded">
+                        <i class="bi bi-code-square display-1"></i>
+                        <p class="mt-3 mb-0 px-3">Jekyll Theme</p>
+                    </div>
                 </div>
                 {% endif %}
             </div>

--- a/_sass/custom.scss
+++ b/_sass/custom.scss
@@ -35,6 +35,28 @@ html, body {
     box-shadow: 0 0.5rem 1rem rgba(0, 0, 0, .35), inset 0 -1px 0 rgba(0, 0, 0, .15);
 }
 
+// Vendored Bootstrap build may omit vh utilities; landing hero uses this for stable min height
+.min-vh-50 {
+    min-height: 50vh;
+}
+
+// Landing layout: stable hero media slot (ratio) + no reliance on scroll script for first paint
+.landing-hero {
+    .landing-hero-media {
+        max-width: min(100%, 28rem);
+    }
+
+    .landing-hero-media.ratio > img {
+        object-position: center;
+    }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .landing-hero .landing-hero-media {
+        transition: none;
+    }
+}
+
 #TableOfContents {
     overflow: hidden;
     text-overflow: ellipsis;

--- a/assets/js/ui-enhancements.js
+++ b/assets/js/ui-enhancements.js
@@ -12,6 +12,16 @@
   /**
    * Initialize scroll animations for elements with animate-on-scroll class
    */
+  /**
+   * True if any part of the element is in the viewport (avoids hiding above-the-fold
+   * content until IntersectionObserver runs — that caused layout “jumps” on the landing hero).
+   */
+  function isInViewport(el) {
+    const rect = el.getBoundingClientRect();
+    const vh = window.innerHeight || document.documentElement.clientHeight;
+    return rect.bottom > 0 && rect.top < vh;
+  }
+
   function initScrollAnimations() {
     if (prefersReducedMotion) return;
 
@@ -35,6 +45,9 @@
     }, observerOptions);
 
     animatedElements.forEach(el => {
+      if (isInViewport(el)) {
+        return;
+      }
       el.style.opacity = '0';
       el.style.transform = 'translateY(30px)';
       el.style.transition = 'opacity 0.6s ease-out, transform 0.6s ease-out';


### PR DESCRIPTION
## Summary

This updates the landing layout and related styles/scripts so the hero section paints consistently and avoids layout jumps from scroll-based animations.

## Changes

- **Landing hero**: Ratio-based media slot for the hero image (with `relative_url`), explicit dimensions, `fetchpriority="high"`, and aligned placeholder when no image is set. Hero headline and CTAs no longer use `animate-on-scroll` so they are not hidden before the observer runs.
- **SCSS**: Adds `.min-vh-50` when the vendored Bootstrap build omits it, plus `.landing-hero` rules for the media slot; respects `prefers-reduced-motion` for hero media transitions.
- **UI enhancements**: Elements already in the viewport are not pre-hidden for scroll animation, preventing above-the-fold flicker or jump.

## Testing

- Build/serve the site locally and open the landing page; confirm hero text and image appear immediately without a flash, and scroll animations still work for content below the fold.

Made with [Cursor](https://cursor.com)