### PR TITLE
Potential fix for code scanning alert no. 23: DOM text reinterpreted as HTML

### DIFF
--- a/pages/posts.html
+++ b/pages/posts.html
@@ -287,11 +287,15 @@ keywords:
         <script>
           function goToPage(event) {
             event.preventDefault();
-            const pageNum = document.getElementById('page-jump').value;
+            const pageInput = document.getElementById('page-jump');
+            const rawValue = pageInput.value;
+            const pageNum = parseInt(rawValue, 10);
             const maxPages = {{ paginator.total_pages }};
-            if (pageNum >= 1 && pageNum <= maxPages) {
+            if (Number.isFinite(pageNum) && pageNum >= 1 && pageNum <= maxPages) {
+              // normalize the value back into the input
+              pageInput.value = String(pageNum);
               const basePath = '{{ "/posts/" | relative_url }}';
-              window.location.href = pageNum == 1 ? basePath : basePath + pageNum + '/';
+              window.location.href = pageNum === 1 ? basePath : basePath + pageNum + '/';
             }
             return false;
           }


### PR DESCRIPTION
Potential fix for [https://github.com/bamr87/zer0-mistakes/security/code-scanning/23](https://github.com/bamr87/zer0-mistakes/security/code-scanning/23)

In general, to fix “DOM text reinterpreted as HTML” issues, you must avoid using raw text from the DOM directly in contexts where it can be interpreted as HTML or as part of a URL without strict validation. The typical remedies are: (1) perform strict validation and canonicalization (e.g., parse to an integer) and then use the validated value; and/or (2) use safe APIs or encoding functions that prevent interpretation of meta-characters.

For this specific case in `pages/posts.html`, the safest and least intrusive fix is:

1. Explicitly parse the input value into an integer using `parseInt` with a radix.
2. Check that the result is a finite integer within the expected range (`1` to `maxPages`).
3. Use this parsed integer both for the comparison (`=== 1`) and for constructing the URL.
4. Optionally, assign the parsed value back to the input element so the DOM reflects the canonicalized value.

This preserves existing functionality (page jumping via the “Go” button) while making sure that any non-numeric or malicious input is rejected and never used to build the URL. The only file to change is `pages/posts.html`, in the inline `<script>` block defining `goToPage`. No new imports or external libraries are needed; we only rely on built-in JavaScript functions.

Concretely:

- Replace `const pageNum = document.getElementById('page-jump').value;` with code that gets the value, parses it as an integer, and validates it.
- Adjust the subsequent `if` condition and the ternary expression to use the parsed integer, ensuring it is not a tainted string.
- Keep the rest of the logic intact.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
