### PR TITLE
feat(features): update registry to v1.6.1 with 16 new entries and instruction file

### DIFF
--- a/.github/instructions/features.instructions.md
+++ b/.github/instructions/features.instructions.md
@@ -1,0 +1,107 @@
+---
+applyTo: "_data/features.yml,features/features.yml,features/README.md,pages/features.md,_includes/components/feature-card.html"
+description: "Feature registry maintenance — schema, sync contract, and update-on-change rules for zer0-mistakes."
+---
+
+# Feature Registry Instructions
+
+The feature registry is the single source of truth for what the theme does. It powers `pages/features.md`, the `feature-card.html` include, and external documentation. **Whenever code changes add, remove, or materially alter a feature, the registry MUST be updated in the same commit.**
+
+## 📂 Files in Scope
+
+| File | Role |
+| --- | --- |
+| `features/features.yml` | Editable master registry |
+| `_data/features.yml` | Jekyll-consumed copy (must be byte-identical to master) |
+| `features/README.md` | Human index — keep feature count + category list current |
+| `pages/features.md` | Showcase page — uses `site.data.features.features` |
+| `_includes/components/feature-card.html` | Renderer — defines which fields are surfaced |
+
+> Both YAML files exist for historical reasons. Until consolidated, `features/features.yml` → `_data/features.yml` is a hard sync. Do not edit only one.
+
+## 🧬 Feature Schema
+
+```yaml
+- id: ZER0-XXX                # REQUIRED. Sequential, zero-padded to 3 digits. Never reuse or reorder.
+  title: "Short Name"          # REQUIRED. Title-case, no trailing punctuation.
+  description: "One sentence." # REQUIRED. Plain prose, ≤ 200 chars.
+  implemented: true            # REQUIRED. true | false (use false for planned/in-progress).
+  version: "X.Y.Z"             # REQUIRED. Gem version that introduced/last materially changed it.
+  link: "/path/"               # REQUIRED. Live URL or "/" if no dedicated page.
+  docs: "/docs/path/"          # REQUIRED. Public docs URL (prefer `/docs/...` over GitHub URLs).
+  tags: [tag1, tag2]           # REQUIRED. Lowercase, kebab-case. Used by features.md filters.
+  date: YYYY-MM-DD             # REQUIRED. Date the feature was added or last materially changed.
+  references:                  # OPTIONAL but strongly recommended. File paths from repo root.
+    layouts: [...]
+    includes: [...]
+    scripts: [...]
+    config: "..."
+    docs: "..."
+  features: [...]              # OPTIONAL. Sub-capability bullets shown by feature-card.html.
+```
+
+### Field rules
+
+- **`id`** — Allocate the next free `ZER0-NNN`. Never recycle a retired ID; mark removed features `implemented: false` and append `removed_in: "X.Y.Z"` instead of deleting.
+- **`tags`** — Reuse existing tags before inventing new ones (`grep -hoE "[a-z0-9-]+" _data/features.yml | sort -u` for the current set). Filters in `pages/features.md` rely on stable tag names (`ai`, `docker`, `jekyll`, `bootstrap`, `privacy`, `analytics`, `navigation`, `accessibility`, `ui`, `content`, `jupyter`, `mermaid`, `testing`, `ci-cd`, `automation`, `release`, …).
+- **`docs`** — Prefer site-relative paths (`/docs/features/foo/`) so links survive repo moves. External GitHub URLs are allowed only when no public doc exists.
+- **`references`** — Use real paths that exist at commit time. Stale references break trust in the registry.
+
+## 🔄 Sync Contract (REQUIRED)
+
+After every edit:
+
+```bash
+# From repo root
+cp features/features.yml _data/features.yml
+diff -q features/features.yml _data/features.yml   # must report no difference
+python3 -c "import yaml; yaml.safe_load(open('_data/features.yml'))"
+```
+
+The two files must be byte-identical. CI / reviewers may reject PRs where they drift.
+
+## 📝 Header Metadata (REQUIRED)
+
+The top of `_data/features.yml` (and its master) carries:
+
+```yaml
+# Version: <current gem version from lib/jekyll-theme-zer0/version.rb>
+# Last Updated: <YYYY-MM-DD of this edit>
+```
+
+**Update both lines on every change to the registry.** Do not leave them stale (a registry header older than the gem version is a code-review blocker).
+
+Also update the `Current count: **N features**` line and the **Categories** list in `features/README.md` whenever the feature count or category set changes.
+
+## 🚦 When to Touch the Registry
+
+Add, modify, or flag (`implemented: false` + `removed_in:`) an entry **in the same commit** as any of the following:
+
+| Code change | Registry action |
+| --- | --- |
+| New layout, include, plugin, script, or workflow that ships user-visible behavior | Add a new `ZER0-NNN` entry |
+| Material change to an existing feature (new sub-capability, new dependency, new docs) | Bump `version`, refresh `date`, update `features:` / `references:` |
+| Renaming or moving referenced files | Update every affected `references:` block |
+| Removing a feature | Set `implemented: false`, add `removed_in: "X.Y.Z"`, keep the entry |
+| Cutting a release (`./scripts/bin/release …`) | Bump the `# Version:` header to the new gem version, refresh `# Last Updated:` |
+
+Documentation-only changes (typos, formatting in `pages/features.md` or `features/README.md`) do **not** require a `version` bump on individual feature entries.
+
+## ✅ Validation Checklist (run before commit)
+
+- [ ] `features/features.yml` and `_data/features.yml` are identical (`diff -q`)
+- [ ] YAML parses (`python3 -c "import yaml; yaml.safe_load(open('_data/features.yml'))"`)
+- [ ] Header `# Version:` matches `lib/jekyll-theme-zer0/version.rb`
+- [ ] Header `# Last Updated:` is today
+- [ ] `features/README.md` feature count matches `grep -c "^  - id: ZER0-" _data/features.yml`
+- [ ] All `references:` paths exist in the repo
+- [ ] Jekyll renders the showcase page without Liquid errors:
+      `docker-compose exec -T jekyll bundle exec jekyll build --config '_config.yml,_config_dev.yml'`
+
+## 🧱 Renderer Contract (`feature-card.html`)
+
+When adding fields, check the include — only fields it reads will appear on `/features/`. Adding a field to YAML without updating the renderer is silent dead data. If a new field should be surfaced, extend `_includes/components/feature-card.html` and document the parameter in its header comment.
+
+---
+
+_Keep this file short. Project-wide conventions live in [`copilot-instructions.md`](../copilot-instructions.md); release/version mechanics live in [`version-control.instructions.md`](./version-control.instructions.md)._

--- a/_data/features.yml
+++ b/_data/features.yml
@@ -1132,7 +1132,6 @@ features:
     references:
       includes:
         - "_includes/navigation/navbar.html"
-        - "_includes/navigation/menu-collections.html"
 
   - id: ZER0-050
     title: "Admin Layout & Configuration Dashboards"
@@ -1174,7 +1173,7 @@ features:
     references:
       data: "_data/roadmap.yml"
       page: "pages/roadmap.md"
-      script: "scripts/generate-roadmap-diagram.sh"
+      script: "scripts/generate-roadmap.sh"
 
   - id: ZER0-053
     title: "Vendored Bootstrap & Icon Assets"
@@ -1203,8 +1202,9 @@ features:
     date: 2025-12-30
     references:
       includes:
-        - "_includes/content/structured-data.html"
-        - "_includes/content/eeat-signals.html"
+        - "_includes/content/seo.html"
+        - "_includes/content/jsonld-faq.html"
+        - "_includes/components/author-eeat.html"
       pages:
         - "pages/faq.md"
         - "pages/glossary.md"
@@ -1224,7 +1224,6 @@ features:
         - "assets/js/navigation.js"
       includes:
         - "_includes/navigation/navbar.html"
-        - "_includes/components/settings-modal.html"
 
   - id: ZER0-056
     title: "DevContainer Configuration"

--- a/_data/features.yml
+++ b/_data/features.yml
@@ -53,7 +53,7 @@ features:
     title: "Modular AI-Powered Installer"
     description: "Self-healing installer rebuilt as a modular CLI dispatcher with declarative profiles, deploy plugins (Docker, GitHub Pages, custom), AI agent integration, and a cross-platform test matrix. Replaces the monolithic install.sh while preserving the one-line install UX"
     implemented: true
-    version: "0.22.22"
+    version: "1.0.0"
     link: "/"
     docs: "/docs/installation/"
     tags: [ai, automation, installation, error-handling, bash, installer]
@@ -1037,12 +1037,12 @@ features:
     references:
       plugin: "_plugins/obsidian_links.rb"
       scripts:
-        - "assets/js/obsidian-resolver.js"
+        - "assets/js/obsidian-wiki-links.js"
         - "assets/js/obsidian-graph.js"
       data: "assets/data/wiki-index.json"
       includes:
         - "_includes/content/backlinks.html"
-        - "_includes/content/wiki-graph.html"
+        - "_includes/obsidian/full-graph.html"
       docs: "pages/_docs/obsidian/"
       tests:
         - "test/test_obsidian.sh"
@@ -1069,8 +1069,8 @@ features:
     date: 2026-03-25
     references:
       includes:
-        - "_includes/content/wiki-graph.html"
-        - "_includes/content/wiki-graph-local.html"
+        - "_includes/obsidian/full-graph.html"
+        - "_includes/navigation/local-graph.html"
       scripts:
         - "assets/js/obsidian-graph.js"
 
@@ -1088,11 +1088,10 @@ features:
     tags: [setup, quickstart, remote-theme, github-pages]
     date: 2026-02-25
     references:
-      starter: "../zer0-pages-remote/"
       includes:
-        - "_includes/welcome.html"
-        - "_includes/info.html"
+        - "_includes/components/info-section.html"
         - "_includes/core/footer.html"
+      layout: "_layouts/welcome.html"
 
   - id: ZER0-047
     title: "Site Configuration Detection & Smart 404"
@@ -1117,8 +1116,8 @@ features:
     tags: [validation, frontmatter, content, ci-cd, automation]
     date: 2026-01-25
     references:
-      script: "scripts/validate-frontmatter.sh"
-      config: "_data/frontmatter-schema.yml"
+      script: "scripts/bin/validate"
+      config: ".github/config/frontmatter_schema.yml"
       prompt: ".github/prompts/frontmatter-maintainer.prompt.md"
 
   - id: ZER0-049
@@ -1147,7 +1146,8 @@ features:
     references:
       layout: "_layouts/admin.html"
       includes:
-        - "_includes/admin/"
+        - "_includes/navigation/admin-nav.html"
+        - "_includes/components/admin-tabs.html"
 
   - id: ZER0-051
     title: "AGENTS.md Cross-Tool Agent Entry Point"
@@ -1238,7 +1238,6 @@ features:
     references:
       config:
         - ".devcontainer/devcontainer.json"
-        - ".devcontainer/Dockerfile"
 
   - id: ZER0-057
     title: "Local Docker Publishing Pipeline"
@@ -1261,7 +1260,7 @@ features:
     implemented: true
     version: "0.20.0"
     link: "/notes/"
-    docs: "/docs/content/notes/"
+    docs: "/notes/"
     tags: [content, collections, notes, jekyll]
     date: 2025-12-15
     references:

--- a/_data/features.yml
+++ b/_data/features.yml
@@ -1,7 +1,7 @@
 # zer0-mistakes Theme Features Registry
 # Comprehensive feature tracking for the zer0-mistakes Jekyll theme
-# Version: 0.15.1
-# Last Updated: 2025-12-16
+# Version: 1.6.1
+# Last Updated: 2026-05-05
 
 features:
   # ============================================================================
@@ -50,25 +50,32 @@ features:
       - "Automated dependency installation"
   
   - id: ZER0-003
-    title: "AI-Powered Installation System"
-    description: "Self-healing installation script with 95% success rate. 1,090-line Bash script with intelligent error recovery, platform detection, and automated fixes for 27+ common scenarios"
+    title: "Modular AI-Powered Installer"
+    description: "Self-healing installer rebuilt as a modular CLI dispatcher with declarative profiles, deploy plugins (Docker, GitHub Pages, custom), AI agent integration, and a cross-platform test matrix. Replaces the monolithic install.sh while preserving the one-line install UX"
     implemented: true
-    version: "0.6.0"
+    version: "0.22.22"
     link: "/"
     docs: "/docs/installation/"
-    tags: [ai, automation, installation, error-handling, bash]
-    date: 2025-01-27
+    tags: [ai, automation, installation, error-handling, bash, installer]
+    date: 2026-02-15
     references:
       script: "install.sh"
-      init: "init_setup.sh"
+      cli: "scripts/bin/install"
+      lib: "scripts/lib/install/"
+      profiles: "templates/profiles/"
+      deploy: "templates/deploy/"
+      agents: "templates/agents/"
+      ai: "templates/ai/"
+      instructions: ".github/instructions/install.instructions.md"
     features:
-      - "One-line installation command"
-      - "Automatic platform detection"
-      - "Docker dependency validation"
+      - "Modular library architecture (scripts/lib/install/)"
+      - "Declarative profile templates"
+      - "Pluggable deploy targets (Docker, GitHub Pages, custom)"
+      - "Cross-platform test matrix"
+      - "AI agent integration scaffolding"
+      - "Backwards-compatible one-line install"
       - "Self-healing error recovery"
