### PR TITLE
feat(ci): continuous-evolution backlog loop

### DIFF
--- a/.cursor/commands/backlog-implement.md
+++ b/.cursor/commands/backlog-implement.md
@@ -1,0 +1,18 @@
+---
+agent: agent
+mode: agent
+description: "Implement the highest-priority open task from _data/backlog.yml on a branch, validate, and open a PR (auto-merge only low-risk docs/deps/lint)."
+tools: [run_in_terminal, read_file, apply_patch, get_changed_files, grep_search]
+---
+
+# Backlog Implement
+
+Follow the canonical, numbered workflow in
+[`.github/prompts/backlog-implement.prompt.md`](../../.github/prompts/backlog-implement.prompt.md).
+
+In short: pick the top `status: open` task (P0→P3), mark it `in-progress`,
+implement it minimally per the matching `.github/instructions/*`, validate
+(`ruby scripts/sync-backlog.rb --check` + tests + Jekyll build as relevant),
+set it `done`, and open one PR. Apply the `auto-merge` label only for
+`risk: low` work in `docs`/`deps`/`lint` with no API/schema/version change;
+everything else is PR-only. Never bump the version or publish a gem.

--- a/.cursor/commands/repo-audit.md
+++ b/.cursor/commands/repo-audit.md
@@ -1,0 +1,17 @@
+---
+agent: agent
+mode: agent
+description: "Review the repo and file tactical tasks into _data/backlog.yml (tests/docs/roadmap), then open a single backlog PR."
+tools: [run_in_terminal, read_file, apply_patch, get_changed_files, grep_search]
+---
+
+# Repo Audit
+
+Follow the canonical, numbered workflow in
+[`.github/prompts/repo-audit.prompt.md`](../../.github/prompts/repo-audit.prompt.md).
+
+In short: review test coverage & quality, documentation freshness, and roadmap
+delivery; append right-sized tasks to `_data/backlog.yml` (validate with
+`ruby scripts/sync-backlog.rb --check`); open one PR
+`chore(backlog): audit YYYY-MM-DD`. Never bump the version or publish a gem; cap
+new tasks at 5 per run.

--- a/.github/instructions/README.md
+++ b/.github/instructions/README.md
@@ -20,10 +20,13 @@ This directory contains file-specific instructions for GitHub Copilot to provide
 │   ├── features.instructions.md      # Feature registry schema + sync contract
 │   ├── obsidian.instructions.md      # Obsidian vault integration (wiki-links, JS resolver, Ruby plugin)
 │   ├── sass.instructions.md          # Sass partials, Bootstrap overrides, CSS custom properties
-│   └── version-control.instructions.md  # Git workflow and releases
+│   ├── version-control.instructions.md  # Git workflow and releases
+│   └── backlog.instructions.md       # Tactical backlog schema + sync contract
 ├── prompts/                         # Reusable agent/chat prompts (.prompt.md)
 │   ├── commit-publish.prompt.md      # Full release pipeline
 │   ├── frontmatter-maintainer.prompt.md  # Front matter audit / fix
+│   ├── repo-audit.prompt.md          # Review repo → file backlog tasks
+│   ├── backlog-implement.prompt.md   # Implement next backlog task → PR
 │   └── seed.prompt.md                # Theme rebuild blueprint
 └── seed/                            # Deep architectural blueprint docs
 
@@ -51,6 +54,7 @@ GitHub Copilot automatically applies these instructions based on the files you'r
 | `obsidian.instructions.md`        | `_plugins/obsidian_links.rb`, `assets/js/obsidian-*.js`, `assets/data/wiki-index.json`, `_includes/content/backlinks.html`, `pages/_docs/obsidian/**`, Obsidian tests | Wiki-link/embed/callout contract across Liquid index, JS resolver, and Ruby plugin |
 | `sass.instructions.md`            | `_sass/**`, `assets/css/**`        | Sass partial layering, Bootstrap variable overrides, no-double-Bootstrap rule |
 | `version-control.instructions.md` | `CHANGELOG.md`, `**/version.*`, `*.gemspec`, `package.json` | Git workflow, semantic versioning, releases        |
+| `backlog.instructions.md`         | `_data/backlog.yml`, `scripts/sync-backlog.*`, `.github/workflows/backlog-sync.yml` | Tactical backlog schema, sync contract, ownership rules |
 
 ## 📖 Main Instructions (copilot-instructions.md)
 

--- a/.github/instructions/backlog.instructions.md
+++ b/.github/instructions/backlog.instructions.md
@@ -1,0 +1,49 @@
+---
+applyTo: "_data/backlog.yml,scripts/sync-backlog.rb,scripts/sync-backlog.sh,.github/workflows/backlog-sync.yml"
+description: "Tactical backlog maintenance — schema, sync contract, and ownership rules for the continuous-evolution loop."
+date: 2026-05-31T12:00:00.000Z
+lastmod: 2026-05-31T12:00:00.000Z
+---
+
+# Backlog Instructions
+
+`_data/backlog.yml` is the single source of truth for **tactical tasks** (granular,
+pickup-able work items). It is mirrored to GitHub Issues by `scripts/sync-backlog.rb`
+and drives the continuous-evolution loop. Full design:
+[`docs/systems/continuous-evolution.md`](../../docs/systems/continuous-evolution.md).
+
+## 📂 Files in Scope
+
+| File | Role |
+| --- | --- |
+| `_data/backlog.yml` | Editable task queue (source of truth); schema in the file header |
+| `scripts/sync-backlog.rb` | Validates schema + creates/updates/closes GitHub Issues |
+| `scripts/sync-backlog.sh` | Thin wrapper forwarding to the Ruby script |
+| `.github/workflows/backlog-sync.yml` | Runs sync on push to `main`; `--check` gate on PRs |
+
+## Rules
+
+- **Edit the file, never the issues.** Issue bodies are auto-generated and
+  overwritten on every sync (they carry a `<!-- backlog-id: T-NNN -->` marker used
+  for matching). Issue state follows the task `status`.
+- **Ids are stable and never reused.** New tasks take the next `T-NNN` from
+  `meta.next_id`; increment `meta.next_id` and bump `meta.updated` when adding.
+- **Every task needs checkable `acceptance` criteria.** The implement routine
+  verifies them before opening a PR.
+- **Set `risk` honestly.** `risk: low` is reserved for `docs`/`deps`/`lint` work
+  with no public-API or schema change — only those are auto-merge eligible.
+- **Validate before committing:** `ruby scripts/sync-backlog.rb --check` (this is
+  also the PR gate; a malformed backlog fails CI).
+- **Mark completion in the backlog, not by closing the issue.** Set the task to
+  `status: done`; the next sync closes its issue.
+- **Keep the script dependency-free** (Ruby stdlib only) and compatible with the
+  macOS system Ruby 2.6 — mirror the YAML-load fallback used in
+  `scripts/generate-roadmap.rb`.
+
+## Sync contract
+
+- Tasks with status `open` / `in-progress` / `blocked` → an **open** issue.
+- Tasks with status `done` → their issue is **closed** (`completed`).
+- Managed labels (owned by the script, safe to reconcile): `agent-ready`,
+  `agent-hold`, `priority:P0..P3`, `area:*`, `risk:*`. Human-applied labels are
+  never removed.

