### PR TITLE
fix: repair failing test suites, validator crashes, and roadmap/changelog drift

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Fixed
+- **Tooling encoding**: `generate-roadmap.rb`, `sync-backlog.rb`, and `scripts/bin/validate` now read repo files as UTF-8 explicitly, fixing `invalid byte sequence in US-ASCII` crashes in environments without a UTF-8 locale (minimal containers, some CI runners) — `generate-roadmap.sh --check` and `validate --quick` both crashed in such environments
+- **Test suite**: repaired the three test suites that failed on `main`:
+  - `scripts/test/integration/auto-version` rewritten against the current release architecture (`scripts/analyze-commits.sh` wrapper, `scripts/utils/analyze-commits`, `scripts/bin/release`, `version-bump.yml`) — it previously targeted the retired `gem-publish.sh`/`auto-version-bump.yml` and aborted under `set -e` due to `((var++))` returning non-zero
+  - `scripts/test/integration/mermaid` repointed at `pages/_docs/features/mermaid-diagrams.md` (the doc moved from `pages/_docs/jekyll/`) and at the current Bootstrap-aware theming instead of the removed forest theme/FontAwesome config
+  - `_layouts/search.html` given a front matter block so theme layout validation passes
+- **Changelog tooling**: `update_changelog_file` now folds any pending `## [Unreleased]` section into the new release entry and inserts before the first release heading (preserving the file preamble) — stale Unreleased blocks no longer accumulate mid-file; the eight historical stray blocks were folded into the releases that shipped them
+
+### Changed
+- **Roadmap**: advanced to track the shipped gem — v1.9 marked completed, v1.10 (Roadmap Validation) and v1.11 (Continuous-Evolution Loop) recorded, v1.12 (Headless Endpoints) is the active milestone (closes backlog T-001, T-002)
+- **Changelog**: restored the Keep a Changelog preamble at the top of this file
+
 ## [1.12.0] - 2026-06-03
 
 ### Changed