-      - "Comprehensive logging"
-      - "Rollback capability"
-      - "Progress indicators"
+      - "Platform detection (macOS / Linux / Windows WSL)"
   
   # ============================================================================
   # AI-POWERED FEATURES
@@ -76,9 +83,9 @@ features:
   
   - id: ZER0-004
     title: "AI Preview Image Generator"
-    description: "AI-powered automatic preview image generation for posts using OpenAI DALL-E, Stability AI, or local placeholders. Configurable via _config.yml with retro pixel art style defaults"
+    description: "AI-powered automatic preview image generation for posts using OpenAI gpt-image-2 / DALL-E, Stability AI, xAI, or local placeholders. Configurable assets prefix, retro pixel art defaults, batch regeneration"
     implemented: true
-    version: "0.8.0"
+    version: "1.5.0"
     link: "/docs/features/preview-image-generator/"
     docs: "/docs/features/preview-image-generator/"
     tags: [ai, images, automation, openai, content]
@@ -97,11 +104,14 @@ features:
       optional: [yq, python3]
     providers:
       - name: openai
-        description: "OpenAI DALL-E 3 image generation"
+        description: "OpenAI gpt-image-2 / DALL-E 3 image generation"
         env_var: OPENAI_API_KEY
       - name: stability
         description: "Stability AI Stable Diffusion"
         env_var: STABILITY_API_KEY
+      - name: xai
+        description: "xAI Grok image generation"
+        env_var: XAI_API_KEY
       - name: local
         description: "Local placeholder (no API needed)"
         env_var: null
@@ -113,28 +123,40 @@ features:
       - "Batch processing"
   
   - id: ZER0-005
-    title: "GitHub Copilot Integration"
-    description: "Comprehensive AI development assistance with structured instructions, file-specific guidance, and front matter optimization for maximum AI productivity"
+    title: "AI Agent Integration (Copilot + AGENTS.md)"
+    description: "Comprehensive AI development assistance with the cross-tool AGENTS.md entry point, file-scoped instruction files (layouts, includes, scripts, sass, obsidian, install, features, version-control, testing, documentation), reusable prompts, and Cursor slash-commands"
     implemented: true
-    version: "0.15.0"
-    link: "https://github.com/bamr87/zer0-mistakes/blob/main/.github/copilot-instructions.md"
+    version: "1.6.0"
+    link: "https://github.com/bamr87/zer0-mistakes/blob/main/AGENTS.md"
     docs: "/docs/features/copilot-integration/"
-    tags: [ai, copilot, development, documentation]
-    date: 2025-11-15
+    tags: [ai, copilot, agents, development, documentation]
+    date: 2026-04-18
     references:
+      entry_point: "AGENTS.md"
+      main: ".github/copilot-instructions.md"
       instructions:
-        - ".github/copilot-instructions.md"
         - ".github/instructions/layouts.instructions.md"
         - ".github/instructions/includes.instructions.md"
         - ".github/instructions/scripts.instructions.md"
+        - ".github/instructions/sass.instructions.md"
+        - ".github/instructions/obsidian.instructions.md"
+        - ".github/instructions/install.instructions.md"
+        - ".github/instructions/features.instructions.md"
         - ".github/instructions/testing.instructions.md"
-        - ".github/instructions/version-control.instructions.md"
         - ".github/instructions/documentation.instructions.md"
+        - ".github/instructions/version-control.instructions.md"
+      prompts:
+        - ".github/prompts/commit-publish.prompt.md"
+        - ".github/prompts/frontmatter-maintainer.prompt.md"
+        - ".github/prompts/obsidian-add-syntax.prompt.md"
+        - ".github/prompts/seed.prompt.md"
+      cursor: ".cursor/commands/"
     features:
-      - "File-pattern specific instructions"
-      - "Development workflow guidance"
-      - "Best practices documentation"
-      - "AI-optimized front matter"
+      - "AGENTS.md cross-tool entry point (Copilot, Codex, Cursor, Aider, …)"
+      - "File-pattern specific instructions via applyTo globs"
+      - "Reusable agent/chat prompts"
+      - "Cursor IDE slash-commands mirror"
+      - "AI-optimized front matter standards"
       - "Automated code generation helpers"
   
   # ============================================================================
@@ -736,19 +758,20 @@ features:
       - "Smooth theme transitions"
 
   - id: ZER0-032
-    title: "Site Search"
-    description: "Client-side search functionality with modal interface, JSON index, and keyboard shortcut activation"
+    title: "GitHub Pages-Compatible Live Search"
+    description: "Self-contained client-side search with live modal, JSON index, and keyboard shortcut activation. Algolia-free — works on bare GitHub Pages with no external service or API key"
     implemented: true
-    version: "0.1.0"
+    version: "1.5.1"
     link: "/"
     docs: "/docs/features/site-search/"
     tags: [search, navigation, modal, keyboard]
-    date: 2025-01-01
+    date: 2026-04-10
     references:
       scripts:
         - "assets/js/search-modal.js"
       includes:
         - "_includes/components/search-modal.html"
+        - "_includes/components/searchbar.html"
       data:
         - "search.json"
     features:
@@ -757,6 +780,7 @@ features:
       - "Keyboard shortcut (/) activation"
       - "Real-time search results"
       - "Accessible search input"
+      - "No external dependency (Algolia removed v1.5.1)"
 
   - id: ZER0-033
     title: "Auto-hide Navigation"
@@ -996,3 +1020,266 @@ features:
       - "Tag cloud visualization"
       - "Content statistics"
       - "Responsive card layout"
+
+  # ============================================================================
+  # OBSIDIAN VAULT INTEGRATION (v1.3.0+)
+  # ============================================================================
+
+  - id: ZER0-044
+    title: "Obsidian Vault Integration"
+    description: "Render an Obsidian vault as a Jekyll site without losing wiki-links, embeds, callouts, or backlinks. Includes a Liquid wiki-index, JS client-side resolver, optional Ruby plugin, and a contract that keeps GitHub Pages and self-build deployments rendering identically"
+    implemented: true
+    version: "1.3.0"
+    link: "/docs/obsidian/"
+    docs: "/docs/obsidian/"
+    tags: [obsidian, content, wiki-links, knowledge-base, jekyll]
+    date: 2026-03-12
+    references:
+      plugin: "_plugins/obsidian_links.rb"
+      scripts:
+        - "assets/js/obsidian-resolver.js"
+        - "assets/js/obsidian-graph.js"
+      data: "assets/data/wiki-index.json"
+      includes:
+        - "_includes/content/backlinks.html"
+        - "_includes/content/wiki-graph.html"
+      docs: "pages/_docs/obsidian/"
+      tests:
+        - "test/test_obsidian.sh"
+        - "test/test_ruby_converter.rb"
+        - "test/test_resolver.js"
+      instructions: ".github/instructions/obsidian.instructions.md"
+    features:
+      - "[[Wiki-links]] resolution"
+      - "![[Embeds]] rendering"
+      - "Callout blocks"
+      - "Automatic backlinks panel"
+      - "Graph view (full + local)"
+      - "GitHub Pages compatible (no plugin required)"
+      - "Optional Ruby plugin for self-builds"
+
+  - id: ZER0-045
+    title: "Obsidian Local Graph Panel"
+    description: "Standalone neighborhood graph view for the current note, extracted as a reusable include for sidebars and modals"
+    implemented: true
+    version: "1.4.0"
+    link: "/docs/obsidian/graph/"
+    docs: "/docs/obsidian/graph/"
+    tags: [obsidian, graph, visualization, navigation]
+    date: 2026-03-25
+    references:
+      includes:
+        - "_includes/content/wiki-graph.html"
+        - "_includes/content/wiki-graph-local.html"
+      scripts:
+        - "assets/js/obsidian-graph.js"
+
+  # ============================================================================
+  # SETUP, NAVIGATION & DEVELOPER UX (v0.20+)
+  # ============================================================================
+
+  - id: ZER0-046
+    title: "Bare-Minimum Remote-Theme Starter"
+    description: "Three-file welcome starter (_config.yml + Gemfile + index.md) that bootstraps a working remote-theme site with no scaffolding required. Footer, welcome, and info partials degrade gracefully when collections are empty"
+    implemented: true
+    version: "1.2.0"
+    link: "/"
+    docs: "/docs/quickstart/bare-minimum/"
+    tags: [setup, quickstart, remote-theme, github-pages]
+    date: 2026-02-25
+    references:
+      starter: "../zer0-pages-remote/"
+      includes:
+        - "_includes/welcome.html"
+        - "_includes/info.html"
+        - "_includes/core/footer.html"
+
+  - id: ZER0-047
+    title: "Site Configuration Detection & Smart 404"
+    description: "Auto-detects whether the site is a fork, remote-theme consumer, or full clone, and renders a smart 404 page that guides users back to a working entry point"
+    implemented: true
+    version: "0.22.18"
+    link: "/404.html"
+    docs: "/docs/features/smart-404/"
+    tags: [setup, 404, configuration, ux]
+    date: 2026-01-30
+    references:
+      page: "404.html"
+      docs: "pages/_docs/features/smart-404.md"
+
+  - id: ZER0-048
+    title: "Config-Driven Frontmatter Validation"
+    description: "Schema-driven frontmatter validation system with configurable rules per collection. Catches missing required fields, bad date formats, and unknown layouts before Jekyll builds"
+    implemented: true
+    version: "0.22.17"
+    link: "/"
+    docs: "/docs/development/frontmatter-validation/"
+    tags: [validation, frontmatter, content, ci-cd, automation]
+    date: 2026-01-25
+    references:
+      script: "scripts/validate-frontmatter.sh"
+      config: "_data/frontmatter-schema.yml"
+      prompt: ".github/prompts/frontmatter-maintainer.prompt.md"
+
+  - id: ZER0-049
+    title: "Dynamic Collection-Based Navigation Fallback"
+    description: "Zero-config navigation: when no _data/navigation entry exists, the navbar auto-populates from Jekyll collections so brand-new sites have a usable nav out of the box"
+    implemented: true
+    version: "0.22.15"
+    link: "/"
+    docs: "/docs/features/dynamic-navigation/"
+    tags: [navigation, ui, zero-config, jekyll]
+    date: 2026-01-15
+    references:
+      includes:
+        - "_includes/navigation/navbar.html"
+        - "_includes/navigation/menu-collections.html"
+
+  - id: ZER0-050
+    title: "Admin Layout & Configuration Dashboards"
+    description: "Admin-style layout and dashboard partials for surfacing site configuration, build info, and feature flags in a single place"
+    implemented: true
+    version: "0.21.4"
+    link: "/admin/"
+    docs: "/docs/features/admin-dashboard/"
+    tags: [admin, dashboard, ui, configuration]
+    date: 2025-12-28
+    references:
+      layout: "_layouts/admin.html"
+      includes:
+        - "_includes/admin/"
+
+  - id: ZER0-051
+    title: "AGENTS.md Cross-Tool Agent Entry Point"
+    description: "Repository-root entry point for AI coding agents (Copilot, Codex, Cursor, Aider, Jules, Continue, Claude Code, \u2026) that links into the layered guidance under .github/. Single source of truth, no per-tool duplication"
+    implemented: true
+    version: "0.22.16"
+    link: "https://github.com/bamr87/zer0-mistakes/blob/main/AGENTS.md"
+    docs: "/docs/development/agents/"
+    tags: [ai, agents, documentation, copilot, cursor]
+    date: 2026-01-20
+    references:
+      file: "AGENTS.md"
+      instructions_index: ".github/instructions/README.md"
+
+  - id: ZER0-052
+    title: "Data-Driven Roadmap with Auto-Generated Diagram"
+    description: "Roadmap page rendered from a YAML data source, with an auto-generated Mermaid diagram embedded in README.md"
+    implemented: true
+    version: "0.22.21"
+    link: "/roadmap/"
+    docs: "/roadmap/"
+    tags: [roadmap, documentation, mermaid, automation]
+    date: 2026-02-08
+    references:
+      data: "_data/roadmap.yml"
+      page: "pages/roadmap.md"
+      script: "scripts/generate-roadmap-diagram.sh"
+
+  - id: ZER0-053
+    title: "Vendored Bootstrap & Icon Assets"
+    description: "Bootstrap 5.3.3 CSS/JS and Bootstrap Icons committed under assets/vendor/ for GitHub Pages safety and offline development. Refreshable via scripts/vendor-install.sh"
+    implemented: true
+    version: "0.21.3"
+    link: "/"
+    docs: "/docs/features/vendored-assets/"
+    tags: [bootstrap, assets, vendor, github-pages, performance]
+    date: 2025-12-20
+    references:
+      script: "scripts/vendor-install.sh"
+      manifest: "vendor-manifest.json"
+      assets:
+        - "assets/vendor/bootstrap/"
+        - "assets/vendor/bootstrap-icons/"
+
+  - id: ZER0-054
+    title: "AIEO Structured Data, FAQ & Glossary"
+    description: "AI-Engine Optimization toolkit: Schema.org JSON-LD, E-E-A-T signals, FAQ page, and glossary collection for stronger AI search and LLM grounding"
+    implemented: true
+    version: "0.21.5"
+    link: "/glossary/"
+    docs: "/docs/seo/aieo/"
+    tags: [seo, aieo, structured-data, faq, glossary, ai]
+    date: 2025-12-30
+    references:
+      includes:
+        - "_includes/content/structured-data.html"
+        - "_includes/content/eeat-signals.html"
+      pages:
+        - "pages/faq.md"
+        - "pages/glossary.md"
+
+  - id: ZER0-055
+    title: "ES6 Modular Navigation Architecture"
+    description: "Navigation JavaScript refactored into ES6 modules with hover dropdowns, settings modal, and a navbar that degrades gracefully on slow connections"
+    implemented: true
+    version: "0.18.0"
+    link: "/"
+    docs: "/docs/features/navigation-architecture/"
+    tags: [navigation, javascript, es6, ui, performance]
+    date: 2025-12-12
+    references:
+      scripts:
+        - "assets/js/modules/"
+        - "assets/js/navigation.js"
+      includes:
+        - "_includes/navigation/navbar.html"
+        - "_includes/components/settings-modal.html"
+
+  - id: ZER0-056
+    title: "DevContainer Configuration"
+    description: "VS Code Dev Container configuration for one-click cloud development environments (GitHub Codespaces, JetBrains Gateway, etc.) with Jekyll, Ruby, and Bootstrap toolchain pre-installed"
+    implemented: true
+    version: "0.17.0"
+    link: "/"
+    docs: "/docs/development/devcontainer/"
+    tags: [devcontainer, codespaces, development, docker]
+    date: 2025-12-10
+    references:
+      config:
+        - ".devcontainer/devcontainer.json"
+        - ".devcontainer/Dockerfile"
+
+  - id: ZER0-057
+    title: "Local Docker Publishing Pipeline"
+    description: "Publish the gem from a clean Docker container locally, mirroring the CI release path for reproducible releases without polluting the host Ruby environment"
+    implemented: true
+    version: "0.21.1"
+    link: "/"
+    docs: "/docs/development/docker-publishing/"
+    tags: [docker, release, ci-cd, gem, automation]
+    date: 2025-12-22
+    references:
+      compose:
+        - "docker-compose.publish.yml"
+        - "docker-compose.prod.yml"
+      script: "scripts/bin/release"
+
+  - id: ZER0-058
+    title: "Notes Collection & Notebook Layout"
+    description: "Dedicated _notes collection alongside _notebooks, with shared standardized layouts for short-form knowledge capture distinct from blog posts"
+    implemented: true
+    version: "0.20.0"
+    link: "/notes/"
+    docs: "/docs/content/notes/"
+    tags: [content, collections, notes, jekyll]
+    date: 2025-12-15
+    references:
+      collection: "pages/_notes/"
+      layouts:
+        - "_layouts/note.html"
+      config: "_config.yml"
+
+  - id: ZER0-059
+    title: "Performance: Page-URL Cache for Obsidian Resolver"
+    description: "Cached page-URL lookups and short-circuited rewrites in the Obsidian Liquid pipeline. Measurable build-time improvement on vaults with hundreds of cross-links"
+    implemented: true
+    version: "1.6.0"
+    link: "/docs/obsidian/performance/"
+    docs: "/docs/obsidian/performance/"
+    tags: [obsidian, performance, jekyll, optimization]
+    date: 2026-04-30
+    references:
+      plugin: "_plugins/obsidian_links.rb"
+      includes:
+        - "_includes/content/backlinks.html"