--- a/.github/prompts/backlog-implement.prompt.md
+++ b/.github/prompts/backlog-implement.prompt.md
@@ -1,0 +1,121 @@
+---
+mode: agent
+description: "Pick the highest-priority open task from _data/backlog.yml, implement it on a branch, validate, and open a PR — auto-merging only low-risk classes (docs/deps/lint). Use for the IMPLEMENT routine or whenever asked to 'work the backlog' / 'do the next task'."
+argument-hint: "Optional task id (e.g. T-003) to implement a specific task instead of the top of the queue"
+tools: [run_in_terminal, read_file, replace_string_in_file, multi_replace_string_in_file, get_changed_files, grep_search, file_search]
+date: 2026-05-31T12:00:00.000Z
+lastmod: 2026-05-31T12:00:00.000Z
+---
+
+# Backlog Implement — work one task
+
+When invoked with `/backlog-implement`, pick one task from
+[`_data/backlog.yml`](../../_data/backlog.yml), implement it, and open a PR.
+**One task, one PR, one run.** The full loop is documented in
+[`docs/systems/continuous-evolution.md`](../../docs/systems/continuous-evolution.md).
+
+Read [`AGENTS.md`](../../AGENTS.md) and the file-scoped
+[`.github/instructions/*`](../instructions/) that match the files you will touch.
+
+## Hard rules
+
+- **One task per PR.** Do not batch.
+- **Never bump the version, never edit `lib/jekyll-theme-zer0/version.rb`, never
+  publish a gem.** Releases are human-only (`/commit-publish`). Add a
+  `CHANGELOG.md` `[Unreleased]` entry for user-visible changes instead.
+- **Validate before opening the PR** (Phase 3). A red build never gets a PR.
+- **Respect holds**: skip any task with `status: blocked` or whose issue carries
+  the `agent-hold` label.
+
+## Phase 0 — Select a task
+
+```bash
+git switch main && git pull --rebase origin main
+ruby scripts/sync-backlog.rb --check
+```
+
+Choose the task: the `--argument-hint` id if given, else the highest-priority
+`status: open` task (P0 → P3; break ties by smallest `effort`, then lowest id).
+Skip `blocked`/`in-progress`/`done`. If nothing is actionable, report that and stop.
+
+Mark it `in-progress` and set `updated` to today in `_data/backlog.yml` (this edit
+rides along on your feature branch, created next).
+
+## Phase 1 — Implement
+
+```bash
+git switch -c "$(echo "<area>/<id>-<slug>")"   # e.g. docs/T-004-link-sweep
+```
+
+Build the change following the matching file-scoped instructions. Keep it
+**minimal and surgical** (AGENTS.md operating rule 1). Stay within the task's
+scope — if you discover adjacent work, file it as a *new* backlog task rather than
+expanding this PR.
+
+## Phase 2 — Document
+
+- Add a `CHANGELOG.md` entry under `[Unreleased]` (Keep a Changelog format) for
+  any user-visible change.
+- Update `docs/` / `pages/_docs/` / `_data/features.yml` if behavior changed.
+- In `_data/backlog.yml`, set the task `status: done` and `updated:` to today.
+
+## Phase 3 — Validate (required)
+
+Run the checks relevant to what you touched — at minimum:
+
+```bash
+ruby scripts/sync-backlog.rb --check                 # backlog still valid
+./scripts/bin/test                                   # or the targeted suite
+# Theme/layout/include/sass changes -> Docker Jekyll build:
+docker-compose exec -T jekyll bundle exec jekyll build \
+  --config '_config.yml,_config_dev.yml'
+```
+
+Verify **every** acceptance criterion on the task. 🛑 Any failure → fix or revert;
+do not open the PR.
+
+## Phase 4 — Open the PR (and maybe auto-merge)
+
+```bash
+git add -A
+git commit -m "<type>(<scope>): <subject>
+
+Implements <id>: <task title>.
+Closes #<issue-number>."
+git push -u origin HEAD
+gh pr create --base main --fill --title "<type>(<scope>): <subject>"
+```
+
+### Autonomy policy — which PRs may auto-merge
+
+Apply the `auto-merge` label **only** when ALL of these hold; otherwise leave the
+PR for human review:
+
+| Condition | Required for auto-merge |
+|---|---|
+| Task `area` ∈ { `docs`, `deps`, `lint` } | ✅ |
+| Task `risk` == `low` | ✅ |
+| No change to public API, gem `version.rb`, gemspec, or a data schema | ✅ |
+| No new runtime dependency | ✅ |
+| All acceptance criteria verified green in Phase 3 | ✅ |
+
+```bash
+# Low-risk only — the auto-merge.yml workflow gates on required CI checks:
+gh pr edit --add-label auto-merge
+```
+
+For everything else (`feat`, `refactor`, anything `risk: standard`): **do not**
+add the label. Post a short PR description and stop — a human reviews and merges.
+
+## Implement summary (return to user)
+
+```markdown
+## Implemented <id> — <task title>
+
+- Branch/PR: <link>
+- Area / risk: <area> / <risk>   ·   Auto-merge: yes|no (human review)
+- Acceptance: all criteria verified ✅
+- Validation: tests ✅ · jekyll build ✅ (if applicable)
+
+Backlog: <id> → done. Issue #<n> closes on the next sync.
+```

