### PR TITLE
chore(backlog): audit 2026-06-01

### DIFF
--- a/_data/backlog.yml
+++ b/_data/backlog.yml
@@ -55,8 +55,8 @@
 
 meta:
   title: "zer0-mistakes Backlog"
-  updated: 2026-05-31
-  next_id: 7
+  updated: 2026-06-01
+  next_id: 12
 
 tasks:
   # --- Housekeeping (seeded so the loop has work on day one) ------------------
@@ -159,3 +159,116 @@ tasks:
     links: { issue: null, pr: null, roadmap: "1.0" }
     created: 2026-05-31
     updated: 2026-05-31
+
+  # --- 2026-06-01 audit -------------------------------------------------------
+
+  - id: T-007
+    title: "Fix global navbar WCAG 2.1 AA violations to enable axe-core full-audit tests"
+    status: open
+    priority: P1
+    area: a11y
+    risk: standard
+    effort: M
+    source: audit
+    summary: >-
+      Three tests in `test/visual/accessibility.spec.js` are frozen with `test.fixme`
+      because four WCAG 2.1 AA violations in the global navbar prevent them from passing:
+      `aria-required-children` (menubar/button nesting), `link-name` (icon-only nav links),
+      `list` (footer list structure), and `scrollable-region-focusable` (code blocks).
+      Fix the HTML/ARIA in `_includes/` and `_layouts/` to make the full axe-core audit green.
+    acceptance:
+      - "All four violations listed in the `test.fixme` comment are resolved in `_includes/` / `_layouts/`."
+      - "The three `test.fixme` blocks in `test/visual/accessibility.spec.js` are changed to live `test()` calls and pass in CI."
+      - "`bundle exec ./scripts/bin/validate --quick` still passes."
+      - "No visual regression in smoke snapshot tests."
+    links: { issue: null, pr: null, roadmap: "1.9" }
+    created: 2026-06-01
+    updated: 2026-06-01
+
+  - id: T-008
+    title: "Fix theme-customizer YAML export to quote hex color values"
+    status: open
+    priority: P2
+    area: feat
+    risk: standard
+    effort: S
+    source: audit
+    summary: >-
+      The JS theme-customizer export serialises CSS custom-property values directly into
+      YAML without quoting strings that start with `#`. Unquoted `#RRGGBB` is treated as a
+      YAML comment by parsers, silently dropping colour values. A regression guard in
+      `test/visual/theme-colors.spec.js` is frozen as `test.fixme` until the bug is fixed.
+    acceptance:
+      - "JS export wraps every hex colour value (matching `/#[0-9a-fA-F]{3,8}/`) in double quotes in the generated YAML."
+      - "The `test.fixme` in `test/visual/theme-colors.spec.js` is promoted to a live `test()` and passes in CI."
+      - "Exported YAML is valid when parsed by `yaml.safe_load` in Ruby."
+    links: { issue: null, pr: null, roadmap: null }
+    created: 2026-06-01
+    updated: 2026-06-01
+
+  - id: T-009
+    title: "Sanitize sensitive config keys from admin config-page DOM injection"
+    status: open
+    priority: P1
+    area: infra
+    risk: standard
+    effort: S
+    source: audit
+    summary: >-
+      The admin config page injects raw `_config.yml` content into a hidden
+      `<pre id="cfg-full-yaml">` element. If the config contains secrets
+      (`api_key`, `token`, PostHog `phc_*` keys, etc.) they are exposed in the page
+      DOM. A regression test in `test/visual/security.spec.js` is frozen as
+      `test.fixme` until a sanitisation pass is in place.
+    acceptance:
+      - "The Liquid/Ruby that populates `<pre id=\"cfg-full-yaml\">` strips or masks keys matching `api_key`, `secret`, `password`, `token`, and `phc_` prefix before DOM injection."
+      - "The `test.fixme` in `test/visual/security.spec.js` is promoted to a live `test()` and passes in CI."
+      - "The visible config display in the admin UI is unaffected (only the raw hidden element is sanitised)."
+    links: { issue: null, pr: null, roadmap: null }
+    created: 2026-06-01
+    updated: 2026-06-01
+
+  - id: T-010
+    title: "Complete v1.9 quickstart docs rewrite with getting-started guide and screenshots"
+    status: open
+    priority: P2
+    area: docs
+    risk: low
+    effort: M
+    source: roadmap
+    summary: >-
+      The v1.9 milestone lists "Quickstart documentation rewrite with screenshots"
+      as a deliverable, but `pages/_docs/quickstart/` contains only `bare-minimum.md`.
+      Add a proper quickstart index page and at least one full getting-started guide
+      (covering the standard GitHub Pages workflow) with annotated screenshots.
+    acceptance:
+      - "`pages/_docs/quickstart/index.md` exists with a nav overview linking to available quickstart guides."
+      - "At least one guide beyond `bare-minimum.md` covers the standard fork/remote-theme workflow."
+      - "Each guide includes at least one screenshot stored under `assets/images/docs/quickstart/`."
+      - "All new pages pass `docs-validate.yml` front-matter and link checks."
+    links: { issue: null, pr: null, roadmap: "1.9" }
+    created: 2026-06-01
+    updated: 2026-06-01
+
+  - id: T-011
+    title: "Add Ruby unit tests for uncovered _plugins/ generators"
+    status: open
+    priority: P2
+    area: tests
+    risk: standard
+    effort: M
+    source: audit
+    summary: >-
+      Three Jekyll plugins have no dedicated unit tests: `content_statistics_generator.rb`,
+      `preview_image_generator.rb`, and `admin_page_urls.rb`. The quality suite has
+      URL-pattern checks (`test_preview_image_urls`) but no specs that exercise the
+      generator logic in isolation. This is a concrete gap on the path to the
+      3.0-milestone 90% coverage target.
+    acceptance:
+      - "`test/test_ruby_converter.rb`-style RSpec or Minitest specs exist for all three plugins."
+      - "Each spec runs independently without a running Jekyll server (`bundle exec ruby -Itest`)."
+      - "`./scripts/bin/test` continues to pass with the new specs included."
+      - "Edge cases covered: empty collections, missing front-matter keys, and duplicate slug detection."
+    links: { issue: null, pr: null, roadmap: "3.0" }
+    created: 2026-06-01
+    updated: 2026-06-01


