### PR TITLE
chore(backlog): plan the Zer0-Mistake Quality Framework (roadmap v1.13, T-012–T-015)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Zer0-Mistake Quality Framework (planning)**: new roadmap milestone v1.13 and backlog tasks T-012–T-015 to close the gap between the repo's quality gates and what CI enforces — CI gate parity with the canonical `./scripts/bin/test` entrypoint (whose integration suites previously rotted unnoticed), re-armed pixel-snapshot and docs link-check gates, and a locale-independence regression guard; coverage baseline task T-005 repointed at the new milestone
+
 ### Fixed
 - **Tooling encoding**: `generate-roadmap.rb`, `sync-backlog.rb`, and `scripts/bin/validate` now read repo files as UTF-8 explicitly, fixing `invalid byte sequence in US-ASCII` crashes in environments without a UTF-8 locale (minimal containers, some CI runners) — `generate-roadmap.sh --check` and `validate --quick` both crashed in such environments
 - **Test suite**: repaired the three test suites that failed on `main`:

--- a/README.md
+++ b/README.md
@@ -833,6 +833,7 @@ gantt
     section Current
     v1.12 Headless Endpoints     :active, 2026-06, 2026-06
     section Future
+    v1.13 Zer0-Mistake Quality Framework :2026-06, 2026-08
     v2.0 CMS Integration         :2026-06, 2026-08
     v2.1 i18n Support            :2026-08, 2026-10
     v2.2 Advanced Analytics      :2026-10, 2026-12
@@ -864,6 +865,7 @@ gantt
 | **v1.10** | ✅ Completed | Jun 2026 | Roadmap integrity validation and catch-up milestones so the roadmap tracks the shipped gem. |
 | **v1.11** | ✅ Completed | Jun 2026 | Self-sustaining backlog loop so AI agents keep improving the repo between human sessions. |
 | **v1.12** | 🚧 In Progress | Current (1.12.x) | Machine-readable site endpoints for downstream sites and AI agents. |
+| **v1.13** | 🗓 Planned | Q3 2026 | Close the gap between the repo's quality gates and what CI actually enforces — no mistake lands green. |
 | **v2.0** | 🗓 Planned | Q3 2026 | Headless CMS integration with a content API and admin dashboard. |
 | **v2.1** | 🗓 Planned | Q4 2026 | Multi-language content support with locale-aware routing. |
 | **v2.2** | 🗓 Planned | Q4 2026 | Visual theme customizer, A/B testing, and conversion funnels. |

--- a/_data/backlog.yml
+++ b/_data/backlog.yml
@@ -56,7 +56,7 @@
 meta:
   title: "zer0-mistakes Backlog"
   updated: 2026-06-10
-  next_id: 12
+  next_id: 16
 
 tasks:
   # --- Housekeeping (seeded so the loop has work on day one) ------------------
@@ -145,7 +145,7 @@ tasks:
     updated: 2026-05-31
 
   - id: T-005
-    title: "Coverage baseline: identify the lowest-covered subsystems toward the v1.0 90% goal"
+    title: "Coverage baseline: identify the lowest-covered subsystems toward the 90% goal"
     status: open
     priority: P1
     area: tests
@@ -153,16 +153,17 @@ tasks:
     effort: L
     source: roadmap
     summary: >-
-      The v1.0 milestone targets 90%+ automated test coverage. Produce a
-      coverage baseline and file follow-up tasks for the lowest-covered areas
-      (start with the modular installer and the Obsidian resolver paths).
+      The 3.0 LTS milestone targets 90%+ automated test coverage, and the v1.13
+      Zer0-Mistake Quality Framework starts with knowing where coverage stands.
+      Produce a coverage baseline and file follow-up tasks for the lowest-covered
+      areas (start with the modular installer and the Obsidian resolver paths).
     acceptance:
       - "A coverage baseline is recorded (test/coverage or a docs note)."
       - "The 2–3 lowest-covered subsystems are identified and filed as new backlog tasks."
       - "No reduction in existing passing tests (`./scripts/bin/test` stays green)."
-    links: { issue: null, pr: null, roadmap: "1.0" }
+    links: { issue: null, pr: null, roadmap: "1.13" }
     created: 2026-05-31
-    updated: 2026-05-31
+    updated: 2026-06-10
 
   # --- 2026-06-01 audit -------------------------------------------------------
 