--- a/.github/prompts/repo-audit.prompt.md
+++ b/.github/prompts/repo-audit.prompt.md
@@ -1,0 +1,130 @@
+---
+mode: agent
+description: "Routinely review the zer0-mistakes repository and file tactical tasks into _data/backlog.yml. Audits test coverage & quality, documentation freshness, and roadmap delivery, then opens a single PR adding/refreshing backlog tasks. Use for the weekly AUDIT routine or whenever asked to 'review the repo and find work'."
+argument-hint: "Optional focus area: tests | docs | roadmap (defaults to all three)"
+tools: [run_in_terminal, read_file, replace_string_in_file, multi_replace_string_in_file, get_changed_files, grep_search, file_search]
+date: 2026-05-31T12:00:00.000Z
+lastmod: 2026-05-31T12:00:00.000Z
+---
+
+# Repo Audit — fill the backlog
+
+When invoked with `/repo-audit`, review the repository against the focus areas
+below and translate findings into **tactical tasks** in
+[`_data/backlog.yml`](../../_data/backlog.yml). You produce *work items*, not code
+changes — the IMPLEMENT routine
+([`backlog-implement.prompt.md`](./backlog-implement.prompt.md)) does the building.
+
+Read [`AGENTS.md`](../../AGENTS.md) and the layered guidance first. The whole loop
+is documented in [`docs/systems/continuous-evolution.md`](../../docs/systems/continuous-evolution.md).
+
+## Hard rules
+
+- **Never bump the version or edit `lib/jekyll-theme-zer0/version.rb`.**
+- **Never publish a gem.** Releases stay human (`/commit-publish`).
+- **One PR per run**, titled `chore(backlog): audit YYYY-MM-DD`.
+- **Cap new tasks at 5 per run.** Quality over quantity; the backlog is a queue,
+  not a dumping ground.
+- **Do not duplicate** existing roadmap milestones, open backlog tasks, or
+  findings already covered by CodeQL (`codeql.yml`) and the dependency canary
+  (`test-latest.yml`). You may *note* a security/dep item but prefer to defer to
+  those systems.
+
+## Phase 0 — Orient
+
+```bash
+git switch main && git pull --rebase origin main
+ruby scripts/sync-backlog.rb --check        # backlog must be valid before you edit it
+```
+
+Read the current backlog so you do not re-file existing work:
+
+```bash
+sed -n '/^tasks:/,$p' _data/backlog.yml | grep -E '^\s+- id:|title:|status:'
+```
+
+Note the highest `T-NNN` id and `meta.next_id` — new tasks continue from there.
+
+## Phase 1 — Review (focus areas)
+
+Run only the checks for the requested focus (default: all three). Keep this
+read-only; you are diagnosing, not fixing.
+
+### A. Test coverage & quality
+```bash
+./scripts/bin/test            # or ./test/test_runner.sh — note failures/skips
+./scripts/bin/validate --quick
+```
+Look for: failing/flaky/skipped tests, subsystems with no tests (cross-check
+`test/` against `scripts/`, `_plugins/`, `assets/js/`), and progress toward the
+v1.0 "90%+ coverage" roadmap goal. File the **lowest-covered** areas first.
+
+### B. Documentation freshness
+```bash
+markdownlint "**/*.md" --ignore node_modules || true
+npx --yes markdown-link-check -q -c .github/config/.markdown-link-check.json \
+  $(git ls-files '*.md' | head -50) || true   # broken internal links
+```
+Look for: broken links, stale dates/versions, `docs/` ↔ `pages/_docs/` drift
+(features documented in one tier but not the other), and undocumented features
+present in `_data/features.yml`.
+
+### C. Roadmap delivery
+Read [`_data/roadmap.yml`](../../_data/roadmap.yml). For the **active** milestone,
+break any not-yet-shipped `features:` bullets into concrete, implementable tasks
+(set `source: roadmap`, `links.roadmap: "<version>"`). Do not invent scope beyond
+the roadmap.
+
+## Phase 2 — Reconcile the backlog
+
+For each finding worth doing, append a task to `_data/backlog.yml` following the
+schema documented at the top of that file. Rules:
+
+- **Dedupe**: skip anything already present as an open task (match by intent, not
+  exact title). If an existing task is now stale or done, update its `status`
+  instead of adding a new one.
+- **Right-size risk**: `risk: low` only for `docs` / `deps` / `lint` work with no
+  public-API or schema change (these become auto-merge eligible). Everything else
+  is `risk: standard`.
+- **Acceptance criteria are mandatory** and must be checkable (the IMPLEMENT
+  routine verifies them).
+- Set `created`/`updated` to today, `source: audit` (unless roadmap-derived).
+- Increment `meta.next_id` and bump `meta.updated`.
+
+Validate before committing:
+
+```bash
+ruby scripts/sync-backlog.rb --check
+```
+
+## Phase 3 — Open the PR
+
+```bash
+git switch -c chore/backlog-audit-$(date +%Y%m%d)
+git add _data/backlog.yml
+git commit -m "chore(backlog): audit $(date +%Y-%m-%d)
+
+Add N tasks from the routine repo audit (tests/docs/roadmap)."
+git push -u origin HEAD
+gh pr create --base main --fill \
+  --title "chore(backlog): audit $(date +%Y-%m-%d)" \
+  --label agent-ready
+```
+
+The PR's `--check` gate runs automatically; once merged, `backlog-sync.yml`
+creates the GitHub Issues. **Do not** enable auto-merge on the audit PR itself —
+a human glances at newly-filed work before it becomes issues.
+
+## Audit summary (return to user)
+
+```markdown
+## Repo audit — YYYY-MM-DD
+
+| Focus | Findings | Tasks filed |
+|---|---|---|
+| Tests & quality | … | T-0NN, T-0NN |
+| Docs freshness  | … | T-0NN |
+| Roadmap (v0.XX) | … | T-0NN |
+
+PR: <link>   ·   Backlog now has N open tasks.
+```

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,0 +1,55 @@
+name: Auto-merge low-risk PRs
+
+# Enable GitHub native auto-merge for PRs the IMPLEMENT routine has classified as
+# low-risk (label `auto-merge`). Native auto-merge only completes once all
+# REQUIRED status checks pass, so CI remains the gate. Everything without the
+# label stays for human review.
+#
+# Prerequisites (configured once by a maintainer, see
+# docs/systems/continuous-evolution.md):
+#   - Settings → General → "Allow auto-merge" enabled.
+#   - Branch protection on `main` with the CI checks marked as required.
+# Without these, this job is a safe no-op and the PR simply waits for a human.
+
+permissions:
+  contents: write
+  pull-requests: write
+
+on:
+  pull_request_target:
+    types: [labeled, opened, reopened, synchronize]
+
+concurrency:
+  group: auto-merge-${{ github.event.pull_request.number }}
+  cancel-in-progress: false
+
+jobs:
+  enable-auto-merge:
+    # Only act on PRs carrying the auto-merge label. Guard against the label
+    # being applied to risky changes: bail if the PR touches version/release or
+    # dependency-manifest files that must never auto-merge.
+    if: contains(github.event.pull_request.labels.*.name, 'auto-merge')
+    runs-on: ubuntu-latest
+    steps:
+      # Note: we never check out the PR head (untrusted code under
+      # pull_request_target). The file list comes from the API via `gh pr diff`.
+      - name: Verify the PR is genuinely low-risk
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR: ${{ github.event.pull_request.number }}
+        run: |
+          changed=$(gh pr diff "$PR" --name-only)
+          echo "Changed files:"; echo "$changed"
+          # Files that must never auto-merge, even if mislabelled.
+          if echo "$changed" | grep -E -q \
+            '(^lib/jekyll-theme-zer0/version\.rb$|\.gemspec$|^Gemfile$|^Gemfile\.lock$|^package\.json$)'; then
+            echo "::error::PR labelled auto-merge but touches version/release/dependency files — removing label."
+            gh pr edit "$PR" --remove-label auto-merge
+            exit 1
+          fi
+
+      - name: Enable native auto-merge (squash)
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR: ${{ github.event.pull_request.number }}
+        run: gh pr merge "$PR" --auto --squash