@@ -37,9 +56,6 @@
 ### Commits in this release
 - 8a5ba7e2 feat(ci): add continuous-evolution backlog loop (#114)
 
-
-## [Unreleased]
-
 ### Added
 - **Continuous-evolution loop**: a self-sustaining backlog mechanism so AI agents can keep improving the repo between human sessions.
   - `_data/backlog.yml` — tactical task queue (single source of truth), mirroring the `_data/roadmap.yml` pattern.
@@ -50,6 +66,8 @@
   - `.github/instructions/backlog.instructions.md` — file-scoped guidance for the backlog.
   - `docs/systems/continuous-evolution.md` — full design, autonomy policy, and setup.
   - `CLAUDE.md` — Claude Code pointer to `AGENTS.md` (per the documented convention).
+
+
 ## [1.10.0] - 2026-06-01
 
 ### Changed
@@ -153,9 +171,6 @@
 ### Commits in this release
 - 8a2bd84 feat(install): modular installer with deploy plugins, AI wizard pipeline, scrape v2, and test suite (#111)
 
-
-## [Unreleased]
-
 ### Added
 - **Modular installer (`scripts/install/`)**: spec-driven, AI-aware installer dispatched by `scripts/bin/install`. Single `.zer0/install.spec.json` contract feeds CLI flags, the TUI wizard, and the OpenAI wizard into one apply pipeline.
 - **Deploy plugins**: `tasks/deploy_github-pages.sh`, `tasks/deploy_azure-swa.sh`, `tasks/deploy_docker-prod.sh`. Spec deploy targets now auto-render the matching workflow / config from `templates/deploy/`.
@@ -171,16 +186,15 @@
 - Rewrote `ai/prompts/wizard.system.md` with explicit profile, deploy, and agent heuristics plus a full example output, eliminating empty AI responses.
 - `plan_load_profile` and `plan_apply_flags` now return `0` explicitly so Bash 3.2 doesn't propagate a trailing-test exit code.
 
+
 ## [1.8.2] - 2026-05-26
 
 ### Changed
 - Version bump: patch release
 
-
-## [Unreleased]
-
 ### Changed
 - **Gem packaging**: `jekyll-theme-zer0.gemspec` now excludes `assets/images/` (287 MB of content previews/author photos), `assets/backgrounds/`, `.DS_Store` files, and binary media outside `assets/vendor/`, reducing gem payload to ~8.9 MB
+
 
 ## [1.8.1] - 2026-05-26
 
@@ -216,9 +230,6 @@
 
 ### Commits in this release
 - 580f2b4 perf: Jekyll build performance improvements + MathJax 3 fix + richer Obsidian cache (#100)
-
-
-## [Unreleased]
 
 ### Added
 - **Design system & layouts**: Sass token layers (`_sass/tokens/`), component and layout partials (`_sass/components/`, `_sass/layouts/`), skins (`theme_skins.yml` + `_sass/theme/_skins.scss`), utilities, and developer docs (`docs/design-system.md`, `design-tokens.md`, `theming.md`, `layouts-and-navigation.md`, and related guides). Homepage sections are driven by `_data/landing.yml` per `_includes/components/README.md`.
@@ -260,6 +271,7 @@
 
 ### Fixed (UI)
 - **Contrast skin — light mode**: The `contrast` skin's `zer0-skin-palette` mixin sets `--bs-link-color: #ffffff` (white accent) which rendered sidebar nav links invisible on a white background in light mode. Added `[data-theme-skin="contrast"]:not([data-bs-theme="dark"])` override in `_sass/theme/_skins.scss` to pin link color to `#111111` in light mode while leaving dark-mode behavior unchanged.
+
 
 ## [1.6.5] - 2026-05-19
 
@@ -394,9 +406,6 @@
 - 3d91006 fix(release): replace ((var++)) with var=$((var + 1)) in release path
 - d33e5e6 feat(intro): refocus Copilot Agent prompts on frontend/CMS workflows (#74)
 
-
-## [Unreleased]
-
 ### Changed
 - **Docker/Jekyll build performance** — Reduced repeated full-page Liquid scans in the footer, settings offcanvas, and cookie consent includes; cached preview image checks during generation; skipped server-side Obsidian rewrites for documents without Obsidian syntax; and changed Docker dev startup to run `bundle install` only when `bundle check` reports missing dependencies. The profiled Docker build improved from 119.2s to 86.8s in local validation.
 
@@ -501,6 +510,7 @@
   `/#setup-wizard`, which is provided by the new welcome layout.
 - **Version-bump workflow no longer crashes on bash 5.x runners.** `scripts/utils/analyze-commits` (and `scripts/lib/changelog.sh`, `scripts/lib/migrate.sh`) used the `((var++))` post-increment idiom. On bash 5.x, when `var` is 0 the expression evaluates to 0 → exit code 1 → `set -euo pipefail` terminates the script silently. macOS bash 3.2 was more forgiving, so the bug only surfaced in CI. Replaced all release-path sites with `var=$((var + 1))`, which always returns 0. Added a static regression check to the unit tests so the pattern can't return.
 
+
 ## [1.0.0] - 2026-04-20
 
 First stable major release. Consolidates the breaking-change installer rewrite
@@ -573,9 +583,6 @@ See [`docs/installation/migration-from-0.x.md`](docs/installation/migration-from
 ### Commits in this release
 - 7f00e4d docs(roadmap): data-driven roadmap with auto-generated README mermaid diagram (#71)
 
-
-## [Unreleased]
-
 ### Changed
 - **Copilot Agent prompts (`_data/prompts.yml`)**: rewritten to focus on
   frontend/CMS workflows for the Jekyll theme. Replaced the previous
@@ -624,6 +631,7 @@ See [`docs/installation/migration-from-0.x.md`](docs/installation/migration-from
 - **Fork cleanup**: `scripts/fork-cleanup.sh` — repository name derivation now strips `.git` suffix and falls back gracefully when `origin` is missing (no `set -euo pipefail` aborts)
 - **Fork cleanup**: `scripts/fork-cleanup.sh` — `posthog`/`giscus` blocks reset only within their own YAML range (no stray matches in unrelated blocks)
 - **Welcome post**: `templates/pages/welcome-post.md.template` and embedded fallback in `scripts/fork-cleanup.sh` — corrected `layout: journals` → `layout: article` so the generated welcome post builds without “Layout does not exist” warnings on a freshly cleaned fork
+
 
 ## [0.22.20] - 2026-04-19
 
@@ -766,9 +774,6 @@ See [`docs/installation/migration-from-0.x.md`](docs/installation/migration-from
 ### Commits in this release
 - a70ae8a chore: consolidate configuration, dependencies, and installation (PRs #48, #51, #52, #53) (#51)
 
-
-## [Unreleased] — Universal Installer
-
 ### Added
 - **Installer**: New `--remote` install mode — forks repo and creates an orphan `gh-pages` branch with only the bare minimum files needed to render via `remote_theme` (no local theme source)
 - **Installer**: New `--github` install mode — interactive fork via `gh` CLI with automatic platform detection and setup
@@ -792,6 +797,7 @@ See [`docs/installation/migration-from-0.x.md`](docs/installation/migration-from
 - **Templates**: `quickstart.md.template` — enhanced with Bootstrap pill tabs for macOS/Linux/WSL/GitHub Fork platform-specific instructions
 - **Templates**: `configuration.md.template` — comprehensive rewrite with URL tables, all config sections, cookie consent, dev config
 - **Templates**: `welcome-post.md.template` — enhanced Day 1 tutorial with folder structure diagram, commands table, feature checklist
+
 
 ## [0.22.6] - 2026-04-03
 
@@ -2376,13 +2382,6 @@ See [`docs/installation/migration-from-0.x.md`](docs/installation/migration-from
 - Initial plan
 - Initial plan
 
-All notable changes to this project will be documented in this file.
-
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
-and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
-
-## [Unreleased]
-
 ### Added
 
 - Comprehensive documentation organization system in `/docs/` directory
@@ -2393,6 +2392,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Migrated scattered documentation files to organized structure
 - Improved documentation discoverability and maintenance
+
 
 ## [0.5.0] - 2025-10-25
 

--- a/README.md
+++ b/README.md
@@ -827,8 +827,11 @@ gantt
     v1.6 About Page & Search Cleanup :done, 2026-04, 2026-04
     v1.7 Build Performance & MathJax 3 :done, 2026-05, 2026-05
     v1.8 Design Tokens & Navigation Chrome :done, 2026-05, 2026-05
+    v1.9 Installer v2 & Site Scraper :done, 2026-05, 2026-05
+    v1.10 Roadmap Validation     :done, 2026-06, 2026-06
+    v1.11 Continuous-Evolution Loop :done, 2026-06, 2026-06
     section Current
-    v1.9 Installer v2 & Site Scraper :active, 2026-05, 2026-05
+    v1.12 Headless Endpoints     :active, 2026-06, 2026-06
     section Future
     v2.0 CMS Integration         :2026-06, 2026-08
     v2.1 i18n Support            :2026-08, 2026-10
@@ -857,7 +860,10 @@ gantt
 | **v1.6** | ✅ Completed | Apr 2026 | Expanded About page and removal of the Algolia search dependency. |
 | **v1.7** | ✅ Completed | May 2026 | Significant Jekyll build speedups and a MathJax 3 inline-math fix. |
 | **v1.8** | ✅ Completed | May 2026 | Sass design-token system, refreshed navigation chrome, and a docs overhaul. |
-| **v1.9** | 🚧 In Progress | Current (1.9.x) | Modular installer v2 with deploy plugins, AI wizard pipeline, and a site scraper. |
+| **v1.9** | ✅ Completed | May 2026 | Modular installer v2 with deploy plugins, AI wizard pipeline, and a site scraper. |
+| **v1.10** | ✅ Completed | Jun 2026 | Roadmap integrity validation and catch-up milestones so the roadmap tracks the shipped gem. |
+| **v1.11** | ✅ Completed | Jun 2026 | Self-sustaining backlog loop so AI agents keep improving the repo between human sessions. |
+| **v1.12** | 🚧 In Progress | Current (1.12.x) | Machine-readable site endpoints for downstream sites and AI agents. |
 | **v2.0** | 🗓 Planned | Q3 2026 | Headless CMS integration with a content API and admin dashboard. |
 | **v2.1** | 🗓 Planned | Q4 2026 | Multi-language content support with locale-aware routing. |
 | **v2.2** | 🗓 Planned | Q4 2026 | Visual theme customizer, A/B testing, and conversion funnels. |

--- a/_data/backlog.yml
+++ b/_data/backlog.yml
@@ -55,7 +55,7 @@
 
 meta:
   title: "zer0-mistakes Backlog"
-  updated: 2026-06-01
+  updated: 2026-06-10
   next_id: 12
 
 tasks:
@@ -63,7 +63,7 @@ tasks:
 
   - id: T-001
     title: "Reconcile roadmap milestone numbering with the published gem version"
-    status: open
+    status: done
     priority: P2
     area: docs
     risk: standard
@@ -73,17 +73,19 @@ tasks:
       `_data/roadmap.yml` milestones run 0.17–1.0 while the gem ships as 1.9.9.
       Decide on a single numbering scheme (or document the mapping) so the
       roadmap, README, and RubyGems version no longer contradict each other.
+      Done 2026-06-10: roadmap advanced to track the shipped gem — v1.9
+      completed, v1.10/v1.11 recorded, v1.12 active.
     acceptance:
       - "Roadmap version line and gem version no longer contradict (either remapped or an explicit mapping note added to `_data/roadmap.yml` and `pages/roadmap.md`)."
       - "`./scripts/generate-roadmap.sh --check` passes after the change."
       - "No edit to `lib/jekyll-theme-zer0/version.rb`."
     links: { issue: null, pr: null, roadmap: null }
     created: 2026-05-31
-    updated: 2026-05-31
+    updated: 2026-06-10
 
   - id: T-002
     title: "Refresh roadmap `updated:` date and review milestone statuses"
-    status: open
+    status: done
     priority: P3
     area: docs
     risk: low
@@ -92,13 +94,15 @@ tasks:
     summary: >-
       `_data/roadmap.yml` `meta.updated` is 2026-04-18. Refresh it and confirm
       the 0.22 "active" milestone still reflects reality.
+      Done 2026-06-10: `meta.updated` refreshed and statuses reconciled with
+      shipped releases through v1.12.0.
     acceptance:
       - "`meta.updated` set to the current date."
       - "Active/planned statuses reviewed against shipped work."
       - "`./scripts/generate-roadmap.sh --check` passes."
     links: { issue: null, pr: null, roadmap: null }
     created: 2026-05-31
-    updated: 2026-05-31
+    updated: 2026-06-10
 
   - id: T-003
     title: "Add GitHub issue templates and a pull-request template"

--- a/_data/roadmap.yml
+++ b/_data/roadmap.yml
@@ -60,7 +60,7 @@
 meta:
   title: "zer0-mistakes Roadmap"
   tagline: "Past releases, current focus, and future plans for the zer0-mistakes Jekyll theme."
-  updated: 2026-05-30
+  updated: 2026-06-10
 
 milestones:
   # --- Completed -------------------------------------------------------------
@@ -270,15 +270,12 @@ milestones:
       - "Unified Playwright test tiers (smoke / snapshots / regression)"
       - "Design-system developer docs"
 
-  # --- Current ---------------------------------------------------------------
-
   - version: "1.9"
     title: "Installer v2 & Site Scraper"
-    status: active
-    section: Current
+    status: completed
+    section: Completed
     start: 2026-05
     end: 2026-05
-    target: "Current (1.9.x)"
     released: 2026-05-27
     summary: "Modular installer v2 with deploy plugins, AI wizard pipeline, and a site scraper."
     features:
@@ -287,6 +284,49 @@ milestones:
       - "Accessibility skin fixes (WCAG AA contrast); `air` default skin"
       - "Quickstart documentation rewrite with screenshots"
       - "Hardened one-line installer path"
+
+  - version: "1.10"
+    title: "Roadmap Validation"
+    status: completed
+    section: Completed
+    start: 2026-06
+    end: 2026-06
+    released: 2026-06-01
+    summary: "Roadmap integrity validation and catch-up milestones so the roadmap tracks the shipped gem."
+    features:
+      - "`generate-roadmap.rb --validate` mode (status/section/version/date checks)"
+      - "Catch-up milestones v1.0–1.9 recorded in the roadmap"
+      - "README roadmap accuracy fixes"
+
+  - version: "1.11"
+    title: "Continuous-Evolution Loop"
+    status: completed
+    section: Completed
+    start: 2026-06
+    end: 2026-06
+    released: 2026-06-01
+    summary: "Self-sustaining backlog loop so AI agents keep improving the repo between human sessions."
+    features:
+      - "`_data/backlog.yml` tactical task queue (single source of truth)"
+      - "Backlog ↔ GitHub Issues sync workflow with schema validation"
+      - "Auto-merge for low-risk (docs/deps/lint) PRs once CI is green"
+      - "`/repo-audit` and `/backlog-implement` agent routines"
+      - "Documentation maintenance system and consolidation"
+
+  # --- Current ---------------------------------------------------------------
+
+  - version: "1.12"
+    title: "Headless Endpoints"
+    status: active
+    section: Current
+    start: 2026-06
+    end: 2026-06
+    target: "Current (1.12.x)"
+    summary: "Machine-readable site endpoints for downstream sites and AI agents."
+    features:
+      - "Auto-generated `/search.json` endpoint for downstream sites"
+      - "Auto-generated `/sitemap/` endpoint"
+      - "Ruby gem and Mermaid dependency updates"
 
   # --- Future ----------------------------------------------------------------
 

--- a/_includes/components/mermaid.html
+++ b/_includes/components/mermaid.html
@@ -27,7 +27,7 @@
   
   Configuration:
   - Mermaid v10 bundled locally (_config.yml mermaid.src)
-  - Forest theme for dark mode compatibility
+  - Adaptive light/dark theme following Bootstrap's data-bs-theme
   - Client-side code block conversion for GitHub Pages compatibility
   
   GitHub Pages Compatibility:

--- a/_layouts/search.html
+++ b/_layouts/search.html
@@ -1,1 +1,6 @@
+---
+# Bare layout that renders the client-side search index as pure JSON.
+# Used by /search.json (see search.json in the site root); downstream
+# sites get the endpoint automatically via the theme gem.
+---
 {% include search-data.json %}

--- a/scripts/bin/validate
+++ b/scripts/bin/validate
@@ -236,7 +236,9 @@ versions = {
 }
 
 if File.file?('package.json')
-  versions['package.json'] = JSON.parse(File.read('package.json')).fetch('version').to_s
+  # Explicit UTF-8: package.json contains multibyte characters and the default
+  # external encoding is US-ASCII when no locale is set (containers, some CI).
+  versions['package.json'] = JSON.parse(File.read('package.json', encoding: 'UTF-8')).fetch('version').to_s
 end
 
 expected = versions.values.first

--- a/scripts/generate-roadmap.rb
+++ b/scripts/generate-roadmap.rb
@@ -149,7 +149,7 @@ end
 def current_gem_version
   return nil unless File.exist?(VERSION_RB)
 
-  m = File.read(VERSION_RB).match(/VERSION\s*=\s*["']([^"']+)["']/)
+  m = File.read(VERSION_RB, encoding: 'UTF-8').match(/VERSION\s*=\s*["']([^"']+)["']/)
   m && m[1]
 end
 
@@ -318,7 +318,7 @@ def main
     begin
       YAML.load_file(DATA_FILE, permitted_classes: [Date, Time])
     rescue ArgumentError
-      YAML.safe_load(File.read(DATA_FILE), permitted_classes: [Date, Time], aliases: false)
+      YAML.safe_load(File.read(DATA_FILE, encoding: 'UTF-8'), permitted_classes: [Date, Time], aliases: false)
     end
 
   return run_validation(data) if options[:mode] == :validate
@@ -333,7 +333,9 @@ def main
     return 0
   end
 
-  original = File.read(README)
+  # Force UTF-8: the README contains emoji, and the default external encoding
+  # is US-ASCII when no locale is set (minimal containers, some CI runners).
+  original = File.read(README, encoding: 'UTF-8')
   updated  = original.dup
   updated  = replace_block(updated, MERMAID_START, MERMAID_END, mermaid)
   updated  = replace_block(updated, TABLE_START,   TABLE_END,   table)

--- a/scripts/lib/changelog.sh
+++ b/scripts/lib/changelog.sh
@@ -305,18 +305,59 @@ update_changelog_file() {
     
     # Create backup
     cp "$CHANGELOG_FILE" "${CHANGELOG_FILE}.bak"
-    
-    # Insert new entry after header (preserve first line)
+
+    # Fold any pending "## [Unreleased]" section into the new entry so its
+    # notes ship with this release instead of getting buried beneath it
+    # (stale Unreleased blocks used to accumulate mid-file).
+    local unreleased_start
+    unreleased_start=$(grep -n '^## \[Unreleased\]' "$CHANGELOG_FILE" | head -1 | cut -d: -f1)
+
+    if [[ -n "$unreleased_start" ]]; then
+        # First "## " heading after the Unreleased one (relative offset)
+        local rel_next
+        rel_next=$(tail -n +"$((unreleased_start + 1))" "$CHANGELOG_FILE" | grep -n '^## ' | head -1 | cut -d: -f1)
+
+        local unreleased_body
+        if [[ -n "$rel_next" ]]; then
+            unreleased_body=$(sed -n "$((unreleased_start + 1)),$((unreleased_start + rel_next - 1))p" "$CHANGELOG_FILE")
+        else
+            unreleased_body=$(tail -n +"$((unreleased_start + 1))" "$CHANGELOG_FILE")
+        fi
+
+        # Drop the Unreleased section (header + body) from the file
+        {
+            head -n "$((unreleased_start - 1))" "$CHANGELOG_FILE"
+            [[ -n "$rel_next" ]] && tail -n +"$((unreleased_start + rel_next))" "$CHANGELOG_FILE"
+        } > "${CHANGELOG_FILE}.tmp"
+        mv "${CHANGELOG_FILE}.tmp" "$CHANGELOG_FILE"
+
+        # Append the pending notes to the new entry (if any are non-blank)
+        if [[ -n "${unreleased_body//[[:space:]]/}" ]]; then
+            debug "Folding pending [Unreleased] notes into the new entry"
+            entry+=$'\n'"$(echo "$unreleased_body" | sed -e '/./,$!d')"$'\n'
+        fi
+    fi
+
+    # Insert the new entry before the first release heading so the file
+    # header/preamble (title, Keep a Changelog blurb) stays at the top.
+    local first_release
+    first_release=$(grep -n '^## ' "$CHANGELOG_FILE" | head -1 | cut -d: -f1)
+
     {
-        head -n 1 "$CHANGELOG_FILE"
-        echo ""
-        echo "$entry"
-        tail -n +2 "$CHANGELOG_FILE"
+        if [[ -n "$first_release" ]]; then
+            head -n "$((first_release - 1))" "$CHANGELOG_FILE"
+            echo "$entry"
+            tail -n +"$first_release" "$CHANGELOG_FILE"
+        else
+            cat "$CHANGELOG_FILE"
+            echo ""
+            echo "$entry"
+        fi
     } > "${CHANGELOG_FILE}.tmp"
-    
+
     mv "${CHANGELOG_FILE}.tmp" "$CHANGELOG_FILE"
     rm -f "${CHANGELOG_FILE}.bak"
-    
+
     debug "✓ Updated $CHANGELOG_FILE"
 }
 

--- a/scripts/sync-backlog.rb
+++ b/scripts/sync-backlog.rb
@@ -78,7 +78,7 @@ def load_data
   begin
     YAML.load_file(DATA_FILE, permitted_classes: [Date, Time])
   rescue ArgumentError
-    YAML.safe_load(File.read(DATA_FILE), permitted_classes: [Date, Time], aliases: false)
+    YAML.safe_load(File.read(DATA_FILE, encoding: 'UTF-8'), permitted_classes: [Date, Time], aliases: false)
   end
 end
 

--- a/scripts/test/integration/auto-version
+++ b/scripts/test/integration/auto-version
@@ -21,6 +21,13 @@ log_warning() { warn "$@"; }
 log_error() { error "$@"; }
 log_test() { step "$@"; }
 
+# Paths under test (the workflow calls the wrapper; the implementation
+# lives in scripts/utils/; releases go through scripts/bin/release)
+ANALYZE_WRAPPER="$SCRIPTS_ROOT/analyze-commits.sh"
+ANALYZE_IMPL="$SCRIPTS_ROOT/utils/analyze-commits"
+RELEASE_BIN="$SCRIPTS_ROOT/bin/release"
+WORKFLOW_FILE="$PROJECT_ROOT/.github/workflows/version-bump.yml"
+
 # Test counter
 TESTS_RUN=0
 TESTS_PASSED=0
@@ -29,49 +36,64 @@ run_test() {
     local test_name="$1"
     local test_command="$2"
     local expected_result="${3:-}"
-    
-    ((TESTS_RUN++))
+
+    # Plain arithmetic assignment: ((VAR++)) returns the pre-increment value,
+    # which is non-zero-exit when 0 and aborts the script under `set -e`.
+    TESTS_RUN=$((TESTS_RUN + 1))
     log_test "Running: $test_name"
-    
+
     local actual_result
     if actual_result=$(eval "$test_command" 2>&1); then
         if [[ -n "$expected_result" ]]; then
             if [[ "$actual_result" == "$expected_result" ]]; then
                 log_success "✅ $test_name"
-                ((TESTS_PASSED++))
+                TESTS_PASSED=$((TESTS_PASSED + 1))
             else
                 log_error "❌ $test_name - Expected: '$expected_result', Got: '$actual_result'"
             fi
         else
             log_success "✅ $test_name"
-            ((TESTS_PASSED++))
+            TESTS_PASSED=$((TESTS_PASSED + 1))
         fi
     else
         log_error "❌ $test_name - Command failed: $actual_result"
     fi
 }
 
+# Test file permissions and executability
+test_file_permissions() {
+    log_info "Testing file permissions..."
+
+    local scripts=(
+        "$ANALYZE_WRAPPER"
+        "$ANALYZE_IMPL"
+        "$RELEASE_BIN"
+    )
+
+    for script in "${scripts[@]}"; do
+        local script_name=$(basename "$script")
+        run_test "$script_name is executable" "test -x '$script'"
+    done
+}
+
 # Test the commit analysis script
 test_commit_analysis() {
     log_info "Testing commit analysis functionality..."
-    
-    # Test script exists and is executable
-    run_test "Commit analysis script exists" "test -x '$SCRIPT_DIR/analyze-commits.sh'"
-    
+
     # Test help output
-    run_test "Help output works" "$SCRIPT_DIR/analyze-commits.sh --help | grep -q 'Commit Analysis Script'"
-    
+    run_test "Help output works" "$ANALYZE_IMPL --help | grep -q 'Commit Analysis Script'"
+
     # Test with sample commit ranges (if we have git history)
     if git rev-list --count HEAD >/dev/null 2>&1; then
         local commit_count=$(git rev-list --count HEAD)
-        
+
         if [[ $commit_count -gt 1 ]]; then
-            # Test analyzing last commit
-            run_test "Analyze last commit" "$SCRIPT_DIR/analyze-commits.sh HEAD~1..HEAD | grep -E '^(patch|minor|major|none)$'"
-            
+            # Test analyzing last commit (through the wrapper, like the workflow)
+            run_test "Analyze last commit" "$ANALYZE_WRAPPER HEAD~1..HEAD | grep -E '^(patch|minor|major|none)$'"
+
             # Test analyzing multiple commits if available
             if [[ $commit_count -gt 3 ]]; then
-                run_test "Analyze multiple commits" "$SCRIPT_DIR/analyze-commits.sh HEAD~3..HEAD | grep -E '^(patch|minor|major|none)$'"
+                run_test "Analyze multiple commits" "$ANALYZE_WRAPPER HEAD~3..HEAD | grep -E '^(patch|minor|major|none)$'"
             fi
         fi
     else
@@ -79,102 +101,51 @@ test_commit_analysis() {
     fi
 }
 
-# Test gem publication script compatibility
-test_gem_publish_script() {
-    log_info "Testing gem publication script compatibility..."
-    
-    # Test script exists and is executable
-    run_test "Gem publish script exists" "test -x '$SCRIPT_DIR/gem-publish.sh'"
-    
-    # Test new automated options
-    run_test "Automated release option works" "$SCRIPT_DIR/gem-publish.sh --help | grep -q 'automated-release'"
-    run_test "Auto commit range option works" "$SCRIPT_DIR/gem-publish.sh --help | grep -q 'auto-commit-range'"
-    
-    # Test dry run with automated options
-    if [[ -f "$PROJECT_ROOT/lib/jekyll-theme-zer0/version.rb" ]]; then
-        run_test "Dry run with automated options" "$SCRIPT_DIR/gem-publish.sh patch --dry-run --automated-release --skip-tests --skip-publish --no-github-release | grep -q 'Automated Release Mode'"
-    fi
+# Test release command compatibility (replaces the retired gem-publish.sh)
+test_release_command() {
+    log_info "Testing release command compatibility..."
+
+    run_test "Release help works" "$RELEASE_BIN --help | grep -q 'VERSION TYPES'"
+    run_test "Dry-run option documented" "$RELEASE_BIN --help | grep -q -- '--dry-run'"
+    run_test "Skip-publish option documented" "$RELEASE_BIN --help | grep -q -- '--skip-publish'"
 }
 
 # Test workflow files syntax
 test_workflow_syntax() {
     log_info "Testing GitHub Actions workflow syntax..."
-    
+
+    run_test "version-bump workflow exists" "test -f '$WORKFLOW_FILE'"
+
     # Check if yamllint is available
     if command -v yamllint >/dev/null 2>&1; then
-        run_test "Auto-version-bump workflow syntax" "yamllint '$PROJECT_ROOT/.github/workflows/auto-version-bump.yml'"
+        run_test "version-bump workflow syntax" "yamllint -c '$PROJECT_ROOT/.github/config/.yamllint.yml' '$WORKFLOW_FILE'"
     else
-        # Basic YAML syntax check with Python
-        if command -v python3 >/dev/null 2>&1; then
-            run_test "Auto-version-bump workflow syntax" "python3 -c 'import yaml; yaml.safe_load(open(\"$PROJECT_ROOT/.github/workflows/auto-version-bump.yml\"))'"
-        else
-            log_warning "Neither yamllint nor python3 available for YAML validation"
-        fi
+        # Basic YAML syntax check with Ruby (always present for this repo)
+        run_test "version-bump workflow syntax" "ruby -ryaml -e 'YAML.safe_load_file(\"$WORKFLOW_FILE\", aliases: true)'"
     fi
-}
-
-# Test file permissions and executability
-test_file_permissions() {
-    log_info "Testing file permissions..."
-    
-    local scripts=(
-        "$SCRIPT_DIR/analyze-commits.sh"
-        "$SCRIPT_DIR/gem-publish.sh"
-    )
-    
-    for script in "${scripts[@]}"; do
-        local script_name=$(basename "$script")
-        run_test "$script_name is executable" "test -x '$script'"
-    done
 }
 
 # Test integration between components
 test_integration() {
     log_info "Testing integration between components..."
-    
-    # Test that analyze-commits.sh can be called by the workflow
-    if [[ -x "$SCRIPT_DIR/analyze-commits.sh" ]]; then
-        # Test with a simple commit range
-        if git rev-list --count HEAD >/dev/null 2>&1; then
-            local commit_count=$(git rev-list --count HEAD)
-            if [[ $commit_count -gt 0 ]]; then
-                run_test "Integration: commit analysis returns valid output" "$SCRIPT_DIR/analyze-commits.sh HEAD~1..HEAD | grep -E '^(patch|minor|major|none)$'"
-            fi
+
+    # The workflow invokes ./scripts/analyze-commits.sh and validates its output
+    if git rev-list --count HEAD >/dev/null 2>&1; then
+        local commit_count=$(git rev-list --count HEAD)
+        if [[ $commit_count -gt 0 ]]; then
+            run_test "Integration: commit analysis returns valid output" "$ANALYZE_WRAPPER HEAD~1..HEAD | grep -E '^(patch|minor|major|none)$'"
         fi
-    fi
-    
-    # Test that gem-publish.sh accepts the new parameters
-    if [[ -x "$SCRIPT_DIR/gem-publish.sh" ]]; then
-        run_test "Integration: gem-publish accepts automated params" "$SCRIPT_DIR/gem-publish.sh patch --dry-run --automated-release --auto-commit-range=HEAD~1..HEAD --skip-tests --skip-publish --no-github-release | grep -q 'DRY RUN MODE'"
     fi
 }
 
 # Test conventional commit detection
 test_conventional_commits() {
     log_info "Testing conventional commit detection..."
-    
-    # Create test commits in memory (don't actually commit)
-    local test_commits=(
-        "feat: add new feature"
-        "fix: resolve bug in component"
-        "BREAKING CHANGE: remove deprecated API"
-        "chore: update dependencies"
-        "docs: improve documentation"
-    )
-    
-    local expected_results=(
-        "minor"
-        "patch" 
-        "major"
-        "patch"
-        "patch"
-    )
-    
-    # Note: This would require a more sophisticated test setup
-    # For now, just test that the patterns exist in the script
-    run_test "Conventional commit patterns exist" "grep -q 'feat.*minor' '$SCRIPT_DIR/analyze-commits.sh'"
-    run_test "Fix patterns exist" "grep -q 'fix.*patch' '$SCRIPT_DIR/analyze-commits.sh'"
-    run_test "Breaking change patterns exist" "grep -q 'BREAKING.*major' '$SCRIPT_DIR/analyze-commits.sh'"
+
+    # Test that the documented mapping exists in the analyzer
+    run_test "Conventional commit patterns exist" "grep -q 'feat.*minor' '$ANALYZE_IMPL'"
+    run_test "Fix patterns exist" "grep -q 'fix.*patch' '$ANALYZE_IMPL'"
+    run_test "Breaking change patterns exist" "grep -q 'BREAKING.*major' '$ANALYZE_IMPL'"
 }
 
 # Main test execution
@@ -182,18 +153,18 @@ main() {
     log_info "🧪 Starting Automated Version Bump System Tests"
     echo "=================================================="
     echo ""
-    
+
     # Change to project root
     cd "$PROJECT_ROOT"
-    
+
     # Run all test suites
     test_file_permissions
     test_commit_analysis
-    test_gem_publish_script
+    test_release_command
     test_workflow_syntax
     test_integration
     test_conventional_commits
-    
+
     # Test summary
     echo ""
     echo "=================================================="
@@ -201,7 +172,7 @@ main() {
     echo "Tests Run: $TESTS_RUN"
     echo "Tests Passed: $TESTS_PASSED"
     echo "Tests Failed: $((TESTS_RUN - TESTS_PASSED))"
-    
+
     if [[ $TESTS_PASSED -eq $TESTS_RUN ]]; then
         log_success "🎉 All tests passed! Automated version bump system is ready."
         exit 0
@@ -221,23 +192,18 @@ USAGE:
 
 DESCRIPTION:
     This script tests the automated version bump system including:
-    - Commit analysis functionality
-    - Gem publication script compatibility  
-    - Workflow file syntax validation
+    - Commit analysis functionality (scripts/analyze-commits.sh wrapper
+      and scripts/utils/analyze-commits implementation)
+    - Release command compatibility (scripts/bin/release)
+    - Workflow file syntax validation (.github/workflows/version-bump.yml)
     - Integration between components
     - Conventional commit detection
 
 REQUIREMENTS:
     - Git repository with commit history
-    - Executable scripts in scripts/ directory
-    - Valid GitHub Actions workflow files
-
-OUTPUT:
-    Detailed test results and summary
-    Exit code 0 on success, 1 on failure
+    - Bash 3.2+ compatible environment
 EOF
     exit 0
 fi
 
-# Execute main function
 main "$@"

--- a/scripts/test/integration/mermaid
+++ b/scripts/test/integration/mermaid
@@ -166,9 +166,7 @@ main() {
     log_info "Testing core files..."
     
     test_file_exists "_includes/components/mermaid.html" "Mermaid include file exists"
-    test_file_exists "pages/_docs/jekyll/mermaid.md" "Main documentation exists"
-    test_file_exists "pages/_docs/jekyll/mermaid-test-suite.md" "Test suite exists"
-    test_file_exists "pages/_docs/jekyll/jekyll-diagram-with-mermaid.md" "Tutorial exists"
+    test_file_exists "pages/_docs/features/mermaid-diagrams.md" "Main documentation exists"
     
     # Configuration tests
     log_info "Testing configuration..."
@@ -183,16 +181,14 @@ main() {
     
     test_file_content "_includes/components/mermaid.html" "site.mermaid.src" "Mermaid script from _config (local vendor path)"
     test_file_content "_includes/components/mermaid.html" "mermaid.initialize" "Mermaid initialization script"
-    test_file_content "_includes/components/mermaid.html" "forest" "Forest theme configured"
-    test_file_content "_includes/components/mermaid.html" "FontAwesome" "FontAwesome support included"
+    test_file_content "_includes/components/mermaid.html" "data-bs-theme" "Bootstrap theme detection configured"
+    test_file_content "_includes/components/mermaid.html" "getMermaidConfig" "Adaptive light/dark theming configured"
     
     # Documentation tests
     log_info "Testing documentation..."
     
-    test_file_content "pages/_docs/jekyll/mermaid.md" "mermaid: true" "Main docs have front matter"
-    test_file_content "pages/_docs/jekyll/mermaid-test-suite.md" "mermaid: true" "Test suite has front matter"
-    test_file_content "pages/_docs/jekyll/mermaid.md" "graph TD" "Main docs have examples"
-    test_file_content "pages/_docs/jekyll/mermaid-test-suite.md" "graph TD" "Test suite has examples"
+    test_file_content "pages/_docs/features/mermaid-diagrams.md" "mermaid: true" "Main docs have front matter"
+    test_file_content "pages/_docs/features/mermaid-diagrams.md" "graph TD" "Main docs have examples"
     
     # Server tests (if not quick mode)
     if [ "$QUICK" = false ]; then
@@ -204,11 +200,10 @@ main() {
             
             # Check if local server is running
             if curl -s -f "http://localhost:4000" >/dev/null 2>&1; then
-                test_url "http://localhost:4000/docs/jekyll/mermaid/" "Main documentation accessible"
-                test_url "http://localhost:4000/docs/jekyll/mermaid-test-suite/" "Test suite accessible"
-                test_mermaid_script "http://localhost:4000/docs/jekyll/mermaid-test-suite/" "Mermaid script loads on test page"
-                test_mermaid_init "http://localhost:4000/docs/jekyll/mermaid-test-suite/" "Mermaid initializes on test page"
-                test_diagram_rendering "http://localhost:4000/docs/jekyll/mermaid-test-suite/" "Diagrams render on test page"
+                test_url "http://localhost:4000/docs/features/mermaid-diagrams/" "Main documentation accessible"
+                test_mermaid_script "http://localhost:4000/docs/features/mermaid-diagrams/" "Mermaid script loads on docs page"
+                test_mermaid_init "http://localhost:4000/docs/features/mermaid-diagrams/" "Mermaid initializes on docs page"
+                test_diagram_rendering "http://localhost:4000/docs/features/mermaid-diagrams/" "Diagrams render on docs page"
             else
                 log_warning "Local Jekyll server not running. Start with: bundle exec jekyll serve"
             fi
@@ -220,11 +215,10 @@ main() {
             
             # Check if Docker container is running
             if docker ps | grep -q "zer0-mistakes-jekyll"; then
-                test_url "http://localhost:4000/docs/jekyll/mermaid/" "Docker: Main documentation accessible"
-                test_url "http://localhost:4000/docs/jekyll/mermaid-test-suite/" "Docker: Test suite accessible"
-                test_mermaid_script "http://localhost:4000/docs/jekyll/mermaid-test-suite/" "Docker: Mermaid script loads"
-                test_mermaid_init "http://localhost:4000/docs/jekyll/mermaid-test-suite/" "Docker: Mermaid initializes"
-                test_diagram_rendering "http://localhost:4000/docs/jekyll/mermaid-test-suite/" "Docker: Diagrams render"
+                test_url "http://localhost:4000/docs/features/mermaid-diagrams/" "Docker: Main documentation accessible"
+                test_mermaid_script "http://localhost:4000/docs/features/mermaid-diagrams/" "Docker: Mermaid script loads"
+                test_mermaid_init "http://localhost:4000/docs/features/mermaid-diagrams/" "Docker: Mermaid initializes"
+                test_diagram_rendering "http://localhost:4000/docs/features/mermaid-diagrams/" "Docker: Diagrams render"
             else
                 log_warning "Docker container not running. Start with: docker-compose up -d"
             fi

--- a/scripts/test/lib/test_changelog.sh
+++ b/scripts/test/lib/test_changelog.sh
@@ -87,4 +87,72 @@ test_categorization "security: patch vulnerability" "security"
 test_categorization "BREAKING: major change" "breaking"
 test_categorization "random commit" "other"
 
+# Test: update_changelog_file
+echo -e "\nTesting update_changelog_file..."
+
+# Each case runs in a throwaway directory; CHANGELOG_FILE is the relative
+# default ("CHANGELOG.md"), so the function operates on the temp copy.
+_changelog_tmp=$(mktemp -d)
+pushd "$_changelog_tmp" >/dev/null
+
+# Case 1: pending [Unreleased] notes are folded into the new entry and the
+# preamble stays at the top of the file.
+cat > CHANGELOG.md <<'FIXTURE'
+# Changelog
+
+All notable changes are documented here.
+
+## [Unreleased]
+
+### Added
+- Pending feature A
+
+## [1.0.0] - 2026-01-01
+
+### Added
+- Initial release
+FIXTURE
+
+update_changelog_file "## [1.1.0] - 2026-06-10
+
+### Changed
+- Version bump: minor release
+" >/dev/null 2>&1
+
+assert_false "grep -q '^## \[Unreleased\]' CHANGELOG.md" "Pending Unreleased section is consumed"
+assert_true "grep -q 'Pending feature A' CHANGELOG.md" "Pending notes are preserved"
+assert_equals "# Changelog" "$(head -n 1 CHANGELOG.md)" "Preamble heading stays on line 1"
+# The folded notes must land inside the new 1.1.0 entry (above 1.0.0)
+_pending_line=$(grep -n 'Pending feature A' CHANGELOG.md | cut -d: -f1)
+_v110_line=$(grep -n '^## \[1.1.0\]' CHANGELOG.md | cut -d: -f1)
+_v100_line=$(grep -n '^## \[1.0.0\]' CHANGELOG.md | cut -d: -f1)
+assert_true "[[ $_pending_line -gt $_v110_line && $_pending_line -lt $_v100_line ]]" "Folded notes live inside the new entry"
+
+# Case 2: without an Unreleased section the entry is inserted before the
+# first release heading, after the preamble.
+cat > CHANGELOG.md <<'FIXTURE'
+# Changelog
+
+All notable changes are documented here.
+
+## [1.0.0] - 2026-01-01
+
+### Added
+- Initial release
+FIXTURE
+
+update_changelog_file "## [1.0.1] - 2026-06-10
+
+### Fixed
+- A bug
+" >/dev/null 2>&1
+
+_v101_line=$(grep -n '^## \[1.0.1\]' CHANGELOG.md | cut -d: -f1)
+_v100_line=$(grep -n '^## \[1.0.0\]' CHANGELOG.md | cut -d: -f1)
+assert_true "[[ $_v101_line -lt $_v100_line ]]" "New entry inserted before previous release"
+assert_true "grep -q 'All notable changes' CHANGELOG.md" "Preamble preserved without Unreleased"
+
+popd >/dev/null
+rm -rf "$_changelog_tmp"
+
 echo -e "\n${GREEN}changelog.sh tests complete${NC}"


### PR DESCRIPTION
## Summary

A "practice what you preach" pass: this PR runs the repo's own quality gates (`scripts/bin/test`, `scripts/bin/validate`, `generate-roadmap --check/--validate`, `sync-backlog --check`) and fixes every mistake they surface. On `main`, 3 of 10 test suites failed, two validators crashed outright in locale-less environments, the roadmap was three releases behind the shipped gem, and eight stale `## [Unreleased]` blocks had accumulated mid-CHANGELOG.

## Fixed

### Validator crashes (UTF-8 encoding)
- `scripts/generate-roadmap.rb`, `scripts/sync-backlog.rb`, and `scripts/bin/validate` now read repo files with explicit UTF-8 encoding. Both `generate-roadmap.sh --check` and `validate --quick` crashed with `invalid byte sequence in US-ASCII` in any environment without a UTF-8 locale (minimal containers, some CI runners) — the repo's own quality gates couldn't run.

### Failing test suites (3 → 0)
- **auto-version**: rewritten against the current release architecture (`scripts/analyze-commits.sh` wrapper, `scripts/utils/analyze-commits`, `scripts/bin/release`, `version-bump.yml`). It previously targeted the retired `gem-publish.sh` / `auto-version-bump.yml` and aborted on its very first test under `set -e` because `((var++))` returns non-zero when the counter is 0 — the exact bug class the repo's own lib tests guard against elsewhere.
- **mermaid**: repointed at `pages/_docs/features/mermaid-diagrams.md` (the doc moved from `pages/_docs/jekyll/`) and at the current Bootstrap-aware adaptive theming instead of the removed forest theme / FontAwesome config. Stale header comment in `_includes/components/mermaid.html` corrected to match.
- **theme validation**: `_layouts/search.html` was the only layout without a front matter block. Added one; verified the built `/search.json` still renders valid JSON (143 entries) via a full Jekyll build.

### Changelog tooling (root cause + data)
- `update_changelog_file` in `scripts/lib/changelog.sh` inserted new release entries after line 1 unconditionally, so any pending `## [Unreleased]` section got buried beneath them — eight stale blocks had accumulated mid-file. It now folds the pending Unreleased notes into the new release entry and inserts before the first release heading, preserving the Keep a Changelog preamble. Unit tests added in `scripts/test/lib/test_changelog.sh`.
- The eight historical stray blocks were folded into the releases that actually shipped them, a duplicated mid-file preamble was removed, and the Keep a Changelog preamble was restored at the top.

### Roadmap drift (closes backlog T-001, T-002)
- `generate-roadmap.sh --validate` warned that the active milestone (v1.9) trailed the shipped gem (v1.12.0). The roadmap now tracks reality: v1.9 completed, v1.10 (Roadmap Validation) and v1.11 (Continuous-Evolution Loop) recorded, v1.12 (Headless Endpoints) active. README regenerated by the generator; validation passes with zero warnings.
- Backlog tasks T-001 and T-002 marked `done` (the sync workflow will close their issues on merge).

## Validation

- `./scripts/bin/test` — **10/10 suites pass** (was 7/10 on `main`)
- `scripts/test/lib/run_tests.sh` — 77/77 unit tests pass (includes 6 new changelog-fold assertions)
- `./scripts/generate-roadmap.sh --check` and `--validate` — clean, zero warnings (crashed on `main` in this environment)
- `ruby scripts/sync-backlog.rb --check` — valid (10 tasks)
- `./scripts/bin/validate --quick` — passes (crashed on `main` in this environment)
- Full Jekyll build (`_config.yml,_config_dev.yml`) — succeeds; `/search.json` verified as valid JSON

No version bump (per operating rules, releases stay human-driven).

https://claude.ai/code/session_01B5Ae9uqneVqkQXZrmz9Qqm

---
_Generated by [Claude Code](https://claude.ai/code/session_01B5Ae9uqneVqkQXZrmz9Qqm)_