--- a/features/README.md
+++ b/features/README.md
@@ -42,30 +42,35 @@ Each feature includes:
 
 Features are organized into these categories:
 
-1. **Core Infrastructure** - Bootstrap, Docker, Installation
-2. **AI-Powered Features** - Preview Generation, Copilot Integration
-3. **Analytics & Privacy** - PostHog, Cookie Consent
-4. **Navigation & UI** - Sidebar, Keyboard Navigation, Mobile TOC
-5. **Content Management** - Jupyter Notebooks, Mermaid, Collections
-6. **Developer Experience** - Testing, CI/CD, Release Automation
-7. **Layouts & Templates** - 15+ layouts, 70+ includes
-8. **Plugins & Extensions** - Custom Jekyll plugins
-9. **Legal & Compliance** - Privacy Policy, Terms of Service
-10. **Documentation** - PRD, Dual Architecture
-11. **Automation & Workflows** - GitHub Actions
-12. **Utility Scripts** - Automation library
+1. **Core Infrastructure** — Bootstrap, Docker, Modular Installer
+2. **AI-Powered Features** — Preview generation, Copilot/AGENTS.md integration
+3. **Analytics & Privacy** — PostHog, Cookie Consent, Google Analytics, GTM
+4. **Navigation & UI** — Sidebar, Keyboard nav, Mobile TOC, ES6 modular nav, Dynamic nav fallback
+5. **Content Management** — Jupyter Notebooks, Mermaid, Collections, Notes
+6. **Obsidian Vault Integration** — Wiki-links, embeds, callouts, backlinks, graph view
+7. **Developer Experience** — Testing, CI/CD, Release Automation, DevContainer, Local Docker Publishing
+8. **Layouts & Templates** — 15+ layouts, 70+ includes, Admin dashboard
+9. **Plugins & Extensions** — Custom Jekyll plugins
+10. **Legal & Compliance** — Privacy Policy, Terms of Service
+11. **Documentation** — PRD, Dual Architecture, AGENTS.md, Roadmap
+12. **Automation & Workflows** — GitHub Actions, Frontmatter Validation
+13. **Utility Scripts** — Automation library, Vendored assets
+14. **SEO & AIEO** — Meta tags, sitemap, structured data, FAQ, glossary
+15. **Setup & Quickstart** — Bare-minimum starter, Smart 404, Site config detection
 
 ## Adding New Features
 
 When adding a new feature:
 
 1. Add the feature to `features/features.yml`
-2. Use the next sequential ID (ZER0-XXX)
-3. Include all required fields (id, title, description, implemented, version, tags, date)
+2. Use the next sequential ID (ZER0-XXX) — never reuse retired IDs
+3. Include all required fields (id, title, description, implemented, version, tags, date, link, docs)
 4. Add file references under `references:`
 5. Link to documentation if available
-6. Copy to `_data/features.yml`
+6. Copy to `_data/features.yml` (the two files must stay byte-identical)
 7. Update the features page if needed
+
+See [.github/instructions/features.instructions.md](../.github/instructions/features.instructions.md) for the full schema and sync contract.
 
 ## Validation
 
@@ -73,8 +78,9 @@ Validate YAML syntax:
 
 ```bash
 python3 -c "import yaml; yaml.safe_load(open('features/features.yml'))"
+diff -q features/features.yml _data/features.yml   # must report no difference
 ```
 
 ## Feature Count
 
-Current count: **28 features** (as of 2025-12-16)
+Current count: **59 features** (as of 2026-05-05, gem v1.6.1)

--- a/features/features.yml
+++ b/features/features.yml
@@ -53,7 +53,7 @@ features:
     title: "Modular AI-Powered Installer"
     description: "Self-healing installer rebuilt as a modular CLI dispatcher with declarative profiles, deploy plugins (Docker, GitHub Pages, custom), AI agent integration, and a cross-platform test matrix. Replaces the monolithic install.sh while preserving the one-line install UX"
     implemented: true
-    version: "0.22.22"
+    version: "1.0.0"
     link: "/"
     docs: "/docs/installation/"
     tags: [ai, automation, installation, error-handling, bash, installer]

--- a/features/features.yml
+++ b/features/features.yml
@@ -1132,7 +1132,6 @@ features:
     references:
       includes:
         - "_includes/navigation/navbar.html"
-        - "_includes/navigation/menu-collections.html"
 
   - id: ZER0-050
     title: "Admin Layout & Configuration Dashboards"
@@ -1174,7 +1173,7 @@ features:
     references:
       data: "_data/roadmap.yml"
       page: "pages/roadmap.md"
-      script: "scripts/generate-roadmap-diagram.sh"
+      script: "scripts/generate-roadmap.sh"
 
   - id: ZER0-053
     title: "Vendored Bootstrap & Icon Assets"
@@ -1203,8 +1202,9 @@ features:
     date: 2025-12-30
     references:
       includes:
-        - "_includes/content/structured-data.html"
-        - "_includes/content/eeat-signals.html"
+        - "_includes/content/seo.html"
+        - "_includes/content/jsonld-faq.html"
+        - "_includes/components/author-eeat.html"
       pages:
         - "pages/faq.md"
         - "pages/glossary.md"
@@ -1224,7 +1224,6 @@ features:
         - "assets/js/navigation.js"
       includes:
         - "_includes/navigation/navbar.html"
-        - "_includes/components/settings-modal.html"
 
   - id: ZER0-056
     title: "DevContainer Configuration"

--- a/features/features.yml
+++ b/features/features.yml
@@ -1,7 +1,7 @@
 # zer0-mistakes Theme Features Registry
 # Comprehensive feature tracking for the zer0-mistakes Jekyll theme
-# Version: 0.15.1
-# Last Updated: 2025-12-16
+# Version: 1.6.1
+# Last Updated: 2026-05-05
 
 features:
   # ============================================================================
@@ -50,25 +50,32 @@ features:
       - "Automated dependency installation"
   
   - id: ZER0-003
-    title: "AI-Powered Installation System"
-    description: "Self-healing installation script with 95% success rate. 1,090-line Bash script with intelligent error recovery, platform detection, and automated fixes for 27+ common scenarios"
+    title: "Modular AI-Powered Installer"
+    description: "Self-healing installer rebuilt as a modular CLI dispatcher with declarative profiles, deploy plugins (Docker, GitHub Pages, custom), AI agent integration, and a cross-platform test matrix. Replaces the monolithic install.sh while preserving the one-line install UX"
     implemented: true
-    version: "0.6.0"
+    version: "0.22.22"
     link: "/"
     docs: "/docs/installation/"
-    tags: [ai, automation, installation, error-handling, bash]
-    date: 2025-01-27
+    tags: [ai, automation, installation, error-handling, bash, installer]
+    date: 2026-02-15
     references:
       script: "install.sh"
-      init: "init_setup.sh"
+      cli: "scripts/bin/install"
+      lib: "scripts/lib/install/"
+      profiles: "templates/profiles/"
+      deploy: "templates/deploy/"
+      agents: "templates/agents/"
+      ai: "templates/ai/"
+      instructions: ".github/instructions/install.instructions.md"
     features:
-      - "One-line installation command"
-      - "Automatic platform detection"
-      - "Docker dependency validation"
+      - "Modular library architecture (scripts/lib/install/)"
+      - "Declarative profile templates"
+      - "Pluggable deploy targets (Docker, GitHub Pages, custom)"
+      - "Cross-platform test matrix"
+      - "AI agent integration scaffolding"
+      - "Backwards-compatible one-line install"
       - "Self-healing error recovery"
-      - "Comprehensive logging"
-      - "Rollback capability"
-      - "Progress indicators"
+      - "Platform detection (macOS / Linux / Windows WSL)"
   
   # ============================================================================
   # AI-POWERED FEATURES
@@ -76,9 +83,9 @@ features:
   
   - id: ZER0-004
     title: "AI Preview Image Generator"
-    description: "AI-powered automatic preview image generation for posts using OpenAI DALL-E, Stability AI, or local placeholders. Configurable via _config.yml with retro pixel art style defaults"
+    description: "AI-powered automatic preview image generation for posts using OpenAI gpt-image-2 / DALL-E, Stability AI, xAI, or local placeholders. Configurable assets prefix, retro pixel art defaults, batch regeneration"
     implemented: true
-    version: "0.8.0"
+    version: "1.5.0"
     link: "/docs/features/preview-image-generator/"
     docs: "/docs/features/preview-image-generator/"
     tags: [ai, images, automation, openai, content]
@@ -97,11 +104,14 @@ features:
       optional: [yq, python3]
     providers:
       - name: openai
-        description: "OpenAI DALL-E 3 image generation"
+        description: "OpenAI gpt-image-2 / DALL-E 3 image generation"
         env_var: OPENAI_API_KEY
       - name: stability
         description: "Stability AI Stable Diffusion"
         env_var: STABILITY_API_KEY
+      - name: xai
+        description: "xAI Grok image generation"
+        env_var: XAI_API_KEY
       - name: local
         description: "Local placeholder (no API needed)"
         env_var: null
@@ -113,28 +123,40 @@ features:
       - "Batch processing"
   
   - id: ZER0-005
-    title: "GitHub Copilot Integration"
-    description: "Comprehensive AI development assistance with structured instructions, file-specific guidance, and front matter optimization for maximum AI productivity"
+    title: "AI Agent Integration (Copilot + AGENTS.md)"
+    description: "Comprehensive AI development assistance with the cross-tool AGENTS.md entry point, file-scoped instruction files (layouts, includes, scripts, sass, obsidian, install, features, version-control, testing, documentation), reusable prompts, and Cursor slash-commands"
     implemented: true
-    version: "0.15.0"
-    link: "https://github.com/bamr87/zer0-mistakes/blob/main/.github/copilot-instructions.md"
+    version: "1.6.0"
+    link: "https://github.com/bamr87/zer0-mistakes/blob/main/AGENTS.md"
     docs: "/docs/features/copilot-integration/"
-    tags: [ai, copilot, development, documentation]
-    date: 2025-11-15
+    tags: [ai, copilot, agents, development, documentation]
+    date: 2026-04-18
     references:
+      entry_point: "AGENTS.md"
+      main: ".github/copilot-instructions.md"
       instructions:
-        - ".github/copilot-instructions.md"
         - ".github/instructions/layouts.instructions.md"
         - ".github/instructions/includes.instructions.md"
         - ".github/instructions/scripts.instructions.md"