--- a/.github/workflows/backlog-sync.yml
+++ b/.github/workflows/backlog-sync.yml
@@ -1,0 +1,53 @@
+name: Backlog Sync
+
+# Mirror `_data/backlog.yml` (the tactical task queue) to GitHub Issues.
+#
+# - On push to main: create/update/close issues so they match the backlog file.
+# - On pull requests touching the data file or script: validate the schema only
+#   (no issue writes), so a malformed backlog can never reach main.
+
+permissions:
+  contents: read
+  issues: write
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - '_data/backlog.yml'
+      - 'scripts/sync-backlog.rb'
+      - 'scripts/sync-backlog.sh'
+      - '.github/workflows/backlog-sync.yml'
+  pull_request:
+    paths:
+      - '_data/backlog.yml'
+      - 'scripts/sync-backlog.rb'
+      - 'scripts/sync-backlog.sh'
+      - '.github/workflows/backlog-sync.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: backlog-sync-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.3'
+
+      - name: Validate backlog schema (PRs)
+        if: github.event_name == 'pull_request'
+        run: ruby scripts/sync-backlog.rb --check
+
+      - name: Sync backlog to issues (push / manual)
+        if: github.event_name != 'pull_request'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: ruby scripts/sync-backlog.rb

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,6 +39,7 @@ files you are about to touch — do **not** load everything up front.
 | **File-scoped instructions** | `.github/instructions/*.instructions.md` | When editing files matching the `applyTo:` glob in each file's front matter |
 | **Reusable prompts (chat/agent modes)** | `.github/prompts/*.prompt.md` | When asked to perform a multi-step task that matches a prompt |
 | **Project "seed" blueprint** | `.github/seed/*.md` | For deep architectural decisions or rebuilding subsystems from scratch |
+| **Tactical backlog** | `_data/backlog.yml` | When picking up or filing granular tasks (synced to GitHub Issues) — see the continuous-evolution loop below |
 | **Obsidian vault docs** | `pages/_docs/obsidian/` | When working with `[[wiki-links]]`, `![[embeds]]`, callouts, or the wiki-index/JS resolver |
 | **Cursor slash-commands** | `.cursor/commands/*.md` | Auto-loaded by Cursor; mirrors the prompts above |
 | **CI / quality config** | `.github/config/`, `.github/workflows/` | When changing lint rules, tests, or release automation |
@@ -60,6 +61,7 @@ should load them manually):
 | `test/**` | `.github/instructions/testing.instructions.md` |
 | `docs/**`, `pages/_docs/**`, `*docs*.md` | `.github/instructions/documentation.instructions.md` |
 | `CHANGELOG.md`, `**/version.*`, `*.gemspec`, `package.json` | `.github/instructions/version-control.instructions.md` |
+| `_data/backlog.yml`, `scripts/sync-backlog.*`, `.github/workflows/backlog-sync.yml` | `.github/instructions/backlog.instructions.md` |
 
 ### Reusable prompts
 
@@ -69,6 +71,28 @@ should load them manually):
 | Add a new Obsidian wiki-link / embed / callout syntax across all rendering paths | `.github/prompts/obsidian-add-syntax.prompt.md` |
 | Front matter audit / fix across content | `.github/prompts/frontmatter-maintainer.prompt.md` |
 | Rebuild the theme from scratch (deep blueprint) | `.github/prompts/seed.prompt.md` |
+| Review the repo and file tactical tasks into the backlog | `.github/prompts/repo-audit.prompt.md` |
+| Implement the next open backlog task and open a PR | `.github/prompts/backlog-implement.prompt.md` |
+
+---
+
+## 🔁 Continuous-Evolution Loop
+
+This repo runs a self-sustaining backlog loop so AI agents can keep improving it
+between human sessions:
+
+1. **Audit** (`/repo-audit`, scheduled weekly) reviews tests, docs, and roadmap
+   delivery and files tasks into [`_data/backlog.yml`](./_data/backlog.yml).
+2. **Sync** (`.github/workflows/backlog-sync.yml`) mirrors open tasks to GitHub
+   Issues (`agent-ready` label) and closes issues for tasks marked `done`.
+3. **Implement** (`/backlog-implement`, scheduled) picks the top open task, builds
+   it on a branch, validates, and opens a PR. Low-risk classes (`docs`/`deps`/`lint`
+   with `risk: low`) auto-merge once CI is green via `.github/workflows/auto-merge.yml`;
+   everything else waits for human review.
+
+`_data/backlog.yml` is the source of truth — edit the file, not the issues. Full
+design, autonomy policy, and how to pause the loop:
+[`docs/systems/continuous-evolution.md`](./docs/systems/continuous-evolution.md).
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## [Unreleased]
+
+### Added
+- **Continuous-evolution loop**: a self-sustaining backlog mechanism so AI agents can keep improving the repo between human sessions.
+  - `_data/backlog.yml` — tactical task queue (single source of truth), mirroring the `_data/roadmap.yml` pattern.
+  - `scripts/sync-backlog.rb` (+ `scripts/sync-backlog.sh`) — schema validator and GitHub Issues sync (idempotent via `<!-- backlog-id -->` markers).
+  - `.github/workflows/backlog-sync.yml` — syncs the backlog to issues on push to `main`; validates schema on PRs.
+  - `.github/workflows/auto-merge.yml` — enables native auto-merge for low-risk (`docs`/`deps`/`lint`) PRs once CI is green.
+  - `.github/prompts/repo-audit.prompt.md` (`/repo-audit`) and `.github/prompts/backlog-implement.prompt.md` (`/backlog-implement`) — the audit and implement routines.
+  - `.github/instructions/backlog.instructions.md` — file-scoped guidance for the backlog.
+  - `docs/systems/continuous-evolution.md` — full design, autonomy policy, and setup.
+  - `CLAUDE.md` — Claude Code pointer to `AGENTS.md` (per the documented convention).
+
 ## [1.9.9] - 2026-05-31
 
 ### Changed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,15 @@
+# CLAUDE.md
+
+This repository uses a single, tool-agnostic guide for AI coding agents.
+
+**See [`AGENTS.md`](./AGENTS.md)** for the project snapshot, where the layered
+guidance lives (`.github/copilot-instructions.md`, `.github/instructions/*`,
+`.github/prompts/*`, `.github/seed/*`), essential commands, and the operating
+rules for agents.
+
+For the continuous-evolution loop (backlog audits and automated implementation),
+see [`docs/systems/continuous-evolution.md`](./docs/systems/continuous-evolution.md)
+and the `/repo-audit` and `/backlog-implement` prompts under `.github/prompts/`.
+
+_This file is intentionally a pointer — keep all detail in `AGENTS.md` and the
+layered guidance to avoid drift._

