### PR TITLE
perf(jekyll): cache page-url lookups and short-circuit obsidian rewrites

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,9 @@
 
 ## [Unreleased]
 
+### Changed
+- **Docker/Jekyll build performance** — Reduced repeated full-page Liquid scans in the footer, settings offcanvas, and cookie consent includes; cached preview image checks during generation; skipped server-side Obsidian rewrites for documents without Obsidian syntax; and changed Docker dev startup to run `bundle install` only when `bundle check` reports missing dependencies. The profiled Docker build improved from 119.2s to 86.8s in local validation.
+
 ### Added
 - **Development Automation**: Added `scripts/bin/validate` and `scripts/validate`
   as the canonical preflight validation command for repository files, version

--- a/_includes/components/cookie-consent.html
+++ b/_includes/components/cookie-consent.html
@@ -59,9 +59,8 @@ Configuration: Uses site.posthog settings from _config.yml
         </p>
         <p class="mb-2 mb-lg-0 small text-white-50">
           This website uses cookies and similar technologies to enhance your browsing experience, analyze traffic, and provide personalized content.
-          {% assign _pp = site.html_pages | where: "url", "/privacy-policy/" | first %}
-          {% unless _pp %}{% assign _pp = site.html_pages | where: "url", "/privacy-policy" | first %}{% endunless %}
-          {% if _pp or site.privacy_policy_url %}
+          {% assign cookie_page_urls = site.html_pages | map: "url" | join: "|" | prepend: "|" | append: "|" %}
+          {% if site.privacy_policy_url or cookie_page_urls contains "|/privacy-policy/|" or cookie_page_urls contains "|/privacy-policy|" %}
             <a href="{{ site.privacy_policy_url | default: '/privacy-policy/' | relative_url }}" class="text-white text-decoration-underline">Learn more in our Privacy Policy</a>.
           {% endif %}
         </p>

--- a/_includes/components/info-section.html
+++ b/_includes/components/info-section.html
@@ -22,6 +22,7 @@
 -->
 
 {% include components/env-detect.html %}
+{% assign info_section_page_urls = site.html_pages | map: "url" | join: "|" | prepend: "|" | append: "|" %}
 <!-- Settings Offcanvas -->
 <div class="offcanvas offcanvas-end" tabindex="-1" id="info-section" aria-labelledby="infoSectionLabel">
   