+        - ".github/instructions/sass.instructions.md"
+        - ".github/instructions/obsidian.instructions.md"
+        - ".github/instructions/install.instructions.md"
+        - ".github/instructions/features.instructions.md"
         - ".github/instructions/testing.instructions.md"
-        - ".github/instructions/version-control.instructions.md"
         - ".github/instructions/documentation.instructions.md"
+        - ".github/instructions/version-control.instructions.md"
+      prompts:
+        - ".github/prompts/commit-publish.prompt.md"
+        - ".github/prompts/frontmatter-maintainer.prompt.md"
+        - ".github/prompts/obsidian-add-syntax.prompt.md"
+        - ".github/prompts/seed.prompt.md"
+      cursor: ".cursor/commands/"
     features:
-      - "File-pattern specific instructions"
-      - "Development workflow guidance"
-      - "Best practices documentation"
-      - "AI-optimized front matter"
+      - "AGENTS.md cross-tool entry point (Copilot, Codex, Cursor, Aider, …)"
+      - "File-pattern specific instructions via applyTo globs"
+      - "Reusable agent/chat prompts"
+      - "Cursor IDE slash-commands mirror"
+      - "AI-optimized front matter standards"
       - "Automated code generation helpers"
   
   # ============================================================================
@@ -736,19 +758,20 @@ features:
       - "Smooth theme transitions"
 
   - id: ZER0-032
-    title: "Site Search"
-    description: "Client-side search functionality with modal interface, JSON index, and keyboard shortcut activation"
+    title: "GitHub Pages-Compatible Live Search"
+    description: "Self-contained client-side search with live modal, JSON index, and keyboard shortcut activation. Algolia-free — works on bare GitHub Pages with no external service or API key"
     implemented: true
-    version: "0.1.0"
+    version: "1.5.1"
     link: "/"
     docs: "/docs/features/site-search/"
     tags: [search, navigation, modal, keyboard]
-    date: 2025-01-01
+    date: 2026-04-10
     references:
       scripts:
         - "assets/js/search-modal.js"
       includes:
         - "_includes/components/search-modal.html"
+        - "_includes/components/searchbar.html"
       data:
         - "search.json"
     features:
@@ -757,6 +780,7 @@ features:
       - "Keyboard shortcut (/) activation"
       - "Real-time search results"
       - "Accessible search input"
+      - "No external dependency (Algolia removed v1.5.1)"
 
   - id: ZER0-033
     title: "Auto-hide Navigation"
@@ -996,3 +1020,266 @@ features:
       - "Tag cloud visualization"
       - "Content statistics"
       - "Responsive card layout"
+
+  # ============================================================================
+  # OBSIDIAN VAULT INTEGRATION (v1.3.0+)
+  # ============================================================================
+
+  - id: ZER0-044
+    title: "Obsidian Vault Integration"
+    description: "Render an Obsidian vault as a Jekyll site without losing wiki-links, embeds, callouts, or backlinks. Includes a Liquid wiki-index, JS client-side resolver, optional Ruby plugin, and a contract that keeps GitHub Pages and self-build deployments rendering identically"
+    implemented: true
+    version: "1.3.0"
+    link: "/docs/obsidian/"
+    docs: "/docs/obsidian/"
+    tags: [obsidian, content, wiki-links, knowledge-base, jekyll]
+    date: 2026-03-12
+    references:
+      plugin: "_plugins/obsidian_links.rb"
+      scripts:
+        - "assets/js/obsidian-resolver.js"
+        - "assets/js/obsidian-graph.js"
+      data: "assets/data/wiki-index.json"
+      includes:
+        - "_includes/content/backlinks.html"
+        - "_includes/content/wiki-graph.html"
+      docs: "pages/_docs/obsidian/"
+      tests:
+        - "test/test_obsidian.sh"
+        - "test/test_ruby_converter.rb"
+        - "test/test_resolver.js"
+      instructions: ".github/instructions/obsidian.instructions.md"
+    features:
+      - "[[Wiki-links]] resolution"
+      - "![[Embeds]] rendering"
+      - "Callout blocks"
+      - "Automatic backlinks panel"
+      - "Graph view (full + local)"
+      - "GitHub Pages compatible (no plugin required)"
+      - "Optional Ruby plugin for self-builds"
+
+  - id: ZER0-045
+    title: "Obsidian Local Graph Panel"
+    description: "Standalone neighborhood graph view for the current note, extracted as a reusable include for sidebars and modals"
+    implemented: true
+    version: "1.4.0"
+    link: "/docs/obsidian/graph/"
+    docs: "/docs/obsidian/graph/"
+    tags: [obsidian, graph, visualization, navigation]
+    date: 2026-03-25
+    references:
+      includes:
+        - "_includes/content/wiki-graph.html"
+        - "_includes/content/wiki-graph-local.html"
+      scripts:
+        - "assets/js/obsidian-graph.js"
+
+  # ============================================================================
+  # SETUP, NAVIGATION & DEVELOPER UX (v0.20+)
+  # ============================================================================
+
+  - id: ZER0-046
+    title: "Bare-Minimum Remote-Theme Starter"
+    description: "Three-file welcome starter (_config.yml + Gemfile + index.md) that bootstraps a working remote-theme site with no scaffolding required. Footer, welcome, and info partials degrade gracefully when collections are empty"
+    implemented: true
+    version: "1.2.0"
+    link: "/"
+    docs: "/docs/quickstart/bare-minimum/"
+    tags: [setup, quickstart, remote-theme, github-pages]
+    date: 2026-02-25
+    references:
+      starter: "../zer0-pages-remote/"
+      includes:
+        - "_includes/welcome.html"
+        - "_includes/info.html"
+        - "_includes/core/footer.html"
+
+  - id: ZER0-047
+    title: "Site Configuration Detection & Smart 404"
+    description: "Auto-detects whether the site is a fork, remote-theme consumer, or full clone, and renders a smart 404 page that guides users back to a working entry point"
+    implemented: true
+    version: "0.22.18"
+    link: "/404.html"
+    docs: "/docs/features/smart-404/"
+    tags: [setup, 404, configuration, ux]
+    date: 2026-01-30
+    references:
+      page: "404.html"
+      docs: "pages/_docs/features/smart-404.md"
+
+  - id: ZER0-048
+    title: "Config-Driven Frontmatter Validation"
+    description: "Schema-driven frontmatter validation system with configurable rules per collection. Catches missing required fields, bad date formats, and unknown layouts before Jekyll builds"
+    implemented: true
+    version: "0.22.17"
+    link: "/"
+    docs: "/docs/development/frontmatter-validation/"
+    tags: [validation, frontmatter, content, ci-cd, automation]
+    date: 2026-01-25
+    references:
+      script: "scripts/validate-frontmatter.sh"
+      config: "_data/frontmatter-schema.yml"
+      prompt: ".github/prompts/frontmatter-maintainer.prompt.md"
+
+  - id: ZER0-049
+    title: "Dynamic Collection-Based Navigation Fallback"
+    description: "Zero-config navigation: when no _data/navigation entry exists, the navbar auto-populates from Jekyll collections so brand-new sites have a usable nav out of the box"
+    implemented: true
+    version: "0.22.15"
+    link: "/"
+    docs: "/docs/features/dynamic-navigation/"
+    tags: [navigation, ui, zero-config, jekyll]
+    date: 2026-01-15
+    references:
+      includes:
+        - "_includes/navigation/navbar.html"
+        - "_includes/navigation/menu-collections.html"
+
+  - id: ZER0-050
+    title: "Admin Layout & Configuration Dashboards"
+    description: "Admin-style layout and dashboard partials for surfacing site configuration, build info, and feature flags in a single place"
+    implemented: true
+    version: "0.21.4"
+    link: "/admin/"
+    docs: "/docs/features/admin-dashboard/"
+    tags: [admin, dashboard, ui, configuration]
+    date: 2025-12-28
+    references:
+      layout: "_layouts/admin.html"
+      includes:
+        - "_includes/admin/"
+
+  - id: ZER0-051
+    title: "AGENTS.md Cross-Tool Agent Entry Point"
+    description: "Repository-root entry point for AI coding agents (Copilot, Codex, Cursor, Aider, Jules, Continue, Claude Code, \u2026) that links into the layered guidance under .github/. Single source of truth, no per-tool duplication"
+    implemented: true
+    version: "0.22.16"
+    link: "https://github.com/bamr87/zer0-mistakes/blob/main/AGENTS.md"
+    docs: "/docs/development/agents/"
+    tags: [ai, agents, documentation, copilot, cursor]
+    date: 2026-01-20
+    references:
+      file: "AGENTS.md"
+      instructions_index: ".github/instructions/README.md"
+
+  - id: ZER0-052
+    title: "Data-Driven Roadmap with Auto-Generated Diagram"
+    description: "Roadmap page rendered from a YAML data source, with an auto-generated Mermaid diagram embedded in README.md"
+    implemented: true
+    version: "0.22.21"
+    link: "/roadmap/"
+    docs: "/roadmap/"
+    tags: [roadmap, documentation, mermaid, automation]
+    date: 2026-02-08
+    references:
+      data: "_data/roadmap.yml"
+      page: "pages/roadmap.md"
+      script: "scripts/generate-roadmap-diagram.sh"
+
+  - id: ZER0-053
+    title: "Vendored Bootstrap & Icon Assets"
+    description: "Bootstrap 5.3.3 CSS/JS and Bootstrap Icons committed under assets/vendor/ for GitHub Pages safety and offline development. Refreshable via scripts/vendor-install.sh"
+    implemented: true
+    version: "0.21.3"
+    link: "/"
+    docs: "/docs/features/vendored-assets/"
+    tags: [bootstrap, assets, vendor, github-pages, performance]
+    date: 2025-12-20
+    references:
+      script: "scripts/vendor-install.sh"
+      manifest: "vendor-manifest.json"
+      assets:
+        - "assets/vendor/bootstrap/"
+        - "assets/vendor/bootstrap-icons/"
+
+  - id: ZER0-054
+    title: "AIEO Structured Data, FAQ & Glossary"
+    description: "AI-Engine Optimization toolkit: Schema.org JSON-LD, E-E-A-T signals, FAQ page, and glossary collection for stronger AI search and LLM grounding"
+    implemented: true
+    version: "0.21.5"
+    link: "/glossary/"
+    docs: "/docs/seo/aieo/"
+    tags: [seo, aieo, structured-data, faq, glossary, ai]
+    date: 2025-12-30
+    references:
+      includes:
+        - "_includes/content/structured-data.html"
+        - "_includes/content/eeat-signals.html"
+      pages:
+        - "pages/faq.md"
+        - "pages/glossary.md"
+
+  - id: ZER0-055
+    title: "ES6 Modular Navigation Architecture"
+    description: "Navigation JavaScript refactored into ES6 modules with hover dropdowns, settings modal, and a navbar that degrades gracefully on slow connections"
+    implemented: true
+    version: "0.18.0"
+    link: "/"
+    docs: "/docs/features/navigation-architecture/"
+    tags: [navigation, javascript, es6, ui, performance]
+    date: 2025-12-12
+    references:
+      scripts:
+        - "assets/js/modules/"
+        - "assets/js/navigation.js"
+      includes:
+        - "_includes/navigation/navbar.html"
+        - "_includes/components/settings-modal.html"
+
+  - id: ZER0-056
+    title: "DevContainer Configuration"
+    description: "VS Code Dev Container configuration for one-click cloud development environments (GitHub Codespaces, JetBrains Gateway, etc.) with Jekyll, Ruby, and Bootstrap toolchain pre-installed"
+    implemented: true
+    version: "0.17.0"
+    link: "/"
+    docs: "/docs/development/devcontainer/"
+    tags: [devcontainer, codespaces, development, docker]
+    date: 2025-12-10
+    references:
+      config:
+        - ".devcontainer/devcontainer.json"
+        - ".devcontainer/Dockerfile"
+
+  - id: ZER0-057
+    title: "Local Docker Publishing Pipeline"
+    description: "Publish the gem from a clean Docker container locally, mirroring the CI release path for reproducible releases without polluting the host Ruby environment"
+    implemented: true
+    version: "0.21.1"
+    link: "/"
+    docs: "/docs/development/docker-publishing/"
+    tags: [docker, release, ci-cd, gem, automation]
+    date: 2025-12-22
+    references:
+      compose:
+        - "docker-compose.publish.yml"
+        - "docker-compose.prod.yml"
+      script: "scripts/bin/release"
+
+  - id: ZER0-058
+    title: "Notes Collection & Notebook Layout"
+    description: "Dedicated _notes collection alongside _notebooks, with shared standardized layouts for short-form knowledge capture distinct from blog posts"
+    implemented: true
+    version: "0.20.0"
+    link: "/notes/"
+    docs: "/docs/content/notes/"
+    tags: [content, collections, notes, jekyll]
+    date: 2025-12-15
+    references:
+      collection: "pages/_notes/"
+      layouts:
+        - "_layouts/note.html"
+      config: "_config.yml"
+
+  - id: ZER0-059
+    title: "Performance: Page-URL Cache for Obsidian Resolver"
+    description: "Cached page-URL lookups and short-circuited rewrites in the Obsidian Liquid pipeline. Measurable build-time improvement on vaults with hundreds of cross-links"
+    implemented: true
+    version: "1.6.0"
+    link: "/docs/obsidian/performance/"
+    docs: "/docs/obsidian/performance/"
+    tags: [obsidian, performance, jekyll, optimization]
+    date: 2026-04-30
+    references:
+      plugin: "_plugins/obsidian_links.rb"
+      includes:
+        - "_includes/content/backlinks.html"