--- a/_data/backlog.yml
+++ b/_data/backlog.yml
@@ -1,0 +1,161 @@
+# =============================================================================
+# zer0-mistakes Backlog — Tactical Task Queue (Single Source of Truth)
+# =============================================================================
+#
+# This file is the canonical, machine-readable backlog of *tactical* tasks
+# (the granular, pickup-able work items). It complements `_data/roadmap.yml`,
+# which holds the *strategic* milestones.
+#
+# It powers the continuous-evolution loop:
+#
+#   1. The AUDIT routine (`.github/prompts/repo-audit.prompt.md`) appends new
+#      tasks here when it reviews the repo.
+#   2. `scripts/sync-backlog.rb` (run by `.github/workflows/backlog-sync.yml`)
+#      mirrors each open task to a GitHub Issue and closes issues for tasks
+#      marked `done`.
+#   3. The IMPLEMENT routine (`.github/prompts/backlog-implement.prompt.md`)
+#      picks the highest-priority open task, implements it, and opens a PR.
+#
+# See `docs/systems/continuous-evolution.md` for the full design.
+#
+# To add a task by hand:
+#   1. Copy the schema block below; give it the next free `T-NNN` id.
+#   2. Set status/priority/area/risk/effort/source and acceptance criteria.
+#   3. Commit. The sync workflow creates the matching GitHub Issue on push.
+#
+# =============================================================================
+# Schema
+# =============================================================================
+#
+# meta:
+#   title:    Display title
+#   updated:  Last-reviewed date (YYYY-MM-DD)
+#   next_id:  Next free task id number (the audit routine increments this)
+#
+# tasks:
+#   - id:         Stable task id, "T-NNN" (never reused; matches the GitHub Issue)
+#     title:      One line — becomes the GitHub Issue title
+#     status:     open | in-progress | blocked | done
+#     priority:   P0 (urgent) | P1 | P2 | P3 (nice-to-have)
+#     area:       tests | docs | feat | infra | a11y | perf | deps | lint
+#     risk:       low (auto-merge eligible) | standard (human review required)
+#     effort:     S | M | L
+#     source:     audit | roadmap | issue | user
+#     summary:    1–2 lines of context
+#     acceptance: List of checkable done-criteria the implement routine verifies
+#     links:      { issue: <#|null>, pr: <#|null>, roadmap: "<version>|null" }
+#     created:    YYYY-MM-DD
+#     updated:    YYYY-MM-DD
+#
+# `risk: low` + area in {docs, deps, lint} makes a task auto-merge eligible once
+# CI is green (see `.github/prompts/backlog-implement.prompt.md`). Everything
+# else stays PR-only for human review.
+#
+# =============================================================================
+
+meta:
+  title: "zer0-mistakes Backlog"
+  updated: 2026-05-31
+  next_id: 7
+
+tasks:
+  # --- Housekeeping (seeded so the loop has work on day one) ------------------
+
+  - id: T-001
+    title: "Reconcile roadmap milestone numbering with the published gem version"
+    status: open
+    priority: P2
+    area: docs
+    risk: standard
+    effort: M
+    source: user
+    summary: >-
+      `_data/roadmap.yml` milestones run 0.17–1.0 while the gem ships as 1.9.9.
+      Decide on a single numbering scheme (or document the mapping) so the
+      roadmap, README, and RubyGems version no longer contradict each other.
+    acceptance:
+      - "Roadmap version line and gem version no longer contradict (either remapped or an explicit mapping note added to `_data/roadmap.yml` and `pages/roadmap.md`)."
+      - "`./scripts/generate-roadmap.sh --check` passes after the change."
+      - "No edit to `lib/jekyll-theme-zer0/version.rb`."
+    links: { issue: null, pr: null, roadmap: null }
+    created: 2026-05-31
+    updated: 2026-05-31
+
+  - id: T-002
+    title: "Refresh roadmap `updated:` date and review milestone statuses"
+    status: open
+    priority: P3
+    area: docs
+    risk: low
+    effort: S
+    source: user
+    summary: >-
+      `_data/roadmap.yml` `meta.updated` is 2026-04-18. Refresh it and confirm
+      the 0.22 "active" milestone still reflects reality.
+    acceptance:
+      - "`meta.updated` set to the current date."
+      - "Active/planned statuses reviewed against shipped work."
+      - "`./scripts/generate-roadmap.sh --check` passes."
+    links: { issue: null, pr: null, roadmap: null }
+    created: 2026-05-31
+    updated: 2026-05-31
+
+  - id: T-003
+    title: "Add GitHub issue templates and a pull-request template"
+    status: open
+    priority: P2
+    area: infra
+    risk: standard
+    effort: M
+    source: user
+    summary: >-
+      The repo has no `.github/ISSUE_TEMPLATE/` or PR template. Add a bug-report
+      and feature-request issue form plus a PR template that nudges contributors
+      toward conventional commits, CHANGELOG updates, and the test checklist.
+    acceptance:
+      - "`.github/ISSUE_TEMPLATE/bug_report.yml` and `feature_request.yml` exist and render."
+      - "`.github/pull_request_template.md` exists with a conventional-commit + CHANGELOG + tests checklist."
+      - "Agent-filed backlog issues remain compatible with the new templates (no broken automation)."
+    links: { issue: null, pr: null, roadmap: null }
+    created: 2026-05-31
+    updated: 2026-05-31
+
+  - id: T-004
+    title: "Docs-freshness sweep: reconcile docs/ ↔ pages/_docs/ and fix broken links"
+    status: open
+    priority: P2
+    area: docs
+    risk: low
+    effort: M
+    source: user
+    summary: >-
+      Run the markdown-link checker and audit the two-tier docs for drift,
+      stale dates/versions, and any user/technical pages that fell out of sync
+      after the recent alignment commit.
+    acceptance:
+      - "`markdown-link-check` (config in `.github/config/`) reports no broken internal links."
+      - "Any stale version/date references in `docs/` and `pages/_docs/` are corrected."
+      - "Cross-links between the user tier and technical tier resolve both ways."
+    links: { issue: null, pr: null, roadmap: null }
+    created: 2026-05-31
+    updated: 2026-05-31
+
+  - id: T-005
+    title: "Coverage baseline: identify the lowest-covered subsystems toward the v1.0 90% goal"
+    status: open
+    priority: P1
+    area: tests
+    risk: standard
+    effort: L
+    source: roadmap
+    summary: >-
+      The v1.0 milestone targets 90%+ automated test coverage. Produce a
+      coverage baseline and file follow-up tasks for the lowest-covered areas
+      (start with the modular installer and the Obsidian resolver paths).
+    acceptance:
+      - "A coverage baseline is recorded (test/coverage or a docs note)."
+      - "The 2–3 lowest-covered subsystems are identified and filed as new backlog tasks."
+      - "No reduction in existing passing tests (`./scripts/bin/test` stays green)."
+    links: { issue: null, pr: null, roadmap: "1.0" }
+    created: 2026-05-31
+    updated: 2026-05-31