@@ -276,3 +277,97 @@ tasks:
     links: { issue: null, pr: null, roadmap: "3.0" }
     created: 2026-06-01
     updated: 2026-06-01
+
+  # --- 2026-06-10 Zer0-Mistake Quality Framework (roadmap v1.13) --------------
+  #
+  # Origin: main carried 3 failing test suites and 2 crashing validators while
+  # every CI check stayed green (fixed in PR #132). Root cause: the PR gate runs
+  # only a subset of the canonical test entrypoint, and two checks are warn-only.
+  # These tasks close the gap between the quality gates and what CI enforces.
+
+  - id: T-012
+    title: "CI gate parity: run the full canonical test entrypoint on PRs"
+    status: open
+    priority: P1
+    area: infra
+    risk: standard
+    effort: M
+    source: roadmap
+    summary: >-
+      `ci.yml`'s test job runs `test/test_runner.sh --suites core,quality,installation`,
+      which skips the lib unit tests (`scripts/test/lib/`), the integration suites
+      (`scripts/test/integration/` — exactly the ones that rotted unnoticed before
+      PR #132), the obsidian suite, and the installer e2e suites that
+      `./scripts/bin/test` runs locally. PRs must gate on the same entrypoint
+      contributors are told to run.
+    acceptance:
+      - "The `ci.yml` test job executes `./scripts/bin/test` (or an explicit suite list that includes lib, integration, obsidian, and installer e2e) on every code PR."
+      - "A deliberately broken integration test fails CI in a draft PR experiment (then reverted)."
+      - "`.github/workflows/README.md` documents which gates run on PR vs push vs schedule."
+      - "Total PR wall-clock stays under 25 minutes (parallelize jobs if needed)."
+    links: { issue: null, pr: null, roadmap: "1.13" }
+    created: 2026-06-10
+    updated: 2026-06-10
+
+  - id: T-013
+    title: "Refresh Playwright snapshot baselines and re-arm the pixel gate"
+    status: open
+    priority: P2
+    area: tests
+    risk: standard
+    effort: M
+    source: roadmap
+    summary: >-
+      The snapshot tier in `ci.yml` is `continue-on-error: true` because the
+      committed baselines predate the PR #108 UI overhaul. Regenerate the Linux
+      baselines via `./test/update-snapshots.sh` and make the tier blocking again
+      so visual regressions cannot land silently.
+    acceptance:
+      - "Baselines under `test/visual/snapshots/` regenerated and committed."
+      - "`continue-on-error: true` removed from the snapshot step in `ci.yml`."
+      - "Snapshot tier passes in CI on an unchanged follow-up commit."
+    links: { issue: null, pr: null, roadmap: "1.13" }
+    created: 2026-06-10
+    updated: 2026-06-10
+
+  - id: T-014
+    title: "Re-arm the docs link-check gate (remove warn-only || true)"
+    status: open
+    priority: P2
+    area: lint
+    risk: standard
+    effort: M
+    source: roadmap
+    summary: >-
+      `docs-validate.yml` runs markdown-link-check with `|| true` ("warn-only
+      until baseline is clean"), so broken links accumulate. Fix the links it
+      currently reports, then drop the `|| true` so the gate blocks.
+    acceptance:
+      - "All links reported by the current `docs-validate.yml` run are fixed or allowlisted in `.github/config/.markdown-link-check.json`."
+      - "Both `|| true` suppressions removed from `docs-validate.yml`."
+      - "`docs-validate.yml` passes blocking on a follow-up PR."
+    links: { issue: null, pr: null, roadmap: "1.13" }
+    created: 2026-06-10
+    updated: 2026-06-10
+
+  - id: T-015
+    title: "Locale-independence regression guard for Ruby/Bash tooling"
+    status: open
+    priority: P2
+    area: infra
+    risk: standard
+    effort: S
+    source: roadmap
+    summary: >-
+      PR #132 fixed `invalid byte sequence in US-ASCII` crashes in
+      `generate-roadmap.rb`, `sync-backlog.rb`, and `scripts/bin/validate` that
+      only reproduced without a UTF-8 locale. Add a guard so the bug class
+      cannot return: run the validators under `LC_ALL=C` in a lib test or a
+      dedicated CI step.
+    acceptance:
+      - "A test (scripts/test/lib/) or CI step runs `generate-roadmap.rb --check`, `sync-backlog.rb --check`, and `validate --quick` with `LC_ALL=C LANG=C`."
+      - "The guard fails when the explicit-UTF-8 reads are reverted (verified once locally)."
+      - "`./scripts/bin/test` stays green."
+    links: { issue: null, pr: null, roadmap: "1.13" }
+    created: 2026-06-10
+    updated: 2026-06-10

--- a/_data/roadmap.yml
+++ b/_data/roadmap.yml
@@ -330,6 +330,22 @@ milestones:
 
   # --- Future ----------------------------------------------------------------
 
+  - version: "1.13"
+    title: "Zer0-Mistake Quality Framework"
+    status: planned
+    section: Future
+    start: 2026-06
+    end: 2026-08
+    target: "Q3 2026"
+    summary: "Close the gap between the repo's quality gates and what CI actually enforces — no mistake lands green."
+    features:
+      - "CI gate parity — PRs run the full canonical test entrypoint (lib unit, theme, integration, installer e2e), not a subset"
+      - "Re-armed pixel-snapshot gate (refreshed baselines, no `continue-on-error`)"
+      - "Re-armed docs link-check gate (clean baseline, no warn-only `|| true`)"
+      - "Locale-independence regression guard for the Ruby/Bash tooling"
+      - "Coverage baseline with follow-up tasks for the lowest-covered subsystems"
+      - "Documented required status checks per branch (the 'controls' contract)"
+
   - version: "2.0"
     title: "CMS Integration"
     status: planned


### PR DESCRIPTION
## Summary

Answers "how do we ensure zero mistakes are made?" the way this repo is designed to: by encoding the strategy into the planning system (`_data/roadmap.yml` + `_data/backlog.yml`) so the continuous-evolution loop implements it task by task.

**The evidence (from PR #132):** `main` carried 3 failing test suites and 2 crashing validators while every CI check stayed green. Root cause: the PR gate runs `test/test_runner.sh --suites core,quality,installation` — a subset that skips the lib unit tests, the integration suites (exactly the ones that rotted), the obsidian suite, and the installer e2e suites that the canonical `./scripts/bin/test` runs. On top of that, two checks are deliberately warn-only (`continue-on-error: true` on the Playwright snapshot tier, `|| true` on the docs link check).

## Changes

### Roadmap — new planned milestone **v1.13 "Zer0-Mistake Quality Framework"** (Q3 2026)
> Close the gap between the repo's quality gates and what CI actually enforces — no mistake lands green.

### Backlog — four new tasks (all `roadmap`-sourced, linked to v1.13)

| Task | Priority | What it closes |
|---|---|---|
| **T-012** CI gate parity | P1 | PR CI runs the full canonical `./scripts/bin/test` entrypoint (lib + theme + integration + installer e2e), with a workflow README documenting which gates run on PR vs push vs schedule |
| **T-013** Re-arm the pixel gate | P2 | Regenerate the stale Playwright snapshot baselines, then drop `continue-on-error` from the snapshot tier |
| **T-014** Re-arm the docs link gate | P2 | Fix the links the warn-only check currently reports, then remove both `\|\| true` suppressions from `docs-validate.yml` |
| **T-015** Locale-independence guard | P2 | Run the validators under `LC_ALL=C` in a test/CI step so the UTF-8 crash class fixed in #132 can't return |

Also: **T-005** (coverage baseline, P1) repointed from the completed v1.0 milestone to v1.13 — it's the framework's measurement pillar.

### Generated/bookkeeping
- README roadmap (gantt + table) regenerated by `generate-roadmap.sh`
- `CHANGELOG.md` `[Unreleased]` entry
- `meta.next_id` → 16, dates refreshed

## Validation

- `ruby scripts/sync-backlog.rb --check` — valid (14 tasks)
- `./scripts/generate-roadmap.sh --check` / `--validate` — clean, zero warnings
- `./scripts/bin/test` — 10/10 suites pass

On merge, `backlog-sync.yml` creates `agent-ready` issues for T-012–T-015; the implement routine (or anyone) can then pick them up — T-012 first by priority.

No version bump (releases stay human-driven).

https://claude.ai/code/session_01B5Ae9uqneVqkQXZrmz9Qqm

---
_Generated by [Claude Code](https://claude.ai/code/session_01B5Ae9uqneVqkQXZrmz9Qqm)_