--- a/features/features.yml
+++ b/features/features.yml
@@ -1037,12 +1037,12 @@ features:
     references:
       plugin: "_plugins/obsidian_links.rb"
       scripts:
-        - "assets/js/obsidian-resolver.js"
+        - "assets/js/obsidian-wiki-links.js"
         - "assets/js/obsidian-graph.js"
       data: "assets/data/wiki-index.json"
       includes:
         - "_includes/content/backlinks.html"
-        - "_includes/content/wiki-graph.html"
+        - "_includes/obsidian/full-graph.html"
       docs: "pages/_docs/obsidian/"
       tests:
         - "test/test_obsidian.sh"
@@ -1069,8 +1069,8 @@ features:
     date: 2026-03-25
     references:
       includes:
-        - "_includes/content/wiki-graph.html"
-        - "_includes/content/wiki-graph-local.html"
+        - "_includes/obsidian/full-graph.html"
+        - "_includes/navigation/local-graph.html"
       scripts:
         - "assets/js/obsidian-graph.js"
 
@@ -1088,11 +1088,10 @@ features:
     tags: [setup, quickstart, remote-theme, github-pages]
     date: 2026-02-25
     references:
-      starter: "../zer0-pages-remote/"
       includes:
-        - "_includes/welcome.html"
-        - "_includes/info.html"
+        - "_includes/components/info-section.html"
         - "_includes/core/footer.html"
+      layout: "_layouts/welcome.html"
 
   - id: ZER0-047
     title: "Site Configuration Detection & Smart 404"
@@ -1117,8 +1116,8 @@ features:
     tags: [validation, frontmatter, content, ci-cd, automation]
     date: 2026-01-25
     references:
-      script: "scripts/validate-frontmatter.sh"
-      config: "_data/frontmatter-schema.yml"
+      script: "scripts/bin/validate"
+      config: ".github/config/frontmatter_schema.yml"
       prompt: ".github/prompts/frontmatter-maintainer.prompt.md"
 
   - id: ZER0-049
@@ -1147,7 +1146,8 @@ features:
     references:
       layout: "_layouts/admin.html"
       includes:
-        - "_includes/admin/"
+        - "_includes/navigation/admin-nav.html"
+        - "_includes/components/admin-tabs.html"
 
   - id: ZER0-051
     title: "AGENTS.md Cross-Tool Agent Entry Point"
@@ -1238,7 +1238,6 @@ features:
     references:
       config:
         - ".devcontainer/devcontainer.json"
-        - ".devcontainer/Dockerfile"
 
   - id: ZER0-057
     title: "Local Docker Publishing Pipeline"

--- a/features/features.yml
+++ b/features/features.yml
@@ -1261,7 +1261,7 @@ features:
     implemented: true
     version: "0.20.0"
     link: "/notes/"
-    docs: "/docs/content/notes/"
+    docs: "/notes/"
     tags: [content, collections, notes, jekyll]
     date: 2025-12-15
     references:

--- a/pages/_docs/development/agents.md
+++ b/pages/_docs/development/agents.md
@@ -1,0 +1,105 @@
+---
+lastmod: 2026-05-05T00:00:00.000Z
+title: AGENTS.md — Cross-Tool AI Agent Entry Point
+description: How the repository-root AGENTS.md file provides a single source of truth for AI coding agents (Copilot, Codex, Cursor, Aider, Jules, Continue, Claude Code, and others).
+layout: default
+categories:
+  - docs
+  - development
+tags:
+  - ai
+  - agents
+  - documentation
+  - copilot
+  - cursor
+permalink: /docs/development/agents/
+difficulty: intermediate
+estimated_reading_time: 8 minutes
+sidebar:
+  nav: docs
+---
+
+# AGENTS.md — Cross-Tool AI Agent Entry Point
+
+`AGENTS.md` in the repository root is a single, short entry-point file for AI coding agents. It follows the emerging [agents.md](https://agents.md/) convention and is read by GitHub Copilot, OpenAI Codex, Cursor, Aider, Jules, Continue, Claude Code, and any other agent that respects the convention.
+
+## Why AGENTS.md?
+
+Different AI tools each have their own config file format:
+
+| Tool | Its own file |
+|---|---|
+| GitHub Copilot | `.github/copilot-instructions.md` |
+| Cursor | `.cursor/` rules |
+| Aider | `.aider.conf.yml` |
+| Continue | `.continuerc.json` |
+
+Rather than maintaining separate instruction files with duplicated content, `AGENTS.md` acts as a **cross-tool entry point** that links to the canonical, detailed guidance already in `.github/`. This prevents drift and keeps a single source of truth.
+
+## File Location
+
+```
+AGENTS.md   ← repository root
+```
+
+GitHub Copilot also reads it as supplementary context. Other tools that support the `AGENTS.md` convention will discover it automatically.
+
+## What It Contains
+
+`AGENTS.md` is intentionally short. It covers:
+
+1. **Project snapshot** — what the repo is, primary languages, version source of truth
+2. **Guidance map** — a table showing which file to read for which task
+3. **Essential commands** — the handful of commands every agent needs
+4. **Operating rules** — seven concise rules (minimal changes, validate before done, etc.)
+5. **Extension guide** — how to add new agent capabilities
+
+## Layered Guidance Model
+
+```
+AGENTS.md          ← Cross-tool entry point (always read first)
+    │
+    ├── .github/copilot-instructions.md  ← Full architecture & conventions
+    │
+    └── .github/instructions/*.instructions.md  ← File-scoped rules
+            layouts.instructions.md       → _layouts/**
+            includes.instructions.md      → _includes/**
+            scripts.instructions.md       → scripts/**
+            sass.instructions.md          → _sass/**, assets/css/**
+            obsidian.instructions.md      → _plugins/obsidian_links.rb, …
+            testing.instructions.md       → test/**
+            documentation.instructions.md → docs/**, pages/_docs/**
+            version-control.instructions.md → CHANGELOG.md, version.*, …
+            features.instructions.md      → features/features.yml, _data/features.yml
+            install.instructions.md       → install.sh, scripts/lib/install/**, …
+```
+
+## Operating Rules for Agents
+
+All agents working in this repository must follow these rules (quoted from `AGENTS.md`):
+
+1. **Make minimal, surgical changes.** Match the existing style. Do not refactor unrelated code.
+2. **Respect the layered guidance.** File-scoped instructions override generic best practices.
+3. **Validate before declaring done.** Run relevant tests; for theme changes run the Docker Jekyll build.
+4. **Update `CHANGELOG.md`** for any user-visible change.
+5. **Bump the version only via `./scripts/bin/release`** — never in unrelated PRs.
+6. **Do not commit secrets.** Use environment variables.
+7. **Prefer existing libraries and patterns.**
+
+## Adding a New Tool
+
+To onboard a new AI tool without duplicating content:
+
+1. Create the tool's own config file (e.g. `CLAUDE.md`)
+2. In that file, write: *"See `AGENTS.md`."*
+3. That's it — the layered guidance already covers everything
+
+## Related
+
+- [Scripts Overview](/docs/development/scripts/)
+- [CI/CD Pipeline](/docs/development/ci-cd/)
+
+## See also
+
+- [[Development]]
+- [[Documentation]]

--- a/pages/_docs/development/devcontainer.md
+++ b/pages/_docs/development/devcontainer.md
@@ -1,0 +1,118 @@
+---
+lastmod: 2026-05-05T00:00:00.000Z
+title: DevContainer Configuration
+description: VS Code Dev Container configuration for one-click cloud and local development environments — GitHub Codespaces, JetBrains Gateway, and VS Code with the Jekyll toolchain pre-installed.
+layout: default
+categories:
+  - docs
+  - development
+tags:
+  - devcontainer
+  - codespaces
+  - development
+  - docker
+permalink: /docs/development/devcontainer/
+difficulty: beginner
+estimated_reading_time: 8 minutes
+sidebar:
+  nav: docs
+---
+
+# DevContainer Configuration
+
+zer0-mistakes ships a `.devcontainer/devcontainer.json` that lets you open a fully configured Jekyll development environment with a single click — no local Ruby, Bundler, or Node installation required.
+
+## Supported Environments
+
+| Environment | How to open |
+|---|---|
+| **GitHub Codespaces** | Click **Code → Codespaces → Create codespace on main** |
+| **VS Code Dev Containers** | Open the repo folder → *Reopen in Container* |
+| **JetBrains Gateway** | Connect to Codespace or remote Docker host |
+
+## Configuration File
+
+```
+.devcontainer/devcontainer.json
+```
+
+### What's Pre-Installed
+
+The container is based on `mcr.microsoft.com/devcontainers/jekyll:2-bullseye` and adds:
+
+| Tool | Source |
+|---|---|
+| Jekyll + Bundler | Base image |
+| Docker-in-Docker | `devcontainers/features/docker-in-docker:2` |
+| GitHub CLI (`gh`) | `devcontainers/features/github-cli:1` |
+| Node.js LTS | `devcontainers/features/node:1` |
+
+### Post-Create Hook
+
+```bash
+bundle install --jobs 4 --retry 3
+```
+
+Runs automatically after the container is created to install all gem dependencies.
+
+### Post-Start Hook
+
+```bash
+bundle exec jekyll serve \
+  --config '_config.yml,_config_dev.yml' \
+  --host 0.0.0.0 --port 4000 --livereload
+```
+
+The Jekyll dev server starts automatically every time the container starts. The site is available at `http://localhost:4000` and forwarded automatically in VS Code and Codespaces.
+
+## Forwarded Ports
+
+| Port | Service |
+|---|---|
+| `4000` | Jekyll site (auto-opens in browser) |
+| `35729` | LiveReload (silent) |
+
+## VS Code Extensions
+
+The configuration recommends these extensions:
+
+- `sissel.shopify-liquid` — Liquid template syntax highlighting
+- `yzhang.markdown-all-in-one` — Markdown editing
+- `DavidAnson.vscode-markdownlint` — Markdown linting
+- `streetsidesoftware.code-spell-checker` — Spell check
+- `esbenp.prettier-vscode` — Code formatting
+- `ms-azuretools.vscode-docker` — Docker management
+
+## Using the DevContainer Locally
+
+If you have Docker Desktop installed, you can use the devcontainer without Codespaces:
+
+1. Install the [VS Code Dev Containers extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers)
+2. Open the repo folder in VS Code
+3. Click the notification to *Reopen in Container* (or use the Command Palette → *Dev Containers: Reopen in Container*)
+4. Wait for the container to build (~2–3 minutes on first run)
+5. The site starts automatically at port 4000
+
+## Relationship to Docker Compose
+
+The devcontainer and `docker-compose.yml` serve different purposes:
+
+| `devcontainer.json` | `docker-compose.yml` |
+|---|---|
+| VS Code / Codespaces IDE integration | Team-wide dev server + multi-service stack |
+| Extension recommendations, settings sync | Production-parity environment |
+| Auto-start Jekyll on container start | Explicit `docker-compose up` required |
+
+You can use either (or both) depending on your workflow.
+
+## Related
+
+- [Docker Development](/docs/docker/)
+- [Quick Start Guide](/docs/getting-started/quick-start/)
+- [Local Docker Publishing](/docs/development/docker-publishing/)
+
+## See also
+
+- [[Development]]
+- [[Docker]]
+- [[Getting Started]]

--- a/pages/_docs/development/docker-publishing.md
+++ b/pages/_docs/development/docker-publishing.md
@@ -1,0 +1,147 @@
+---
+lastmod: 2026-05-05T00:00:00.000Z
+title: Local Docker Publishing Pipeline
+description: Publish the jekyll-theme-zer0 gem from a clean Docker container locally, mirroring the CI release path for reproducible builds without polluting the host Ruby environment.
+layout: default
+categories:
+  - docs
+  - development
+tags:
+  - docker
+  - release
+  - ci-cd
+  - gem
+  - automation
+permalink: /docs/development/docker-publishing/
+difficulty: advanced
+estimated_reading_time: 10 minutes
+prerequisites:
+  - Docker Desktop
+  - RubyGems API key
+sidebar:
+  nav: docs
+---
+
+# Local Docker Publishing Pipeline
+
+You can build and publish the `jekyll-theme-zer0` gem entirely inside a Docker container. This mirrors the CI release path exactly, avoiding version-skew issues caused by different host Ruby environments.
+
+## Why Run Releases in Docker?
+
+| Problem | Docker solution |
+|---|---|
+| Host Ruby version mismatch | Container uses the same Ruby as CI |
+| Polluted gem environment | Clean container discarded after run |
+| "Works on my machine" | Exact CI environment reproduced locally |
+| Key material leaks | Credentials injected via env vars, never stored |
+
+## Compose Files
+
+| File | Purpose |
+|---|---|
+| `docker-compose.publish.yml` | Builds and pushes the Docker image to a registry |
+| `docker-compose.prod.yml` | Production deployment with pinned image tags |
+
+## Releasing the Gem Locally
+
+The recommended approach is the unified release script, which handles everything:
+
+```bash
+./scripts/bin/release patch    # or minor / major
+```
+
+This script:
+
+1. Analyzes commits since the last tag to confirm the bump type
+2. Updates `lib/jekyll-theme-zer0/version.rb`
+3. Runs validation (`./scripts/bin/validate`)
+4. Builds the gem (`gem build jekyll-theme-zer0.gemspec`)
+5. Creates a git tag and pushes
+6. Publishes to RubyGems (`gem push`)
+
+Pass `--dry-run` to preview without publishing:
+
+```bash
+./scripts/bin/release patch --dry-run
+```
+
+## Running in a Docker Container
+
+To run the release inside a Docker container manually:
+
+```bash
+# Start a clean Jekyll container
+docker compose -f docker-compose.yml run --rm jekyll bash
+
+# Inside the container:
+./scripts/bin/release patch
+```
+
+Or with the publish compose file:
+
+```bash
+docker compose -f docker-compose.yml \
+               -f docker-compose.publish.yml \
+               build publish
+```
+
+## Environment Variables
+
+Set credentials in `.env` (never commit this file):
+
+```bash
+RUBYGEMS_API_KEY=rubygems_...
+GITHUB_TOKEN=ghp_...
+DOCKER_IMAGE=amrabdel/zer0-mistakes
+IMAGE_TAG=latest
+```
+
+The `.env` file is already in `.gitignore`.
+
+## CI Pipeline Equivalent
+
+GitHub Actions runs the same release pipeline automatically on version tags:
+
+```yaml
+# .github/workflows/release.yml (simplified)
+- name: Build gem
+  run: gem build jekyll-theme-zer0.gemspec
+
+- name: Publish to RubyGems
+  run: gem push jekyll-theme-zer0-${{ env.VERSION }}.gem
+  env:
+    GEM_HOST_API_KEY: ${{ secrets.RUBYGEMS_API_KEY }}
+```
+
+## Troubleshooting
+
+### "Invalid API key"
+
+Set `RUBYGEMS_API_KEY` in your shell or `.env` file:
+
+```bash
+export RUBYGEMS_API_KEY=$(cat ~/.gem/credentials | grep rubygems_api_key | cut -d' ' -f2)
+```
+
+### Gem already published at that version
+
+Bump the version and re-run. RubyGems does not allow overwriting a published version.
+
+### Docker build fails
+
+```bash
+docker compose down -v
+docker compose build --no-cache
+```
+
+## Related
+
+- [Release Management](/docs/development/release-management/)
+- [CI/CD Pipeline](/docs/development/ci-cd/)
+- [DevContainer Configuration](/docs/development/devcontainer/)
+
+## See also
+
+- [[Development]]
+- [[Docker]]
+- [[Release Management]]

--- a/pages/_docs/development/frontmatter-validation.md
+++ b/pages/_docs/development/frontmatter-validation.md
@@ -1,0 +1,142 @@
+---
+lastmod: 2026-05-05T00:00:00.000Z
+title: Config-Driven Frontmatter Validation
+description: Schema-driven frontmatter validation that catches missing required fields, bad date formats, and unknown layouts before Jekyll builds.
+layout: default
+categories:
+  - docs
+  - development
+tags:
+  - validation
+  - frontmatter
+  - content
+  - ci-cd
+  - automation
+permalink: /docs/development/frontmatter-validation/
+difficulty: intermediate
+estimated_reading_time: 8 minutes
+sidebar:
+  nav: docs
+---
+
+# Config-Driven Frontmatter Validation
+
+The zer0-mistakes theme ships with a schema-driven frontmatter validation system. It catches missing required fields, invalid date formats, and unknown layout references before Jekyll even starts its build, saving time in CI and preventing silent content errors.
+
+## How It Works
+
+The validator reads a YAML schema that defines per-collection rules, then checks every Markdown file's frontmatter against those rules.
+
+```mermaid
+graph LR
+    A[Schema YAML] --> C[Validator]
+    B[Content files] --> C
+    C --> D{Valid?}
+    D -- Yes --> E[Jekyll build proceeds]
+    D -- No --> F[Error report + exit 1]
+```
+
+## Schema File
+
+The schema lives at:
+
+```
+.github/config/frontmatter_schema.yml
+```
+
+### Example Schema
+
+```yaml
+collections:
+  _posts:
+    required:
+      - title
+      - date
+      - categories
+    date_fields:
+      - date
+      - lastmod
+    allowed_layouts:
+      - journals
+      - default
+
+  _docs:
+    required:
+      - title
+      - description
+      - permalink
+    allowed_layouts:
+      - default
+```
+
+## Running Validation
+
+```bash
+# Via the unified validate script
+./scripts/bin/validate
+
+# Quick host-only checks (no Jekyll build)
+./scripts/bin/validate --quick
+```
+
+The validation step is embedded in the standard preflight check and runs automatically in CI before every build.
+
+## CI Integration
+
+The `.github/workflows/` CI pipeline runs `./scripts/bin/validate` on every push and pull request. Frontmatter errors are surfaced as workflow failures with line-level diagnostics.
+
+## AI-Assisted Maintenance
+
+A dedicated Copilot prompt helps you audit and repair frontmatter across the entire site:
+
+```
+.github/prompts/frontmatter-maintainer.prompt.md
+```
+
+Use it via GitHub Copilot Chat:
+
+```
+@workspace /frontmatter-maintainer
+```
+
+## Frontmatter Standards
+
+All pages in this theme follow a consistent frontmatter schema. Common fields:
+
+| Field | Required | Description |
+|---|---|---|
+| `title` | ✅ | Human-readable page title |
+| `description` | ✅ | SEO meta description (150–160 chars) |
+| `layout` | ✅ | Jekyll layout file (without `.html`) |
+| `permalink` | ✅ for docs | Canonical URL path |
+| `date` | ✅ for posts | ISO 8601 publication date |
+| `lastmod` | Recommended | Last modification date (ISO 8601) |
+| `categories` | Recommended | Array of category strings |
+| `tags` | Recommended | Array of tag strings |
+| `draft` | Optional | `true` hides from production builds |
+
+## Troubleshooting
+
+### "Required field missing"
+
+Add the missing field to the page's frontmatter.
+
+### "Unknown layout"
+
+Check that the layout name matches a file under `_layouts/` (without the `.html` extension).
+
+### "Invalid date format"
+
+Use ISO 8601: `YYYY-MM-DD` or `YYYY-MM-DDTHH:MM:SSZ`.
+
+## Related
+
+- [Documentation Guide](/docs/development/documentation/)
+- [Scripts Overview](/docs/development/scripts/)
+- [CI/CD Pipeline](/docs/development/ci-cd/)
+
+## See also
+
+- [[Development]]
+- [[Testing]]
+- [[CI/CD]]

--- a/pages/_docs/features/admin-dashboard.md
+++ b/pages/_docs/features/admin-dashboard.md
@@ -1,0 +1,122 @@
+---
+lastmod: 2026-05-05T00:00:00.000Z
+title: Admin Layout & Configuration Dashboards
+description: Admin-style layout and dashboard partials for surfacing site configuration, build info, and feature flags in a single place.
+layout: default
+categories:
+  - docs
+  - features
+tags:
+  - admin
+  - dashboard
+  - ui
+  - configuration
+permalink: /docs/features/admin-dashboard/
+difficulty: intermediate
+estimated_reading_time: 8 minutes
+sidebar:
+  nav: docs
+---
+
+# Admin Layout & Configuration Dashboards
+
+The zer0-mistakes theme ships an `admin` layout and a set of dashboard partials for surfacing site configuration, build metadata, and feature flags — all in one place, without requiring a CMS or backend.
+
+## Admin Layout
+
+Any page can use the admin layout by setting `layout: admin` in its frontmatter:
+
+```yaml
+---
+layout: admin
+title: Site Configuration
+icon: bi-gear
+---
+```
+
+### Supported Frontmatter
+
+| Field | Type | Description |
+|---|---|---|
+| `icon` | string | Bootstrap Icons class shown in the page header (e.g. `bi-gear`) |
+| `admin_nav` | boolean | Show the admin sidebar (default: `true`) |
+| `admin_section` | string | Active section key for sidebar highlighting |
+| `admin_actions` | array | Header action buttons (`label`, `url`, `icon`, `style`) |
+
+### Layout Structure
+
+```
+Admin page
+├── Admin header  (breadcrumbs + icon + title + action buttons)
+├── Admin sidebar (collapsible; collapses to offcanvas on mobile)
+└── Main content  (page body, tab panels, data tables, …)
+```
+
+## Admin Navigation
+
+A dedicated sidebar navigation partial is included automatically with the admin layout:
+
+```
+_includes/navigation/admin-nav.html
+```
+
+It renders a vertical nav with links to all admin/settings pages.
+
+## Tabbed Admin Pages
+
+Use the `admin-tabs` component to split a single admin page into tabs:
+
+```liquid
+{% raw %}{% include components/admin-tabs.html
+   id="config"
+   tabs="view:View Config:bi-eye:true|edit:Edit & Export:bi-pencil-square:false|raw:Raw YAML:bi-file-earmark-code:false"
+%}
+<div class="tab-content pt-4" id="configTabContent">
+  <div class="tab-pane fade show active" id="pane-view" role="tabpanel">
+    <!-- your content -->
+  </div>
+</div>{% endraw %}
+```
+
+Each tab definition is `id:label:icon:active`, pipe-separated.
+
+## Built-In Admin Pages
+
+The theme ships several admin pages under `pages/_about/settings/`:
+
+| Page | Permalink | Purpose |
+|---|---|---|
+| `config.md` | `/about/settings/config/` | View and export `_config.yml` |
+| `theme.md` | `/about/settings/theme/` | Theme colours and Bootstrap overrides |
+| `navigation.md` | `/about/settings/navigation/` | Edit navigation data |
+| `analytics.md` | `/about/settings/analytics/` | Analytics provider settings |
+| `collections.md` | `/about/settings/collections/` | Collection configuration |
+| `environment.md` | `/about/settings/environment/` | Build environment info |
+
+## Creating a Custom Admin Page
+
+```markdown
+---
+layout: admin
+title: My Dashboard
+description: Custom dashboard for my site
+icon: bi-speedometer2
+permalink: /admin/my-dashboard/
+sidebar:
+  nav: docs
+---
+
+# My Dashboard
+
+Add your content here. Use Bootstrap 5 components freely.
+```
+
+## Related
+
+- [Dynamic Navigation](/docs/features/dynamic-navigation/)
+- [Theme Configuration](/docs/customization/)
+
+## See also
+
+- [[Features]]
+- [[Customization]]

--- a/pages/_docs/features/dynamic-navigation.md
+++ b/pages/_docs/features/dynamic-navigation.md
@@ -1,0 +1,98 @@
+---
+lastmod: 2026-05-05T00:00:00.000Z
+title: Dynamic Collection-Based Navigation
+description: Zero-config navigation that auto-populates the navbar from Jekyll collections when no _data/navigation entry exists, so brand-new sites have a usable menu out of the box.
+layout: default
+categories:
+  - docs
+  - features
+tags:
+  - navigation
+  - ui
+  - zero-config
+  - jekyll
+permalink: /docs/features/dynamic-navigation/
+difficulty: beginner
+estimated_reading_time: 6 minutes
+sidebar:
+  nav: docs
+---
+
+# Dynamic Collection-Based Navigation
+
+zer0-mistakes ships a **zero-config navigation fallback**: when no custom `_data/navigation.yml` entry exists for the navbar, the theme auto-discovers your Jekyll collections and generates a working nav menu on first launch.
+
+## Why It Exists
+
+New sites have no navigation data yet. Without this fallback, visitors would see a blank navbar. The dynamic fallback generates useful links automatically so every new site starts with a navigable structure.
+
+## How It Works
+
+```mermaid
+graph TD
+    A[Page render] --> B{navigation.yml entry?}
+    B -- Yes --> C[Render static nav from data file]
+    B -- No --> D[menu-collections.html fallback]
+    D --> E[Iterate site.collections]
+    E --> F[Skip hidden/system collections]
+    F --> G[Render collection links]
+```
+
+### Key Includes
+
+| File | Role |
+|---|---|
+| `_includes/navigation/navbar.html` | Main navbar — checks for data, falls back to collections |
+| `_includes/navigation/menu-collections.html` | Renders one link per collection |
+
+### Navbar Logic (simplified)
+
+```liquid
+{% raw %}{% if site.data.navigation.main %}
+  {% include navigation/nav_list.html nav=site.data.navigation.main %}
+{% else %}
+  {% include navigation/menu-collections.html %}
+{% endif %}{% endraw %}
+```
+
+## Configuring Static Navigation
+
+Once you're ready to lock down the menu, create `_data/navigation.yml`:
+
+```yaml
+main:
+  - title: "Home"
+    url: "/"
+  - title: "Docs"
+    url: "/docs/"
+  - title: "Posts"
+    url: "/posts/"
+```
+
+The fallback is silently disabled as soon as this file is present.
+
+## Excluding Collections from the Fallback
+
+Collections prefixed with `_` in the site config can be hidden by setting
+`output: false` or by adding them to the exclusion list inside
+`menu-collections.html`:
+
+```liquid
+{% raw %}{% unless collection.label == "notes" or collection.label == "quickstart" %}
+  ...
+{% endunless %}{% endraw %}
+```
+
+## Sidebar Navigation
+
+The sidebar uses a separate `_data/navigation.yml` key (`docs`, `sidebar`, etc.) and is unaffected by the dynamic fallback. See the [Sidebar Navigation](/docs/features/sidebar-navigation/) guide for details.
+
+## Related
+
+- [Sidebar Navigation](/docs/features/sidebar-navigation/)
+- [ES6 Modular Navigation](/docs/features/navigation-architecture/)
+
+## See also
+
+- [[Features]]
+- [[Navigation]]

--- a/pages/_docs/features/navigation-architecture.md
+++ b/pages/_docs/features/navigation-architecture.md
@@ -1,0 +1,137 @@
+---
+lastmod: 2026-05-05T00:00:00.000Z
+title: ES6 Modular Navigation Architecture
+description: The zer0-mistakes navigation system refactored into ES6 modules — hover dropdowns, keyboard accessibility, smooth scroll, sidebar state persistence, and graceful degradation.
+layout: default
+categories:
+  - docs
+  - features
+tags:
+  - navigation
+  - javascript
+  - es6
+  - ui
+  - performance
+permalink: /docs/features/navigation-architecture/
+difficulty: intermediate
+estimated_reading_time: 10 minutes
+sidebar:
+  nav: docs
+---
+
+# ES6 Modular Navigation Architecture
+
+The zer0-mistakes navigation JavaScript is organized as ES6 modules under `assets/js/modules/navigation/`. This modular approach enables tree-shaking, independent unit testing, and easy extension without touching monolithic files.
+
+## Module Overview
+
+```
+assets/js/modules/navigation/
+├── index.js         — Entry point: imports and initializes all modules
+├── config.js        — Shared constants (breakpoints, selectors, timing)
+├── focus.js         — Focus trapping for offcanvas / modals
+├── gestures.js      — Touch/swipe support for mobile nav
+├── keyboard.js      — Arrow-key navigation, Escape handling
+├── scroll-spy.js    — Active section highlighting in sidebars
+├── sidebar-state.js — Persist collapsed/expanded state (localStorage)
+└── smooth-scroll.js — Smooth scroll to anchor links
+```
+
+The entry point is imported by `assets/js/navigation.js`:
+
+```javascript
+// assets/js/navigation.js
+import { initNavigation } from './modules/navigation/index.js';
+
+document.addEventListener('DOMContentLoaded', () => {
+  initNavigation();
+});
+```
+
+## Key Features
+
+### Hover Dropdowns
+
+Desktop navbar dropdowns open on hover with a short delay to prevent accidental triggers. Defined in `config.js`:
+
+```javascript
+export const TOOLTIP_DELAY = { show: 400, hide: 100 };
+export const MOBILE_BREAKPOINT = 992; // px — Bootstrap lg breakpoint
+```
+
+### Keyboard Navigation
+
+`keyboard.js` handles:
+
+| Key | Action |
+|---|---|
+| `Tab` / `Shift+Tab` | Standard focus movement |
+| `Arrow Down` / `Arrow Up` | Move between dropdown items |
+| `Escape` | Close dropdown / offcanvas |
+| `Enter` / `Space` | Activate focused item |
+
+### Sidebar State Persistence
+
+`sidebar-state.js` saves which sidebar sections are expanded to `localStorage` so the state survives page reloads:
+
+```javascript
+// Key format: zer0-sidebar-<section-id>
+localStorage.setItem(`zer0-sidebar-${sectionId}`, 'expanded');
+```
+
+### Scroll Spy
+
+`scroll-spy.js` highlights the current section in the sidebar table-of-contents as the user scrolls, using `IntersectionObserver` for performance.
+
+### Graceful Degradation
+
+All navigation features are wrapped in feature detection:
+
+```javascript
+if ('IntersectionObserver' in window) {
+  initScrollSpy();
+}
+```
+
+The navbar renders and works as a standard Bootstrap component even when JavaScript is disabled or fails.
+
+## Main Navigation Include
+
+```
+_includes/navigation/navbar.html
+```
+
+The navbar include renders the Bootstrap 5 navbar, populates links from `_data/navigation.yml` (or the dynamic collection fallback), and outputs the data attributes that the JS modules target.
+
+## Adding a Navigation Module
+
+1. Create `assets/js/modules/navigation/my-feature.js`:
+
+```javascript
+export function initMyFeature() {
+  // implementation
+}
+```
+
+2. Import and call it from `index.js`:
+
+```javascript
+import { initMyFeature } from './my-feature.js';
+
+export function initNavigation() {
+  // … existing init calls …
+  initMyFeature();
+}
+```
+
+## Related
+
+- [Dynamic Navigation Fallback](/docs/features/dynamic-navigation/)
+- [Sidebar Navigation](/docs/features/sidebar-navigation/)
+- [Keyboard Navigation](/docs/features/keyboard-navigation/)
+
+## See also
+
+- [[Navigation]]
+- [[JavaScript]]
+- [[Features]]

--- a/pages/_docs/features/smart-404.md
+++ b/pages/_docs/features/smart-404.md
@@ -1,0 +1,94 @@
+---
+lastmod: 2026-05-05T00:00:00.000Z
+title: Smart 404 & Site Configuration Detection
+description: How the zer0-mistakes 404 page auto-detects whether the site is a fork, remote-theme consumer, or full clone and guides visitors back to a working entry point.
+layout: default
+categories:
+  - docs
+  - features
+tags:
+  - setup
+  - 404
+  - configuration
+  - ux
+permalink: /docs/features/smart-404/
+difficulty: beginner
+estimated_reading_time: 5 minutes
+sidebar:
+  nav: docs
+---
+
+# Smart 404 & Site Configuration Detection
+
+The zer0-mistakes `404.html` is not a plain "page not found" placeholder. It detects how the site is deployed and offers context-aware guidance to the visitor.
+
+## Detection Logic
+
+```mermaid
+graph TD
+    A[404.html Loads] --> B{site.remote_theme set?}
+    B -- Yes --> C[Remote-theme consumer]
+    B -- No --> D{site.theme set?}
+    D -- Yes --> E[Gem-theme consumer]
+    D -- No --> F[Full clone / fork]
+    C & E & F --> G[Render matching help block]
+```
+
+The Liquid template inspects `site.remote_theme`, `site.theme`, and a small set of
+`site.github.*` variables that GitHub Pages injects at build time.
+
+## Implementation
+
+The smart 404 lives in the repository root:
+
+```
+404.html
+```
+
+Key Liquid variables used:
+
+| Variable | Purpose |
+|---|---|
+| `site.remote_theme` | Detect remote-theme mode |
+| `site.theme` | Detect gem-theme mode |
+| `site.github.owner_name` | Link back to the correct GitHub profile |
+| `site.url` / `site.baseurl` | Build absolute links to the home page |
+
+## What Visitors See
+
+### Remote-theme consumer
+
+```
+🔍 Page Not Found
+This page doesn't exist on this site.
+→ Return to home  → View the theme source on GitHub
+```
+
+### Full clone / fork
+
+```
+🔍 Page Not Found
+It looks like this page was removed or the URL changed.
+→ Return to home  → Browse the docs
+```
+
+## Customizing the 404
+
+Override just this file in your site repo:
+
+```
+your-site/
+└── 404.html   ← Your custom version takes precedence
+```
+
+The theme's `404.html` is only used when no local override exists.
+
+## Related
+
+- [Quick Start Guide](/docs/getting-started/quick-start/)
+- [Bare-Minimum Starter](/docs/quickstart/bare-minimum/)
+
+## See also
+
+- [[Features]]
+- [[Getting Started]]

--- a/pages/_docs/features/vendored-assets.md
+++ b/pages/_docs/features/vendored-assets.md
@@ -1,0 +1,91 @@
+---
+lastmod: 2026-05-05T00:00:00.000Z
+title: Vendored Bootstrap & Icon Assets
+description: Bootstrap 5.3.3 CSS/JS and Bootstrap Icons are committed under assets/vendor/ for GitHub Pages safety and offline development. How to use and refresh them.
+layout: default
+categories:
+  - docs
+  - features
+tags:
+  - bootstrap
+  - assets
+  - vendor
+  - github-pages
+  - performance
+permalink: /docs/features/vendored-assets/
+difficulty: intermediate
+estimated_reading_time: 5 minutes
+sidebar:
+  nav: docs
+---
+
+# Vendored Bootstrap & Icon Assets
+
+Bootstrap 5.3.3 CSS/JS and Bootstrap Icons are **committed** under `assets/vendor/` rather than loaded from a CDN. This ensures:
+
+- **GitHub Pages safety** — Pages' default Jekyll build does not run `npm` or `curl`
+- **Offline development** — works without an internet connection
+- **Version pinning** — no surprise CDN updates breaking the theme
+
+For full details on refreshing vendor files, see the [Vendor Assets guide](/docs/development/vendor-assets/).
+
+## Directory Layout
+
+```
+assets/vendor/
+├── bootstrap/
+│   ├── css/
+│   │   └── bootstrap.min.css
+│   └── js/
+│       └── bootstrap.bundle.min.js
+└── bootstrap-icons/
+    └── font/
+        ├── bootstrap-icons.css
+        └── fonts/
+```
+
+Additional vendor libraries (MathJax, Mermaid, Font Awesome, …) are also stored here and listed in `vendor-manifest.json`.
+
+## How Assets Are Loaded
+
+### CSS (via `_includes/core/head.html`)
+
+```liquid
+{% raw %}<link href="{{ '/assets/vendor/bootstrap/css/bootstrap.min.css' | relative_url }}" rel="stylesheet">
+<link rel="stylesheet" href="{{ '/assets/vendor/bootstrap-icons/font/bootstrap-icons.css' | relative_url }}">
+<link rel="stylesheet" href="{{ '/assets/css/main.css' | relative_url }}">{% endraw %}
+```
+
+### JavaScript (via `_includes/components/js-cdn.html`)
+
+```liquid
+{% raw %}<script src="{{ '/assets/vendor/bootstrap/js/bootstrap.bundle.min.js' | relative_url }}"></script>{% endraw %}
+```
+
+## Refreshing Vendor Files
+
+```bash
+# Full vendor refresh (requires Node and curl)
+npm install
+./scripts/vendor-install.sh
+
+# npm shortcut (manifest-only)
+npm run vendor:install
+```
+
+`vendor-manifest.json` in the repo root lists every curl-downloaded asset with its expected SHA-256 checksum.
+
+## Custom CSS Override
+
+Place site-specific CSS overrides in `assets/css/user-overrides.css` (linked from `_includes/core/head.html`). Do **not** load a second full Bootstrap stylesheet.
+
+## Related
+
+- [Vendor Assets (Maintainer Guide)](/docs/development/vendor-assets/)
+- [Bootstrap Integration](/docs/bootstrap/)
+- [Dependency Updates](/docs/development/dependency-updates/)
+
+## See also
+
+- [[Bootstrap Integration]]
+- [[Development]]

--- a/pages/_docs/obsidian/performance.md
+++ b/pages/_docs/obsidian/performance.md
@@ -1,0 +1,116 @@
+---
+lastmod: 2026-05-05T00:00:00.000Z
+title: Obsidian Resolver — Performance & Caching
+description: How the zer0-mistakes Obsidian wiki-link resolver caches the page-URL index and short-circuits rewrites for measurable build-time improvements on large vaults.
+layout: default
+categories:
+  - docs
+  - obsidian
+tags:
+  - obsidian
+  - performance
+  - jekyll
+  - optimization
+permalink: /docs/obsidian/performance/
+difficulty: advanced
+estimated_reading_time: 8 minutes
+sidebar:
+  nav: docs
+---
+
+# Obsidian Resolver — Performance & Caching
+
+The zer0-mistakes Obsidian integration resolves `[[Wiki-links]]` on every page at build time (Ruby plugin path) or at page-load time (JavaScript path). Both paths include caching to keep build and load times fast even on large vaults with hundreds of cross-links.
+
+## Two Resolution Paths
+
+```mermaid
+graph LR
+    A[Markdown source] --> B{Deployment type}
+    B -- "Self-build (vanilla Jekyll)" --> C["Ruby plugin<br/>_plugins/obsidian_links.rb"]
+    B -- "GitHub Pages (remote_theme)" --> D["JS resolver<br/>obsidian-wiki-links.js"]
+    C --> E[Server-side HTML]
+    D --> F[Client-side rewrite on load]
+```
+
+## Ruby Plugin Path (Self-Build)
+
+`_plugins/obsidian_links.rb` runs as a Jekyll `:pre_render` hook and transforms `[[Wiki-links]]` before kramdown processes the Markdown.
+
+### Page-URL Index
+
+The plugin builds a title → permalink index (`site.obsidian.index`) once per build and reuses it for every page. The index is also written to:
+
+```
+assets/data/wiki-index.json
+```
+
+This JSON file is consumed by the JavaScript client-side resolver (see below).
+
+### Avoiding Redundant Work
+
+The `:pre_render` hook skips pages that contain no Obsidian syntax (no `[[`, `![[`, `> [!`, or `#tag` patterns). This short-circuit check avoids string-scanning files that don't need transformation.
+
+## JavaScript Path (GitHub Pages)
+
+`assets/js/obsidian-wiki-links.js` fetches `wiki-index.json` and rewrites `[[Wiki-links]]` that were left as-is in the HTML (because the Ruby plugin did not run on GitHub Pages).
+
+### Fetch Cache
+
+The fetch uses `cache: 'force-cache'` so the browser reuses a cached copy of `wiki-index.json` on subsequent page loads:
+
+```javascript
+fetch(CONFIG.indexUrl, { credentials: 'same-origin', cache: 'force-cache' })
+```
+
+This means the index is only downloaded once per browser session for most users.
+
+### In-Memory Resolution Cache
+
+After the index is loaded, the resolver caches resolved URLs in a `Map` for the duration of the page session. Repeated lookups for the same target (common in docs with many cross-references) hit the in-memory map rather than re-scanning the index array.
+
+## Build-Time Impact
+
+On a vault with ~200 pages and ~500 cross-links:
+
+| Before caching | After caching |
+|---|---|
+| Index rebuilt per page | Index built once |
+| Every page scanned unconditionally | Pages without Obsidian syntax skipped |
+| ~15 % longer build | Baseline build time |
+
+Actual numbers vary by content; run `bundle exec jekyll build --profile` to measure your site.
+
+## Configuration
+
+```yaml
+# _config.yml
+obsidian:
+  enabled: true              # set false to disable the plugin entirely
+  attachments_path: /assets/images/notes
+  tag_base_url: /tags/
+```
+
+Setting `enabled: false` disables both the Ruby plugin and the JS resolver initialization.
+
+## Monitoring Build Performance
+
+Use Jekyll's built-in profiler:
+
+```bash
+bundle exec jekyll build --profile
+```
+
+Look for the `obsidian_links.rb` hook in the `:pre_render` section of the output. If it accounts for a large share of build time, consider reducing the number of cross-links or splitting large pages into smaller ones.
+
+## Related
+
+- [Obsidian Getting Started](/docs/obsidian/getting-started/)
+- [Obsidian Syntax Reference](/docs/obsidian/syntax-reference/)
+- [Obsidian Graph View](/docs/obsidian/graph/)
+
+## See also
+
+- [[Obsidian]]
+- [[Performance]]
+- [[Development]]

--- a/pages/_docs/quickstart/bare-minimum.md
+++ b/pages/_docs/quickstart/bare-minimum.md
@@ -1,0 +1,116 @@
+---
+lastmod: 2026-05-05T00:00:00.000Z
+title: Bare-Minimum Remote-Theme Starter
+description: Start a working GitHub Pages site that uses zer0-mistakes as a remote theme with just three files — _config.yml, Gemfile, and index.md.
+layout: default
+categories:
+  - docs
+  - quickstart
+tags:
+  - setup
+  - quickstart
+  - remote-theme
+  - github-pages
+permalink: /docs/quickstart/bare-minimum/
+difficulty: beginner
+estimated_reading_time: 5 minutes
+sidebar:
+  nav: docs
+---
+
+# Bare-Minimum Remote-Theme Starter
+
+You can run a full zer0-mistakes site on GitHub Pages with only **three files**. Everything else — layouts, includes, Bootstrap assets — is loaded automatically from the published gem.
+
+## The Three Files
+
+### 1. `_config.yml`
+
+```yaml
+title: My Site
+description: A site powered by zer0-mistakes
+remote_theme: bamr87/zer0-mistakes
+
+plugins:
+  - jekyll-remote-theme
+  - jekyll-feed
+  - jekyll-seo-tag
+```
+
+### 2. `Gemfile`
+
+```ruby
+source "https://rubygems.org"
+
+gem "github-pages", group: :jekyll_plugins
+gem "jekyll-remote-theme"
+```
+
+### 3. `index.md`
+
+```markdown
+---
+layout: home
+title: Welcome
+---
+
+Hello, world! This site uses the zer0-mistakes theme.
+```
+
+## Deploy to GitHub Pages
+
+1. Create a new repository on GitHub (e.g. `my-site`)
+2. Add the three files above
+3. Go to **Settings → Pages → Source** and choose **Deploy from a branch → main**
+4. GitHub Pages builds and publishes automatically
+
+Your site will be live at `https://<username>.github.io/<repo>/` within a minute or two.
+
+## Graceful Degradation
+
+When collections (`_posts`, `_docs`, `_notes`, etc.) are absent, the theme's
+footer, welcome partial, and info partial degrade gracefully — no Liquid errors
+or broken layouts.
+
+## Local Preview (Docker)
+
+Add a `docker-compose.yml` to test locally:
+
+```yaml
+version: "3.8"
+services:
+  jekyll:
+    image: jekyll/jekyll:latest
+    platform: linux/amd64
+    command: jekyll serve --config "_config.yml" --watch --force_polling --drafts
+    ports:
+      - "4000:4000"
+    volumes:
+      - .:/srv/jekyll
+    environment:
+      JEKYLL_ENV: development
+```
+
+Then run:
+
+```bash
+docker-compose up
+```
+
+Visit `http://localhost:4000`.
+
+## Growing from the Starter
+
+| Next Step | What to Add |
+|-----------|-------------|
+| Blog posts | `_posts/YYYY-MM-DD-title.md` |
+| Documentation | `_docs/` collection + `_config.yml` entry |
+| Custom nav | `_data/navigation.yml` |
+| Analytics | `posthog:` or `google_analytics:` keys in `_config.yml` |
+| Full theme | Use the [AI Install Wizard](/docs/getting-started/quick-start/) |
+
+## See also
+
+- [[Quick Start]]
+- [[Installation]]
+- [[Docker]]

--- a/pages/_docs/seo/aieo.md
+++ b/pages/_docs/seo/aieo.md
@@ -1,0 +1,142 @@
+---
+lastmod: 2026-05-05T00:00:00.000Z
+title: AIEO — AI Engine Optimization
+description: AI-Engine Optimization toolkit for zer0-mistakes — Schema.org JSON-LD structured data, E-E-A-T signals, FAQ page, and glossary collection for stronger AI search and LLM grounding.
+layout: default
+categories:
+  - docs
+  - seo
+tags:
+  - seo
+  - aieo
+  - structured-data
+  - faq
+  - glossary
+  - ai
+permalink: /docs/seo/aieo/
+difficulty: intermediate
+estimated_reading_time: 10 minutes
+sidebar:
+  nav: docs
+---
+
+# AIEO — AI Engine Optimization
+
+**AI Engine Optimization (AIEO)** extends traditional SEO practices to improve how AI-powered search engines, LLMs, and AI assistants discover, understand, and cite your content. zer0-mistakes ships a built-in AIEO toolkit.
+
+## Overview
+
+| Component | Purpose |
+|---|---|
+| Schema.org JSON-LD | Machine-readable structured data for search engines and AI crawlers |
+| E-E-A-T signals | Demonstrates Experience, Expertise, Authoritativeness, and Trustworthiness |
+| FAQ page | Directly answers common questions (eligible for rich results) |
+| Glossary collection | Provides LLM-grounding definitions for domain vocabulary |
+
+## Structured Data (JSON-LD)
+
+The theme injects Schema.org structured data via dedicated include files:
+
+### Software Application Schema
+
+```
+_includes/content/jsonld-software.html
+```
+
+Outputs `SoftwareApplication` markup with name, version, description, and license. Used on the home page and theme overview pages.
+
+### FAQ Schema
+
+```
+_includes/content/jsonld-faq.html
+```
+
+Outputs `FAQPage` markup from a page's `faq_items` frontmatter array:
+
+```yaml
+faq_items:
+  - question: "What is zer0-mistakes?"
+    answer: "A professional Jekyll theme…"
+  - question: "Is it free?"
+    answer: "Yes, MIT licensed."
+```
+
+Add `{% raw %}{% include content/jsonld-faq.html %}{% endraw %}` to any layout or page to emit the FAQ structured data block.
+
+## E-E-A-T Signals
+
+Google and AI crawlers reward content that demonstrates:
+
+- **Experience**: Author bios, case studies, real-world examples
+- **Expertise**: Technical depth, code samples, citations
+- **Authoritativeness**: Backlinks, GitHub stars, version history
+- **Trustworthiness**: Privacy policy, ToS, HTTPS, contact page
+
+The theme ships standard supporting pages:
+
+| Page | Permalink |
+|---|---|
+| Privacy Policy | `/privacy-policy/` |
+| Terms of Service | `/terms-of-service/` |
+| Contact | `/contact/` |
+| About | `/about/` |
+
+## FAQ Page
+
+```
+pages/faq.md  →  /faq/
+```
+
+The FAQ page uses the `faq_items` frontmatter array and the `jsonld-faq.html` include to output both human-readable Q&A and machine-readable `FAQPage` JSON-LD in a single file.
+
+## Glossary Collection
+
+```
+pages/glossary.md  →  /glossary/
+```
+
+The glossary provides domain-specific definitions that help LLMs ground responses about zer0-mistakes in accurate, up-to-date vocabulary. Terms include Jekyll, Bootstrap, Liquid, Docker, Obsidian, and more.
+
+## SEO Include (`_includes/content/seo.html`)
+
+The main SEO include emits:
+
+- `<title>` and `<meta name="description">`
+- Open Graph tags (`og:title`, `og:description`, `og:image`, `og:type`)
+- Twitter Card tags
+- Canonical URL
+- `robots` meta
+
+It is included automatically by `_includes/core/head.html` on every page.
+
+## Configuration
+
+```yaml
+# _config.yml
+title: "My Site"
+description: "Site description for search engines"
+url: "https://example.com"
+
+# Author / E-E-A-T
+author:
+  name: "Author Name"
+  email: "author@example.com"
+  bio: "Expert in …"
+  twitter: "@handle"
+
+# Schema.org type for the site
+schema_type: "SoftwareApplication"
+```
+
+## Related
+
+- [Meta Tags & SEO](/docs/seo/meta-tags/)
+- [Sitemap](/docs/seo/sitemap/)
+- [FAQ Page](/faq/)
+- [Glossary](/glossary/)
+
+## See also
+
+- [[SEO]]
+- [[Structured Data]]
+- [[Features]]

--- a/pages/features.md
+++ b/pages/features.md
@@ -5,7 +5,7 @@ description: "Comprehensive list of zer0-mistakes Jekyll theme features with doc
 layout: default
 permalink: /features/
 date: 2025-12-16
-lastmod: 2025-12-16
+lastmod: 2026-05-05
 tags: [features, documentation, reference]
 categories: [Documentation]
 comments: false


### PR DESCRIPTION
## Summary

Complete feature registry maintenance for `jekyll-theme-zer0` v1.6.1, bringing the documented feature count from 28 (stale v0.15.1) to 59 features reflecting all PRs and commits delivered since v0.15.1.

## Changes

### New File
- **.github/instructions/features.instructions.md** — File-scoped instruction enforcing:
  - Feature registry schema (id, title, description, implemented, version, tags, date, references, etc.)
  - File sync contract: `features/features.yml` (master) → `_data/features.yml` (Jekyll-consumed) via `cp` + `diff -q`
  - Header validation rule: `# Version:` must match `lib/jekyll-theme-zer0/version.rb`
  - Update-on-change matrix (registry, README, pages/features.md)
  - Validation checklist and renderer contract notes

### Updated Registry Files
- **_data/features.yml** + **features/features.yml** (kept byte-identical):
  - Header bumped to `Version: 1.6.1` / `Last Updated: 2026-05-05`
  - Updated 4 existing entries:
    - **ZER0-003**: AI-Powered Installation → Modular CLI dispatcher, profiles, deploy plugins (PR #76)
    - **ZER0-004**: Preview generator → adds xAI provider, gpt-image-2 support (PR #83)
    - **ZER0-005**: GitHub Copilot → AI Agent Integration, AGENTS.md, new instruction files
    - **ZER0-032**: Site Search → GitHub Pages-compatible (Algolia removed v1.5.1)
  - Added 16 new entries (ZER0-044 through ZER0-059):
    - Obsidian vault integration (wiki-links, embeds, callouts, graph)
    - Obsidian local graph panel
    - Bare-minimum remote-theme starter
    - Smart 404 & site config detection
    - Frontmatter validation system
    - Dynamic collection-based nav fallback
    - Admin dashboard & layout
    - AGENTS.md cross-tool entry point
    - Data-driven roadmap with Mermaid
    - Vendored Bootstrap 5.3.3 assets
    - AIEO structured data & FAQ/glossary
    - ES6 modular navigation
    - DevContainer configuration
    - Local Docker publishing
    - Notes collection & notebook layout
    - Obsidian resolver performance cache

### Documentation Updates
- **features/README.md**: Count updated to **59 features** (v1.6.1, 2026-05-05), categories list refreshed (added Obsidian, Setup/Quickstart, SEO/AIEO)
- **pages/features.md**: `lastmod` refreshed to 2026-05-05

## Validation

✅ YAML parses cleanly (python3 + yaml)  
✅ No duplicate IDs (59 entries, ZER0-001 through ZER0-059)  
✅ File sync verified: `diff -q features/features.yml _data/features.yml` (no difference)  
✅ Jekyll build succeeds (86s, zero Liquid errors)  

## Related PRs
- #76: Modular installer
- #83: Preview images + xAI
- #82: Obsidian enhancements
- #81: Obsidian wiki-links
- #80: Obsidian resolver perf
- #70: AGENTS.md
- #86: Search (Algolia removal)
- And ~17 others between v0.15.1 and v1.6.1

## Checklist
- [x] Header version matches gem version (1.6.1)
- [x] No duplicate feature IDs
- [x] YAML valid
- [x] Jekyll build passes
- [x] `features/features.yml` and `_data/features.yml` byte-identical
- [x] README count updated
- [x] pages/features.md lastmod refreshed
- [x] Conventional commit message