### PR DESCRIPTION
## Weekly backlog audit — 2026-06-01

Routine repo audit filing 5 new tasks into `_data/backlog.yml`.  
`backlog-sync.yml` will mirror these to GitHub Issues once merged.

**Do not enable auto-merge** — a human should glance at the newly-filed work before it becomes issues.

---

### Findings summary

| Focus | Finding | Task |
|---|---|---|
| Tests & quality | 3 `test.fixme` blocks in `accessibility.spec.js` blocked by 4 navbar WCAG violations | T-007 |
| Tests & quality | `test.fixme` in `theme-colors.spec.js` — hex color values unquoted in YAML export | T-008 |
| Tests & quality | `test.fixme` in `security.spec.js` — raw `_config.yml` injected into hidden DOM `<pre>` may expose secrets | T-009 |
| Roadmap (v1.9) | `pages/_docs/quickstart/` has only `bare-minimum.md`; v1.9 milestone calls for full quickstart rewrite with screenshots | T-010 |
| Tests & quality | `_plugins/content_statistics_generator.rb`, `preview_image_generator.rb`, `admin_page_urls.rb` have no unit tests | T-011 |

### Tasks filed

| ID | Title | Area | Risk | Effort |
|---|---|---|---|---|
| T-007 | Fix global navbar WCAG 2.1 AA violations to enable axe-core full-audit tests | a11y | standard | M |
| T-008 | Fix theme-customizer YAML export to quote hex color values | feat | standard | S |
| T-009 | Sanitize sensitive config keys from admin config-page DOM injection | infra | standard | S |
| T-010 | Complete v1.9 quickstart docs rewrite with getting-started guide and screenshots | docs | low | M |
| T-011 | Add Ruby unit tests for uncovered `_plugins/` generators | tests | standard | M |

### Not filed (deferred)

- Dependabot security alerts (7 vulnerabilities on default branch) — deferred to the dependency canary (`test-latest.yml`) and CodeQL per audit rules.
- Docs `docs/` ↔ `pages/_docs/` structural drift — already covered by open T-004.
- Roadmap milestone numbering inconsistency — already covered by open T-001.

---

_Backlog now has 10 open tasks. `meta.next_id` advanced to 12._

---
_Generated by [Claude Code](https://claude.ai/code/session_01UbFmNJUJrHFReFg3JZc2sw)_