--- a/docs/systems/continuous-evolution.md
+++ b/docs/systems/continuous-evolution.md
@@ -1,0 +1,148 @@
+# Continuous-Evolution Loop
+
+**Status:** ✅ Active
+**Last Updated:** 2026-05-31
+**Audience:** Maintainers & AI agents (technical tier)
+
+> **User guide:** there is no separate end-user page for this system — it is
+> contributor/maintainer infrastructure. Start here.
+
+## Overview
+
+The continuous-evolution loop lets AI agents keep improving this repository
+between human sessions. It has two halves:
+
+1. **Review → file work.** A scheduled agent audits the repo (tests, docs,
+   roadmap delivery) and records granular tasks in
+   [`_data/backlog.yml`](../../_data/backlog.yml).
+2. **Pick up → implement.** A scheduled agent takes the highest-priority open
+   task, builds it on a branch, validates, and opens a PR. Low-risk classes
+   auto-merge once CI is green; everything else waits for human review.
+
+`_data/backlog.yml` is the **single source of truth** for tactical tasks, the same
+way [`_data/roadmap.yml`](../../_data/roadmap.yml) is for strategic milestones.
+The backlog is mirrored to GitHub Issues for visibility, but you edit the file —
+not the issues.
+
+```
+  AUDIT routine (weekly)
+    └─ /repo-audit  ──►  _data/backlog.yml  ──►  PR "chore(backlog): audit …"
+                                                      │ (merged)
+                                                      ▼
+                              backlog-sync.yml → GitHub Issues (agent-ready)
+                                                      │
+  IMPLEMENT routine (2–3×/week)                       ▼
+    └─ /backlog-implement ──► branch + PR ──► CI gate ──► auto-merge (low-risk)
+                                                          └─ else human review
+                                  on merge: task → done → issue closes (next sync)
+```
+
+## Components
+
+| Component | Path | Role |
+|---|---|---|
+| Backlog (source of truth) | `_data/backlog.yml` | Tactical task queue; schema documented in the file header |
+| Sync script | `scripts/sync-backlog.rb` (+ `.sh` wrapper) | Mirrors tasks → GitHub Issues; validates schema |
+| Sync workflow | `.github/workflows/backlog-sync.yml` | Runs sync on push to `main`; `--check` gate on PRs |
+| Audit prompt | `.github/prompts/repo-audit.prompt.md` | `/repo-audit` — review repo, file tasks |
+| Implement prompt | `.github/prompts/backlog-implement.prompt.md` | `/backlog-implement` — build one task, open PR |
+| Auto-merge workflow | `.github/workflows/auto-merge.yml` | Enables native auto-merge for low-risk labelled PRs |
+
+It deliberately reuses the existing **roadmap-sync** pattern
+(`scripts/generate-roadmap.rb` + `.github/workflows/roadmap-sync.yml`): a Ruby
+generator/validator with `--check`, driven by a path-filtered workflow.
+
+## Task lifecycle
+
+```
+open ──► in-progress ──► done            (blocked is a parked state)
+  ▲           │
+  └───────────┘  (reopened if work is abandoned)
+```
+
+| Status | Meaning | Issue state |
+|---|---|---|
+| `open` | Ready to be picked up | Open, `agent-ready` |
+| `in-progress` | An implement run is building it | Open |
+| `blocked` | Parked; not eligible for pickup | Open, `agent-hold` |
+| `done` | Merged | Closed (next sync) |
+
+Each task carries `priority` (P0–P3), `area`, `risk`, `effort`, `source`, and
+**checkable `acceptance` criteria** that the implement routine must verify.
+
+## Autonomy policy
+
+A PR may **auto-merge** only when ALL hold (enforced by the implement prompt and
+re-checked by `auto-merge.yml`):
+
+- `area` ∈ { `docs`, `deps`, `lint` } **and** `risk: low`
+- no change to public API, `lib/jekyll-theme-zer0/version.rb`, the gemspec, a
+  dependency manifest, or a data schema
+- no new runtime dependency
+- all acceptance criteria verified green in CI
+
+Everything else — `feat`, `refactor`, anything `risk: standard` — is **PR-only**
+and waits for a human. CI is the merge gate in every case.
+
+### Guardrails
+
+- **One task ⇒ one PR.** Conventional commits.
+- **Agents never bump the version, edit `version.rb`, or publish gems** — releases
+  stay human via [`/commit-publish`](../../.github/prompts/commit-publish.prompt.md).
+- **Loop-prevention:** the audit dedupes by task id/intent and caps new tasks at 5
+  per run; the implement routine does at most one task per invocation.
+- **Default-safe:** with no branch protection, `auto-merge.yml` is a no-op and PRs
+  simply wait for a human.
+
+## One-time setup (maintainer)
+
+To enable auto-merge of low-risk PRs:
+
+1. **Settings → General → Pull Requests →** check **"Allow auto-merge"**.
+2. **Settings → Branches →** add a protection rule for `main` requiring the CI
+   status checks (from `ci.yml`) to pass before merge.
+
+Without these, the loop still works end-to-end — low-risk PRs just need a human to
+click merge.
+
+## Running the routines (Claude Code `/schedule`)
+
+The loop is driven by two scheduled Claude Code routines. Create them with the
+`/schedule` skill (they invoke the committed prompts, so the logic stays in-repo):
+
+- **Routine A — Weekly audit** (e.g. Mondays):
+  *"In the zer0-mistakes repo, run `/repo-audit` and open the backlog PR."*
+- **Routine B — Implementation cadence** (e.g. 2–3×/week):
+  *"In the zer0-mistakes repo, run `/backlog-implement` for the next open task."*
+
+Both can also be run on demand from an interactive session, and the workflows can
+be triggered manually via `workflow_dispatch`.
+
+> **Portability:** because all logic lives in the prompt + script files, the same
+> loop can later be driven by a GitHub Actions cron + the Claude Code GitHub
+> Action without rewriting anything.
+
+## Working with the backlog by hand
+
+```bash
+# Validate the file (CI runs this on every PR that touches it)
+ruby scripts/sync-backlog.rb --check
+
+# Preview the GitHub Issue calls without making changes
+./scripts/sync-backlog.sh --dry-run
+
+# Actually sync (needs gh authenticated with issues: write)
+./scripts/sync-backlog.sh
+```
+
+To **pause** the loop: disable the routines (and/or set tasks to `blocked`).
+To **remove a task from pickup**: set `status: blocked` or add the `agent-hold`
+label to its issue.
+
+## Related
+
+- [`_data/backlog.yml`](../../_data/backlog.yml) — the task queue
+- [`AGENTS.md`](../../AGENTS.md) — agent guidance entry point
+- [`docs/systems/release-automation.md`](./release-automation.md) — the
+  human-owned release path the loop never touches
+- [`docs/systems/automated-version-system.md`](./automated-version-system.md)

