### PR TITLE
fix(infra): sanitize sensitive config keys from admin config-page DOM (T-009)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [Unreleased]
+
+### Security
+- Sanitize sensitive config keys (`api_key`, `secret`, `password`, `token`, `phc_*`) from the hidden `<pre id="cfg-full-yaml">` DOM element on the admin config page. Values are replaced with `[REDACTED]` at build time via a new `sanitize_config` Liquid filter (`_plugins/config_sanitizer.rb`). The visible config display and Raw YAML tab are unaffected.
+
 ## [1.12.0] - 2026-06-03
 
 ### Changed

--- a/_data/backlog.yml
+++ b/_data/backlog.yml
@@ -208,7 +208,7 @@ tasks:
 
   - id: T-009
     title: "Sanitize sensitive config keys from admin config-page DOM injection"
-    status: open
+    status: done
     priority: P1
     area: infra
     risk: standard
@@ -226,7 +226,7 @@ tasks:
       - "The visible config display in the admin UI is unaffected (only the raw hidden element is sanitised)."
     links: { issue: null, pr: null, roadmap: null }
     created: 2026-06-01
-    updated: 2026-06-01
+    updated: 2026-06-09
 
   - id: T-010
     title: "Complete v1.9 quickstart docs rewrite with getting-started guide and screenshots"

--- a/_plugins/config_sanitizer.rb
+++ b/_plugins/config_sanitizer.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+#
+# File: config_sanitizer.rb
+# Path: _plugins/config_sanitizer.rb
+# Purpose: Liquid filter that masks sensitive YAML keys before DOM injection.
+#
+# Registered filter: sanitize_config
+#
+# Masks values for keys matching api_key, secret, password, token (case-insensitive)
+# and any value starting with the PostHog phc_ prefix.
+#
+# Usage in templates:
+#   {% capture raw_config %}{% include_relative _config.yml %}{% endcapture %}
+#   {{ raw_config | sanitize_config }}
+#
+
+module Jekyll
+  module ConfigSanitizerFilter
+    SENSITIVE_KEY_RE = /\A(\s*(?:api[_-]?key|secret|password|token)\s*:)\s*.*/i
+    PHC_RE           = /phc_[A-Za-z0-9_]+/
+
+    def sanitize_config(input)
+      safe = input.encode('UTF-8', invalid: :replace, undef: :replace, replace: '')
+      safe.each_line.map do |line|
+        if SENSITIVE_KEY_RE.match(line)
+          "#{Regexp.last_match(1)} '[REDACTED]'\n"
+        elsif PHC_RE.match(line)
+          line.gsub(PHC_RE, '[REDACTED]')
+        else
+          line
+        end
+      end.join
+    end
+  end
+end
+
+Liquid::Template.register_filter(Jekyll::ConfigSanitizerFilter)

--- a/pages/_about/settings/config.md
+++ b/pages/_about/settings/config.md
@@ -220,7 +220,9 @@ Get-Content {{ page.config-dir }}/config-utf16.txt |
 </div>
 
 <!-- Hidden full YAML used by the viewer's "Copy Full Config" button -->
-<pre id="cfg-full-yaml" class="d-none">{% include_relative _config.yml %}</pre>
+<!-- Sensitive keys (api_key, secret, password, token, phc_*) are masked by the sanitize_config filter. -->
+{% capture _cfg_raw %}{% include_relative _config.yml %}{% endcapture %}
+<pre id="cfg-full-yaml" class="d-none">{{ _cfg_raw | sanitize_config }}</pre>
 
 <!-- Config Utility JS (must load after DOM) -->
 <script src="{{ '/assets/js/config-utility.js' | relative_url }}" defer></script>

--- a/test/visual/security.spec.js
+++ b/test/visual/security.spec.js
@@ -14,10 +14,7 @@ test.describe('Security — secret exposure prevention', () => {
     await waitForJekyll(page, CONFIG_URL);
   });
 
-  test.fixme('no hidden <pre> elements containing full config YAML (regression)', async ({ page }) => {
-    // KNOWN ISSUE: <pre id="cfg-full-yaml"> includes raw _config.yml with api_key.
-    // TODO: Sanitize sensitive values before injecting into DOM.
-    // PR review flagged: <pre id="cfg-full-yaml"> hidden in DOM exposes secrets
+  test('no hidden <pre> elements containing full config YAML (regression)', async ({ page }) => {
     const hiddenPre = page.locator('pre#cfg-full-yaml');
     const count = await hiddenPre.count();
     if (count > 0) {


### PR DESCRIPTION
## Summary

- Adds `_plugins/config_sanitizer.rb` — a new Liquid filter `sanitize_config` that masks sensitive YAML values before they are injected into the browser DOM.
- Updates `pages/_about/settings/config.md` to pass `_config.yml` content through the filter via a `capture` block before injecting it into `<pre id="cfg-full-yaml">`.
- Promotes the `test.fixme` in `test/visual/security.spec.js` to a live `test()` now that the vulnerability is addressed.

**What is masked:** YAML key lines whose name exactly matches `api_key`, `api-key`, `secret`, `password`, or `token` have their value replaced with `[REDACTED]`; values containing the PostHog `phc_*` prefix are replaced inline. Key names are preserved in the output. The visible Raw YAML tab and accordion display in the admin UI are unaffected — only the hidden `<pre id="cfg-full-yaml">` element is sanitised.

**Improvement over previous attempt:** adds UTF-8 encoding safety (`encode('UTF-8', invalid: :replace)`) to handle `_config.yml` files with non-ASCII characters; preserves key names in output for better readability.

Implements **T-009** (P1 / infra / risk: standard). Human review required (not auto-merge eligible).

## Acceptance criteria

- [x] Liquid/Ruby filter strips keys matching `api_key`, `secret`, `password`, `token`, and `phc_` prefix before DOM injection (`_plugins/config_sanitizer.rb` + `config.md` change).
- [x] `test.fixme` in `test/visual/security.spec.js` promoted to live `test()`.
- [x] Visible config display in the admin UI is unaffected (only hidden element sanitised).

## Test plan

- [ ] CI Playwright suite runs the promoted security test against the built site and it passes green.
- [ ] `ruby scripts/sync-backlog.rb --check` passes (10 tasks valid).
- [ ] Spot-check: load `/about/config/` in a browser; confirm the Raw YAML tab still shows full config, while DevTools shows `[REDACTED]` for sensitive keys in `pre#cfg-full-yaml`.

https://claude.ai/code/session_01RNbFCSLhLcemyY1utWKox2