### PR TITLE
fix(features): correct stale file references — release v1.6.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [1.6.3] - 2026-05-21
+
+### Fixed
+- **Feature Registry**: Remove stale `_includes/navigation/menu-collections.html` reference from ZER0-049
+- **Feature Registry**: Fix roadmap script path from `generate-roadmap-diagram.sh` → `generate-roadmap.sh` in ZER0-052
+- **Feature Registry**: Replace non-existent `structured-data.html`/`eeat-signals.html` with correct `seo.html`, `jsonld-faq.html`, `author-eeat.html` in ZER0-054
+- **Feature Registry**: Remove stale `_includes/components/settings-modal.html` reference from ZER0-055
+
+### Commits in this release
+- fix(features): correct stale file references in ZER0-049/052/054/055
+
+
 ## [1.6.2] - 2026-05-19
 
 ### Changed

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    jekyll-theme-zer0 (1.6.2)
+    jekyll-theme-zer0 (1.6.3)
       jekyll
 
 GEM

--- a/_data/features.yml
+++ b/_data/features.yml
@@ -1132,7 +1132,6 @@ features:
     references:
       includes:
         - "_includes/navigation/navbar.html"
-        - "_includes/navigation/menu-collections.html"
 
   - id: ZER0-050
     title: "Admin Layout & Configuration Dashboards"
@@ -1174,7 +1173,7 @@ features:
     references:
       data: "_data/roadmap.yml"
       page: "pages/roadmap.md"
-      script: "scripts/generate-roadmap-diagram.sh"
+      script: "scripts/generate-roadmap.sh"
 
   - id: ZER0-053
     title: "Vendored Bootstrap & Icon Assets"
@@ -1203,8 +1202,9 @@ features:
     date: 2025-12-30
     references:
       includes:
-        - "_includes/content/structured-data.html"
-        - "_includes/content/eeat-signals.html"
+        - "_includes/content/seo.html"
+        - "_includes/content/jsonld-faq.html"
+        - "_includes/components/author-eeat.html"
       pages:
         - "pages/faq.md"
         - "pages/glossary.md"
@@ -1224,7 +1224,6 @@ features:
         - "assets/js/navigation.js"
       includes:
         - "_includes/navigation/navbar.html"
-        - "_includes/components/settings-modal.html"
 
   - id: ZER0-056
     title: "DevContainer Configuration"

--- a/features/features.yml
+++ b/features/features.yml
@@ -1132,7 +1132,6 @@ features:
     references:
       includes:
         - "_includes/navigation/navbar.html"
-        - "_includes/navigation/menu-collections.html"
 
   - id: ZER0-050
     title: "Admin Layout & Configuration Dashboards"
@@ -1174,7 +1173,7 @@ features:
     references:
       data: "_data/roadmap.yml"
       page: "pages/roadmap.md"
-      script: "scripts/generate-roadmap-diagram.sh"
+      script: "scripts/generate-roadmap.sh"
 
   - id: ZER0-053
     title: "Vendored Bootstrap & Icon Assets"
@@ -1203,8 +1202,9 @@ features:
     date: 2025-12-30
     references:
       includes:
-        - "_includes/content/structured-data.html"
-        - "_includes/content/eeat-signals.html"
+        - "_includes/content/seo.html"
+        - "_includes/content/jsonld-faq.html"
+        - "_includes/components/author-eeat.html"
       pages:
         - "pages/faq.md"
         - "pages/glossary.md"
@@ -1224,7 +1224,6 @@ features:
         - "assets/js/navigation.js"
       includes:
         - "_includes/navigation/navbar.html"
-        - "_includes/components/settings-modal.html"
 
   - id: ZER0-056
     title: "DevContainer Configuration"

--- a/lib/jekyll-theme-zer0/version.rb
+++ b/lib/jekyll-theme-zer0/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module JekyllThemeZer0
-  VERSION = "1.6.2" unless defined?(JekyllThemeZer0::VERSION)
+  VERSION = "1.6.3" unless defined?(JekyllThemeZer0::VERSION)
 end

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zer0-mistakes-theme-tools",
-  "version": "1.6.2",
+  "version": "1.6.3",
   "private": true,
   "description": "Theme tooling: Playwright tests; vendor:mermaid copies Mermaid from node_modules (no jsDelivr); optional css:bootstrap for advanced Bootstrap SCSS. Committed assets/vendor/ is GitHub Pages–safe.",
   "scripts": {


### PR DESCRIPTION
## Summary

Patch release v1.6.3 fixing 4 stale file references in the feature registry that reference files that do not exist in the repository.

## Changes

### Fixed
- **ZER0-049**: Remove `_includes/navigation/menu-collections.html` (file does not exist)
- **ZER0-052**: Fix roadmap script path `generate-roadmap-diagram.sh` → `generate-roadmap.sh`
- **ZER0-054**: Replace `structured-data.html`/`eeat-signals.html` with correct `seo.html`, `jsonld-faq.html`, `author-eeat.html`
- **ZER0-055**: Remove `_includes/components/settings-modal.html` (file does not exist)

Both `_data/features.yml` and `features/features.yml` are updated identically (byte-identical pair maintained).

## Validation
- ✅ Jekyll build passes
- ✅ `_data/features.yml` == `features/features.yml` (byte-identical)
- ✅ All referenced files verified to exist (or correctly removed)

Closes #92