--- a/scripts/sync-backlog.rb
+++ b/scripts/sync-backlog.rb
@@ -1,0 +1,309 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# =============================================================================
+# sync-backlog.rb
+# =============================================================================
+#
+# Mirrors `_data/backlog.yml` (the tactical task queue) to GitHub Issues.
+#
+#   - Each task with status open|in-progress|blocked  -> an OPEN issue.
+#   - Each task with status done                       -> its issue is CLOSED.
+#
+# Issues are matched back to tasks idempotently by a hidden marker embedded in
+# the issue body: `<!-- backlog-id: T-001 -->`. Re-running the sync updates the
+# title/body/labels in place rather than creating duplicates.
+#
+# Managed labels (created with `gh label create --force` if missing):
+#   agent-ready · priority:P0..P3 · area:<area> · risk:<low|standard> · agent-hold
+#
+# Usage:
+#   ruby scripts/sync-backlog.rb            # create/update/close issues via `gh`
+#   ruby scripts/sync-backlog.rb --check    # validate schema only (no `gh`, CI/PR gate)
+#   ruby scripts/sync-backlog.rb --dry-run  # print intended `gh` calls, make no changes
+#
+# Requires the `gh` CLI authenticated with `issues: write` for the write path.
+# `--check` needs only Ruby stdlib (used as the pull-request gate).
+# =============================================================================
+
+require 'yaml'
+require 'date'
+require 'json'
+require 'optparse'
+require 'open3'
+require 'shellwords'
+
+ROOT      = File.expand_path('..', __dir__)
+DATA_FILE = File.join(ROOT, '_data', 'backlog.yml')
+
+VALID_STATUS   = %w[open in-progress blocked done].freeze
+VALID_PRIORITY = %w[P0 P1 P2 P3].freeze
+VALID_AREA     = %w[tests docs feat infra a11y perf deps lint].freeze
+VALID_RISK     = %w[low standard].freeze
+VALID_EFFORT   = %w[S M L].freeze
+VALID_SOURCE   = %w[audit roadmap issue user].freeze
+
+OPEN_STATUSES = %w[open in-progress blocked].freeze
+
+# Labels this script owns. On each sync we reconcile a task's labels to exactly
+# the managed set it should carry, leaving any human-applied labels untouched.
+def managed_labels(task)
+  labels = ['agent-ready', "priority:#{task['priority']}", "area:#{task['area']}", "risk:#{task['risk']}"]
+  labels << 'agent-hold' if task['status'] == 'blocked'
+  labels
+end
+
+ALL_MANAGED_LABELS = (
+  ['agent-ready', 'agent-hold'] +
+  VALID_PRIORITY.map { |p| "priority:#{p}" } +
+  VALID_AREA.map { |a| "area:#{a}" } +
+  VALID_RISK.map { |r| "risk:#{r}" }
+).freeze
+
+LABEL_COLORS = {
+  'agent-ready' => '0e8a16',
+  'agent-hold'  => 'b60205'
+}.freeze
+PRIORITY_COLOR = 'd93f0b'
+AREA_COLOR     = '1d76db'
+RISK_COLOR     = 'fbca04'
+
+# ---------------------------------------------------------------------------
+# Load + validate
+# ---------------------------------------------------------------------------
+
+def load_data
+  # Mirror generate-roadmap.rb: permit Date/Time, and fall back for the older
+  # macOS system Ruby (2.6) whose safe loader signature differs.
+  begin
+    YAML.load_file(DATA_FILE, permitted_classes: [Date, Time])
+  rescue ArgumentError
+    YAML.safe_load(File.read(DATA_FILE), permitted_classes: [Date, Time], aliases: false)
+  end
+end
+
+def validate(data)
+  errors = []
+  errors << 'Missing top-level `meta:` mapping.' unless data.is_a?(Hash) && data['meta'].is_a?(Hash)
+  tasks = data.is_a?(Hash) ? data['tasks'] : nil
+  return ['Missing or empty `tasks:` list.'] unless tasks.is_a?(Array) && !tasks.empty?
+
+  seen_ids = {}
+  tasks.each_with_index do |task, i|
+    where = "tasks[#{i}]"
+    unless task.is_a?(Hash)
+      errors << "#{where}: each task must be a mapping."
+      next
+    end
+    id = task['id']
+    where = id ? "task #{id}" : where
+    errors << "#{where}: missing `id`." if id.to_s.empty?
+    errors << "#{where}: `id` must match T-NNN (got #{id.inspect})." if id && id !~ /\AT-\d{3,}\z/
+    if id && seen_ids[id]
+      errors << "#{where}: duplicate id #{id} (also at #{seen_ids[id]})."
+    elsif id
+      seen_ids[id] = where
+    end
+    errors << "#{where}: missing `title`." if task['title'].to_s.strip.empty?
+    check_enum(errors, where, task, 'status', VALID_STATUS)
+    check_enum(errors, where, task, 'priority', VALID_PRIORITY)
+    check_enum(errors, where, task, 'area', VALID_AREA)
+    check_enum(errors, where, task, 'risk', VALID_RISK)
+    check_enum(errors, where, task, 'effort', VALID_EFFORT) if task['effort']
+    check_enum(errors, where, task, 'source', VALID_SOURCE) if task['source']
+    unless task['acceptance'].is_a?(Array) && !task['acceptance'].empty?
+      errors << "#{where}: `acceptance` must be a non-empty list."
+    end
+  end
+  errors
+end
+
+def check_enum(errors, where, task, field, allowed)
+  value = task[field]
+  return if allowed.include?(value)
+
+  errors << "#{where}: `#{field}` must be one of #{allowed.join('|')} (got #{value.inspect})."
+end
+
+# ---------------------------------------------------------------------------
+# Issue body rendering
+# ---------------------------------------------------------------------------
+
+def marker(id)
+  "<!-- backlog-id: #{id} -->"
+end
+
+def render_body(task)
+  accept = (task['acceptance'] || []).map { |a| "- [ ] #{a}" }.join("\n")
+  roadmap = task.dig('links', 'roadmap')
+  meta_row = [
+    "**Priority:** #{task['priority']}",
+    "**Area:** #{task['area']}",
+    "**Risk:** #{task['risk']}",
+    "**Effort:** #{task['effort']}",
+    "**Source:** #{task['source']}"
+  ].join(' · ')
+
+  <<~BODY.strip
+    #{marker(task['id'])}
+    > Auto-managed from [`_data/backlog.yml`](../blob/main/_data/backlog.yml) by `scripts/sync-backlog.rb`.
+    > Edit the backlog file, not this issue body — changes here are overwritten on the next sync.
+
+    #{meta_row}#{roadmap ? " · **Roadmap:** v#{roadmap}" : ''}
+
+    #{task['summary'].to_s.strip}
+
+    ## Acceptance criteria
+
+    #{accept}
+
+    ---
+    Picked up by the IMPLEMENT routine (`.github/prompts/backlog-implement.prompt.md`).
+    See [`docs/systems/continuous-evolution.md`](../blob/main/docs/systems/continuous-evolution.md).
+  BODY
+end
+
+# ---------------------------------------------------------------------------
+# gh helpers
+# ---------------------------------------------------------------------------
+
+class Gh
+  def initialize(dry_run:)
+    @dry_run = dry_run
+  end
+
+  # Read-only call. Always executed (even in dry-run) so we can compute a diff;
+  # degrades to a default value if `gh` is unavailable/unauthenticated.
+  def read(args, default:)
+    out, _err, status = Open3.capture3('gh', *args)
+    return default unless status.success?
+
+    out
+  rescue Errno::ENOENT
+    default
+  end
+
+  # Mutating call. Printed (not executed) in dry-run mode.
+  def write(args)
+    if @dry_run
+      puts "DRY-RUN gh #{args.map { |a| a.to_s.include?(' ') ? a.inspect : a }.join(' ')}"
+      return true
+    end
+    _out, err, status = Open3.capture3('gh', *args)
+    warn "gh #{args.first} failed: #{err.strip}" unless status.success?
+    status.success?
+  end
+end
+
+def ensure_labels(gh)
+  LABEL_COLORS.each { |name, color| gh.write(['label', 'create', name, '--color', color, '--force']) }
+  VALID_PRIORITY.each { |p| gh.write(['label', 'create', "priority:#{p}", '--color', PRIORITY_COLOR, '--force']) }
+  VALID_AREA.each { |a| gh.write(['label', 'create', "area:#{a}", '--color', AREA_COLOR, '--force']) }
+  VALID_RISK.each { |r| gh.write(['label', 'create', "risk:#{r}", '--color', RISK_COLOR, '--force']) }
+end
+
+# Map of backlog id -> existing issue {number, state, labels} via the body marker.
+def existing_issues(gh)
+  raw = gh.read(
+    ['issue', 'list', '--label', 'agent-ready', '--state', 'all', '--limit', '500',
+     '--json', 'number,body,state,labels'],
+    default: '[]'
+  )
+  index = {}
+  JSON.parse(raw).each do |issue|
+    next unless issue['body'] =~ /<!-- backlog-id: (T-\d+) -->/
+
+    index[Regexp.last_match(1)] = {
+      'number' => issue['number'],
+      'state'  => issue['state'].to_s.downcase,
+      'labels' => (issue['labels'] || []).map { |l| l['name'] }
+    }
+  end
+  index
+rescue JSON::ParserError
+  {}
+end
+
+# ---------------------------------------------------------------------------
+# Sync
+# ---------------------------------------------------------------------------
+
+def label_args(desired, current)
+  desired_set = desired
+  # Only remove labels we manage; never touch human-applied ones.
+  to_remove = (current & ALL_MANAGED_LABELS) - desired_set
+  to_add    = desired_set - current
+  args = []
+  to_add.each    { |l| args.push('--add-label', l) }
+  to_remove.each { |l| args.push('--remove-label', l) }
+  args
+end
+
+def sync(data, gh)
+  ensure_labels(gh)
+  index = existing_issues(gh)
+  created = updated = closed = 0
+
+  (data['tasks'] || []).each do |task|
+    id    = task['id']
+    title = task['title']
+    body  = render_body(task)
+    want_open = OPEN_STATUSES.include?(task['status'])
+    issue = index[id]
+
+    if issue.nil?
+      next unless want_open # never create an issue for an already-done task
+
+      args = ['issue', 'create', '--title', title, '--body', body]
+      managed_labels(task).each { |l| args.push('--label', l) }
+      created += 1 if gh.write(args)
+      next
+    end
+
+    number = issue['number'].to_s
+    gh.write(['issue', 'edit', number, '--title', title, '--body', body] +
+             label_args(managed_labels(task), issue['labels']))
+    updated += 1
+
+    if want_open && issue['state'] != 'open'
+      gh.write(['issue', 'reopen', number])
+    elsif !want_open && issue['state'] != 'closed'
+      gh.write(['issue', 'close', number, '--reason', 'completed'])
+      closed += 1
+    end
+  end
+
+  puts "Backlog sync complete: #{created} created, #{updated} updated, #{closed} closed."
+  0
+end
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def main
+  mode = :sync
+  OptionParser.new do |opts|
+    opts.banner = 'Usage: sync-backlog.rb [--check|--dry-run]'
+    opts.on('--check', 'Validate schema only; make no gh calls') { mode = :check }
+    opts.on('--dry-run', 'Print intended gh calls without executing') { mode = :dry_run }
+  end.parse!
+
+  data = load_data
+  errors = validate(data)
+  unless errors.empty?
+    warn '✗ _data/backlog.yml failed validation:'
+    errors.each { |e| warn "  - #{e}" }
+    return 1
+  end
+  task_count = (data['tasks'] || []).size
+
+  if mode == :check
+    puts "✓ _data/backlog.yml is valid (#{task_count} tasks)."
+    return 0
+  end
+
+  sync(data, Gh.new(dry_run: mode == :dry_run))
+end
+
+exit main if $PROGRAM_NAME == __FILE__