@@ -111,9 +112,12 @@
         <!-- Admin Quick Links — only render links to pages that actually exist
              in the build (prevents 404s on bare-minimum / remote-theme sites
              that haven't created the admin pages). -->
-        {% assign _cfg_page = site.html_pages | where: "url", "/about/config/" | first %}
-        {% assign _theme_page = site.html_pages | where: "url", "/about/settings/theme/" | first %}
-        {% assign _nav_page = site.html_pages | where: "url", "/about/settings/navigation/" | first %}
+        {% assign _cfg_page = false %}
+        {% assign _theme_page = false %}
+        {% assign _nav_page = false %}
+        {% if info_section_page_urls contains "|/about/config/|" %}{% assign _cfg_page = true %}{% endif %}
+        {% if info_section_page_urls contains "|/about/settings/theme/|" %}{% assign _theme_page = true %}{% endif %}
+        {% if info_section_page_urls contains "|/about/settings/navigation/|" %}{% assign _nav_page = true %}{% endif %}
         {% if _cfg_page or _theme_page or _nav_page %}
         <div class="mb-3">
           <h6 class="text-body-secondary small text-uppercase fw-semibold mb-2">
@@ -145,7 +149,8 @@
         {% include components/env-switcher.html %}
 
         <!-- Admin Link — only when target page exists -->
-        {% assign _env_page = site.html_pages | where: "url", "/about/settings/environment/" | first %}
+        {% assign _env_page = false %}
+        {% if info_section_page_urls contains "|/about/settings/environment/|" %}{% assign _env_page = true %}{% endif %}
         {% if _env_page %}
         <div class="mt-4 pt-3 border-top">
           <a href="{{ '/about/settings/environment/' | relative_url }}" class="btn btn-outline-secondary btn-sm w-100">

--- a/_includes/core/footer.html
+++ b/_includes/core/footer.html
@@ -31,6 +31,7 @@
 -->
 
 <footer class="bd-footer border-top" role="contentinfo">
+  {% assign footer_page_urls = site.html_pages | map: "url" | join: "|" | prepend: "|" | append: "|" %}
   <!-- Powered by Row -->
   <div class="container-xl my-3">
     <ul class="nav justify-content-end list-unstyled d-flex align-items-center flex-wrap" aria-label="Powered by technologies">
@@ -100,8 +101,8 @@
                   {% assign _parts = entry | split: "," %}
                   {% assign _label = _parts[0] %}
                   {% assign _url   = _parts[1] %}
-                  {% assign _page  = site.html_pages | where: "url", _url | first %}
-                  {% if _page %}
+                  {% assign _needle = "|" | append: _url | append: "|" %}
+                  {% if footer_page_urls contains _needle %}
                     <li><a href="{{ _url | relative_url }}" class="text-light text-decoration-none">{{ _label }}</a></li>
                   {% endif %}
                 {% endfor %}
@@ -169,14 +170,14 @@
           <div class="col-md-4 text-md-end">
             <ul class="list-inline mb-0">
               {% comment %} Only render policy links whose pages exist (or that are explicitly configured). {% endcomment %}
-              {% assign _privacy = site.html_pages | where: "url", "/privacy-policy/" | first %}
-              {% unless _privacy %}{% assign _privacy = site.html_pages | where: "url", "/privacy-policy" | first %}{% endunless %}
-              {% if _privacy or site.privacy_policy_url %}
+              {% assign _privacy_needle = "|/privacy-policy/|" %}
+              {% assign _privacy_alt_needle = "|/privacy-policy|" %}
+              {% if site.privacy_policy_url or footer_page_urls contains _privacy_needle or footer_page_urls contains _privacy_alt_needle %}
                 <li class="list-inline-item"><a href="{{ site.privacy_policy_url | default: '/privacy-policy' | relative_url }}" class="text-light text-decoration-none">Privacy Policy</a></li>
               {% endif %}
-              {% assign _terms = site.html_pages | where: "url", "/terms-of-service/" | first %}
-              {% unless _terms %}{% assign _terms = site.html_pages | where: "url", "/terms-of-service" | first %}{% endunless %}
-              {% if _terms or site.terms_of_service_url %}
+              {% assign _terms_needle = "|/terms-of-service/|" %}
+              {% assign _terms_alt_needle = "|/terms-of-service|" %}
+              {% if site.terms_of_service_url or footer_page_urls contains _terms_needle or footer_page_urls contains _terms_alt_needle %}
                 <li class="list-inline-item"><a href="{{ site.terms_of_service_url | default: '/terms-of-service' | relative_url }}" class="text-light text-decoration-none">Terms of Service</a></li>
               {% endif %}
               <li class="list-inline-item">

--- a/_plugins/obsidian_links.rb
+++ b/_plugins/obsidian_links.rb
@@ -416,9 +416,14 @@ module Jekyll
 
       def rewrite_document(doc)
         return unless index
+        return unless needs_rewrite?(doc.content)
 
         converter = Converter.new(nil, index, config)
         doc.content = converter.convert(doc.content, current_url: doc.url)
+      end
+
+      def needs_rewrite?(content)
+        content.include?('[[') || content.include?('> [!') || content.match?(Converter::INLINE_TAG_RE)
       end
     end
   end

--- a/_plugins/preview_image_generator.rb
+++ b/_plugins/preview_image_generator.rb
@@ -47,6 +47,9 @@ module Jekyll
 
     # Check if a document has a preview image defined
     def self.has_preview?(doc)
+      cached = cached_preview_entry(doc)
+      return cached['has_preview'] unless cached.nil?
+
       preview = doc.data['preview']
       return false if preview.nil? || preview.to_s.strip.empty?
       
@@ -95,6 +98,9 @@ module Jekyll
 
     # Get the preview image path for a document
     def self.preview_path(doc)
+      cached = cached_preview_entry(doc)
+      return cached['path'] unless cached.nil?
+
       preview = doc.data['preview']
       return nil if preview.nil? || preview.to_s.strip.empty?
       
@@ -113,36 +119,86 @@ module Jekyll
 
     # Get list of documents missing preview images
     def self.missing_previews(site)
+      build_index(site)['missing']
+    end
+
+    def self.build_index(site)
+      cached = site.data['preview_image_index']
+      return cached if cached
+
       config = self.config(site)
+      index = {}
       missing = []
-      
-      config['collections'].each do |collection_name|
+
+      preview_documents(site, config).each do |doc, collection_name|
+        key = preview_cache_key(doc)
+        next if index.key?(key)
+
+        preview = doc.data['preview']
+        normalized_path = nil
+        has_preview = false
+
+        if preview && !preview.to_s.strip.empty? && (preview.match?(/\.(png|jpe?g|gif|svg|webp)$/i) || preview.start_with?('http'))
+          normalized_path = preview.start_with?('http') ? preview : normalize_preview_path(preview, config)
+          has_preview = preview.start_with?('http') || preview_file_exists?(site, normalized_path, config)
+        end
+
+        index[key] = {
+          'has_preview' => has_preview,
+          'path' => normalized_path,
+          'collection' => collection_name
+        }
+
+        next if has_preview
+
+        missing << {
+          'path' => doc.relative_path,
+          'title' => doc.data['title'] || File.basename(doc.relative_path),
+          'collection' => collection_name
+        }
+      end
+
+      site.data['preview_image_index'] = {
+        'documents' => index,
+        'missing' => missing
+      }
+    end
+
+    def self.cached_preview_entry(doc)
+      return nil unless doc.respond_to?(:site) && doc.site && doc.site.data['preview_image_index']
+
+      doc.site.data['preview_image_index']['documents'][preview_cache_key(doc)]
+    end
+
+    def self.preview_documents(site, config)
+      docs = []
+      Array(config['collections']).each do |collection_name|
         collection = site.collections[collection_name]
         next unless collection
-        
-        collection.docs.each do |doc|
-          unless has_preview?(doc)
-            missing << {
-              'path' => doc.relative_path,
-              'title' => doc.data['title'] || File.basename(doc.relative_path),
-              'collection' => collection_name
-            }
-          end
-        end
+
+        collection.docs.each { |doc| docs << [doc, collection_name] }
       end
-      
-      # Also check posts (which are special in Jekyll)
-      site.posts.docs.each do |doc|
-        unless has_preview?(doc)
-          missing << {
-            'path' => doc.relative_path,
-            'title' => doc.data['title'] || File.basename(doc.relative_path),
-            'collection' => 'posts'
-          }
-        end
+
+      site.posts.docs.each { |doc| docs << [doc, 'posts'] } if site.respond_to?(:posts) && site.posts
+      docs
+    end
+
+    def self.preview_cache_key(doc)
+      doc.respond_to?(:relative_path) ? doc.relative_path : doc.path
+    end
+
+    def self.preview_file_exists?(site, normalized_preview, config)
+      candidates = []
+      if normalized_preview.start_with?('/')
+        candidates << File.join(site.source, normalized_preview.sub(/^\//, ''))
+        candidates << File.join(site.source, 'assets', normalized_preview.sub(/^\//, ''))
+      else
+        candidates << File.join(site.source, 'assets', normalized_preview)
+        candidates << File.join(site.source, normalized_preview)
+        candidates << File.join(site.source, config['output_dir'], normalized_preview)
       end
-      
-      missing.uniq { |m| m['path'] }
+
+      candidates.any? { |path| File.exist?(path) }
     end
 
     # Generate a preview image filename from document
@@ -264,7 +320,8 @@ module Jekyll
       return unless config['enabled']
       
       # Store missing previews in site data for access in templates
-      site.data['preview_images_missing'] = PreviewImageGenerator.missing_previews(site)
+      preview_index = PreviewImageGenerator.build_index(site)
+      site.data['preview_images_missing'] = preview_index['missing']
       site.data['preview_images_config'] = config
       
       # Log status

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,9 +28,9 @@ services:
     # Platform specification for Apple Silicon compatibility
     platform: linux/amd64
     
-    # Run bundle install first since volume mount overwrites container's /site
+    # Run bundle install only when needed since volume mount overwrites container's /site
     # Also configure git safe.directory to avoid ownership warnings in CI
-    command: ["sh", "-c", "git config --global --add safe.directory /site 2>/dev/null || true && bundle install --jobs 4 --retry 3 && bundle exec jekyll serve --watch --force_polling --config '_config.yml,_config_dev.yml' --host 0.0.0.0 --port 4000 --livereload"]
+    command: ["sh", "-c", "git config --global --add safe.directory /site 2>/dev/null || true && bundle check || bundle install --jobs 4 --retry 3 && bundle exec jekyll serve --watch --force_polling --config '_config.yml,_config_dev.yml' --host 0.0.0.0 --port 4000 --livereload"]
     
     volumes:
       - .:/site


### PR DESCRIPTION
## Summary

Speeds up the Jekyll build by removing repeated full-site Liquid scans and unnecessary plugin work. Profiled Docker build improved from **119.2s → 86.8s (~27% faster)**.

## Changes

### Plugins
- **`_plugins/obsidian_links.rb`** — `rewrite_document` now short-circuits for documents that don't contain `[[wiki-links]]`, `> [!callouts]`, or inline `#tags`, avoiding full regex passes on plain Markdown.
- **`_plugins/preview_image_generator.rb`** — Builds a single per-site preview index cached in `site.data['preview_image_index']` instead of re-scanning the filesystem for every document.

### Includes (Liquid)
Replaced `site.html_pages | where: "url", "..."` lookups (which scan all pages each time) with one joined-URL string per include and `contains` checks:

- `_includes/core/footer.html`
- `_includes/components/info-section.html`
- `_includes/components/cookie-consent.html`

### Docker
- **`docker-compose.yml`** — Startup uses `bundle check || bundle install` so the container only runs a full bundler install when dependencies actually changed.

### Docs
- **`CHANGELOG.md`** — Note under `[Unreleased] → Changed`.

## Validation

- ✅ `ruby -c` on modified plugins
- ✅ `test/test_obsidian.sh` — 18 runs, 65 assertions, 0 failures
- ✅ `bundle exec jekyll build` (standard + dev configs)
- ✅ `scripts/bin/validate --quick`
- ✅ Profiled build before/after with `--profile`: 119.21s → 86.78s

## Notes

- No public API or theme contract changes.
- No version bump (perf-only); release captured in `[Unreleased]`.
