### PR TITLE
Potential fix for code scanning alert no. 20: DOM text reinterpreted as HTML

### DIFF
--- a/_includes/components/zer0-env-var.html
+++ b/_includes/components/zer0-env-var.html
@@ -59,14 +59,37 @@
 
     document.getElementById('submit').addEventListener('click', function() {
         const rows = document.querySelectorAll('#envTable tbody tr');
-        let codeBlockText = '';
-        rows.forEach(row => {
+        const codeBlock = document.getElementById('codeBlock');
+        // Clear previous content safely
+        codeBlock.textContent = '';
+        rows.forEach((row, index) => {
             const key = row.querySelector('td:nth-child(1) input').value;
             const value = row.querySelector('td:nth-child(2) input').value;
             sessionStorage.setItem(key, value);
-            codeBlockText += `<span class="nb">export </span><span class="nv">${key}</span><span class="o">=</span>${value}\n`;
+
+            // Create a line for "export KEY=VALUE" using safe text assignment
+            const line = document.createElement('div');
+
+            const exportSpan = document.createElement('span');
+            exportSpan.className = 'nb';
+            exportSpan.textContent = 'export ';
+            line.appendChild(exportSpan);
+
+            const keySpan = document.createElement('span');
+            keySpan.className = 'nv';
+            keySpan.textContent = key;
+            line.appendChild(keySpan);
+
+            const equalsSpan = document.createElement('span');
+            equalsSpan.className = 'o';
+            equalsSpan.textContent = '=';
+            line.appendChild(equalsSpan);
+
+            // Value is appended as plain text to avoid HTML interpretation
+            line.appendChild(document.createTextNode(value));
+
+            codeBlock.appendChild(line);
         });
-        document.getElementById('codeBlock').innerHTML = codeBlockText;
 
         // Get the environment variables from the session storage
         const GHUSER = sessionStorage.getItem('GHUSER');


### PR DESCRIPTION
Potential fix for [https://github.com/bamr87/zer0-mistakes/security/code-scanning/20](https://github.com/bamr87/zer0-mistakes/security/code-scanning/20)

In general, the fix is to ensure that user-controlled text is not interpreted as HTML. Instead of building an HTML string and assigning it to `innerHTML`, we should build DOM nodes and assign text via `textContent` (or create text nodes) so that any meta-characters are automatically escaped. This preserves the visible behavior (showing “export KEY=VALUE” lines, optionally with styling) without allowing injected HTML/JS.

The best minimal fix here is:

- Stop concatenating HTML into `codeBlockText` and assigning it to `innerHTML`.
- Instead, clear the existing contents of `#codeBlock` and, for each row, create a container element (e.g., `<div>` or `<span>`) and put the “export KEY=VALUE” content into it using `textContent`, appending a newline between lines.
- If you want to preserve the syntax-highlight-like spans (`nb`, `nv`, `o`), you can create each span element with `document.createElement` and set its `textContent` individually. That keeps all styling while avoiding HTML interpolation of user input.

Concretely in `_includes/components/zer0-env-var.html`:

- Replace the `let codeBlockText = '';` initialization and the use of `codeBlockText += ...` with logic that builds DOM nodes.
- Before the loop, grab `const codeBlock = document.getElementById('codeBlock');` and clear it (`codeBlock.textContent = '';`).
- In the loop, for each row, create a container (e.g., `const line = document.createElement('div');`), then create three spans: one static “export ”, one for the key, one for “=”, plus a text node for the value. All dynamic values (`key`, `value`) must be assigned via `textContent` or `createTextNode`, never through string concatenation into HTML.
- Append each `line` to `codeBlock`. This removes the tainted flow into `innerHTML` while providing equivalent behavior.

No new methods or external libraries are required; we only need standard DOM APIs.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