--- a/scripts/sync-backlog.sh
+++ b/scripts/sync-backlog.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# =============================================================================
+# sync-backlog.sh
+# =============================================================================
+#
+# Thin wrapper around scripts/sync-backlog.rb.
+#
+# Mirrors `_data/backlog.yml` (the tactical task queue) to GitHub Issues:
+# open tasks become open issues; tasks marked `done` close their issue.
+#
+# Usage:
+#   ./scripts/sync-backlog.sh             # create/update/close issues via gh
+#   ./scripts/sync-backlog.sh --check     # validate schema only (CI/PR gate)
+#   ./scripts/sync-backlog.sh --dry-run   # print intended gh calls only
+#
+# =============================================================================
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+exec ruby "${SCRIPT_DIR}/sync-backlog.rb" "$@"


### PR DESCRIPTION
## What

Adds a self-sustaining **continuous-evolution loop** so AI agents can keep improving the repo between human sessions — a tactical, machine-readable backlog that complements the strategic `_data/roadmap.yml`.

### The loop
1. **Audit** (`/repo-audit`, scheduled) reviews tests/docs/roadmap and files tasks into `_data/backlog.yml`.
2. **Sync** (`backlog-sync.yml`) mirrors open tasks → GitHub Issues (`agent-ready`), closes issues for `done` tasks.
3. **Implement** (`/backlog-implement`, scheduled) builds the top open task, opens a PR. Low-risk (`docs`/`deps`/`lint`, `risk: low`) PRs auto-merge once CI is green; everything else is human-reviewed.

### Files
- `_data/backlog.yml` — task queue (source of truth), seeded with 5 tasks
- `scripts/sync-backlog.{rb,sh}` — schema validator + idempotent Issues sync (stdlib-only)
- `.github/workflows/backlog-sync.yml` — sync on push to `main`, `--check` gate on PRs
- `.github/workflows/auto-merge.yml` — native auto-merge for low-risk labelled PRs
- `.github/prompts/repo-audit.prompt.md`, `backlog-implement.prompt.md` (+ Cursor mirrors)
- `.github/instructions/backlog.instructions.md`
- `docs/systems/continuous-evolution.md` — full design + autonomy policy
- `CLAUDE.md` (pointer to `AGENTS.md`), plus AGENTS.md / instructions README / CHANGELOG wiring

### Guardrails
- One task ⇒ one PR; CI is the merge gate in every case.
- Agents never bump `version.rb` or publish gems — releases stay human (`/commit-publish`).
- Default-safe: with no branch protection, `auto-merge.yml` is a no-op (PRs wait for a human).

## Follow-ups (maintainer, one-time)
- Enable **Settings → Allow auto-merge** and add **branch protection on `main`** requiring CI checks (see `docs/systems/continuous-evolution.md`).
- The two scheduled Claude Code routines drive the loop (set up separately).

## Verification
Run in the Docker container (Ruby 3.3.11): `ruby -c scripts/sync-backlog.rb` ✅ · `ruby scripts/sync-backlog.rb --check` ✅ · `--dry-run` prints correct `gh` calls ✅ · all workflow/data YAML parses ✅ · `bash -n` ✅.

🤖 Generated with [Claude Code](https://claude.com/claude-code)