### PR TITLE
feat(tests): plugin unit specs and coverage baseline — T-011, T-005

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- **Plugin unit specs (T-011)**: 19 Minitest specs for the previously-untested `preview_image_generator.rb`, `content_statistics_generator.rb`, and `admin_page_urls.rb` plugins (config merge, path normalization, index dedupe by relative path, hook output, edge cases); wired into the core suite as "Plugin Unit Specs"
+- **Coverage baseline (T-005)**: structural survey recorded at `docs/development/coverage-baseline.md` — 10/10 suites green; the two remaining zero-coverage subsystems filed as T-019 (migrate.sh + theme_version.rb) and T-020 (installer wizard/upgrade)
+
 ## [1.16.0] - 2026-06-12
 
 ### Changed
@@ -16,8 +22,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - **AI Chat Assistant (ZER0-060)**: opt-in floating chat widget grounded in the current page's content, with proxy-first auth — renders nothing until `ai_chat.enabled` plus a deployed proxy (`proxy_ready: true`) or an explicit direct-mode key are configured; FAB positioning/stacking driven by the design tokens (new `--zer0-layer-fab-chat`)
-- **Plugin unit specs (T-011)**: 19 Minitest specs for the previously-untested `preview_image_generator.rb`, `content_statistics_generator.rb`, and `admin_page_urls.rb` plugins (config merge, path normalization, index dedupe by relative path, hook output, edge cases); wired into the core suite as "Plugin Unit Specs"
-- **Coverage baseline (T-005)**: structural survey recorded at `docs/development/coverage-baseline.md` — 10/10 suites green; the two remaining zero-coverage subsystems filed as T-019 (migrate.sh + theme_version.rb) and T-020 (installer wizard/upgrade)
 
 ### Fixed
 - **Chat render guard**: the original guard used boolean expressions inside Liquid `assign` tags (always truthy), which would have rendered a dead chat button on every page; computed with if-tags instead

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - **AI Chat Assistant (ZER0-060)**: opt-in floating chat widget grounded in the current page's content, with proxy-first auth — renders nothing until `ai_chat.enabled` plus a deployed proxy (`proxy_ready: true`) or an explicit direct-mode key are configured; FAB positioning/stacking driven by the design tokens (new `--zer0-layer-fab-chat`)
+- **Plugin unit specs (T-011)**: 19 Minitest specs for the previously-untested `preview_image_generator.rb`, `content_statistics_generator.rb`, and `admin_page_urls.rb` plugins (config merge, path normalization, index dedupe by relative path, hook output, edge cases); wired into the core suite as "Plugin Unit Specs"
+- **Coverage baseline (T-005)**: structural survey recorded at `docs/development/coverage-baseline.md` — 10/10 suites green; the two remaining zero-coverage subsystems filed as T-019 (migrate.sh + theme_version.rb) and T-020 (installer wizard/upgrade)
 
 ### Fixed
 - **Chat render guard**: the original guard used boolean expressions inside Liquid `assign` tags (always truthy), which would have rendered a dead chat button on every page; computed with if-tags instead

--- a/_data/backlog.yml
+++ b/_data/backlog.yml
@@ -56,7 +56,7 @@
 meta:
   title: "zer0-mistakes Backlog"
   updated: 2026-06-12
-  next_id: 19
+  next_id: 21
 
 tasks:
   # --- Housekeeping (seeded so the loop has work on day one) ------------------
@@ -155,7 +155,7 @@ tasks:
 
   - id: T-005
     title: "Coverage baseline: identify the lowest-covered subsystems toward the 90% goal"
-    status: open
+    status: done
     priority: P1
     area: tests
     risk: standard
@@ -166,13 +166,17 @@ tasks:
       Zer0-Mistake Quality Framework starts with knowing where coverage stands.
       Produce a coverage baseline and file follow-up tasks for the lowest-covered
       areas (start with the modular installer and the Obsidian resolver paths).
+      Done 2026-06-12: baseline recorded at docs/development/coverage-baseline.md
+      (refreshed from the closed PR #122 survey against the current tree);
+      remaining gaps filed as T-019 (migrate.sh + theme_version.rb) and
+      T-020 (installer wizard/upgrade CI coverage).
     acceptance:
       - "A coverage baseline is recorded (test/coverage or a docs note)."
       - "The 2–3 lowest-covered subsystems are identified and filed as new backlog tasks."
       - "No reduction in existing passing tests (`./scripts/bin/test` stays green)."
     links: { issue: null, pr: null, roadmap: "1.13" }
     created: 2026-05-31
-    updated: 2026-06-10
+    updated: 2026-06-12
 
   # --- 2026-06-01 audit -------------------------------------------------------
 
@@ -273,7 +277,7 @@ tasks:
 
   - id: T-011
     title: "Add Ruby unit tests for uncovered _plugins/ generators"
-    status: open
+    status: done
     priority: P2
     area: tests
     risk: standard
@@ -285,6 +289,11 @@ tasks:
       URL-pattern checks (`test_preview_image_urls`) but no specs that exercise the
       generator logic in isolation. This is a concrete gap on the path to the
       3.0-milestone 90% coverage target.
+      Done 2026-06-12: test/test_plugins.rb — 19 Minitest specs covering all
+      three plugins (config merge, path normalization, index dedupe by
+      relative_path, filename sanitization, hook output/filtering/sorting,
+      script discovery with theme fallback); wired into test_core.sh as the
+      "Plugin Unit Specs" unit test; runs standalone without a Jekyll server.
     acceptance:
       - "`test/test_ruby_converter.rb`-style RSpec or Minitest specs exist for all three plugins."
       - "Each spec runs independently without a running Jekyll server (`bundle exec ruby -Itest`)."
@@ -292,7 +301,7 @@ tasks:
       - "Edge cases covered: empty collections, missing front-matter keys, and duplicate slug detection."
     links: { issue: null, pr: null, roadmap: "3.0" }
     created: 2026-06-01
-    updated: 2026-06-01
+    updated: 2026-06-12
 
   # --- 2026-06-10 Zer0-Mistake Quality Framework (roadmap v1.13) --------------
   #
@@ -477,3 +486,47 @@ tasks:
     links: { issue: null, pr: null, roadmap: "1.13" }
     created: 2026-06-11
     updated: 2026-06-11
+
+  - id: T-019
+    title: "Unit tests for migrate.sh and theme_version.rb (coverage rank #1)"
+    status: open
+    priority: P2
+    area: tests
+    risk: standard
+    effort: M
+    source: audit
+    summary: >-
+      The 2026-06-12 coverage baseline (docs/development/coverage-baseline.md,
+      T-005) ranks scripts/lib/migrate.sh (265 lines, 5 functions: site
+      detection, theme connection, admin-page install/verify, version-gap
+      detection) plus _plugins/theme_version.rb (88 lines) as the largest
+      remaining zero-coverage surface (353 lines).
+    acceptance:
+      - "scripts/test/lib/test_migrate.sh exercises detect_jekyll_site, validate_theme_connection, and detect_version_gap against fixture directories."
+      - "test/test_plugins.rb (or a sibling spec) covers theme_version.rb's version resolution."
+      - "./scripts/bin/test stays green with the new specs included."
+    links: { issue: null, pr: null, roadmap: "1.14" }
+    created: 2026-06-12
+    updated: 2026-06-12
+
+  - id: T-020
+    title: "CI coverage for installer interactive wizard and upgrade path (coverage rank #2)"
+    status: open
+    priority: P2
+    area: tests
+    risk: standard
+    effort: M
+    source: audit
+    summary: >-
+      Per the T-005 baseline, scripts/lib/install/wizard_interactive.sh (189
+      lines — prompt helpers need a TTY) and scripts/lib/install/upgrade.sh
+      (184 lines) have effectively no CI coverage. Drive the wizard with
+      scripted stdin (the suite pattern in test_install_legacy_flags.sh) and
+      add an upgrade-path fixture (old-version site → upgrade → assert state).
+    acceptance:
+      - "Wizard prompt helpers exercised non-interactively (piped answers) in a test_install_* suite."
+      - "An upgrade fixture covers detect→migrate→verify for at least one version gap."
+      - "Suites run in CI via the standard installer e2e discovery (test_install_*.sh)."
+    links: { issue: null, pr: null, roadmap: "1.14" }
+    created: 2026-06-12
+    updated: 2026-06-12

--- a/docs/development/coverage-baseline.md
+++ b/docs/development/coverage-baseline.md
@@ -1,0 +1,120 @@
+---
+title: "Test Coverage Baseline"
+description: "Structural coverage baseline recorded as part of T-005. Identifies the lowest-covered subsystems and links to the follow-up backlog tasks."
+date: 2026-06-12T00:00:00.000Z
+lastmod: 2026-06-12T00:00:00.000Z
+categories: [docs, development]
+tags: [development, testing, coverage]
+author: bamr87
+---
+
+# Test Coverage Baseline — 2026-06-12
+
+Recorded as part of T-005 (Zer0-Mistake Quality Framework, roadmap v1.14;
+coverage end-goal lives in the v3.0 LTS milestone: ≥90% automated coverage).
+This document establishes the baseline from which that goal is measured and
+identifies the subsystems that need the most attention.
+
+## How coverage is estimated here
+
+Ruby and shell have no off-the-shelf combined coverage tool in this repo.
+Coverage is estimated **structurally**: for each source module we count
+(a) the dedicated test files that reference it and (b) the number of
+exercisable code paths (functions / methods). A subsystem with zero dedicated
+test files and ≥1 function is rated "uncovered".
+
+`./scripts/bin/test` results as of this baseline: **10 of 10 suites pass**,
+and since T-012 the same suites gate every code PR in CI (no local/CI drift).
+
+---
+
+## Subsystem inventory
+
+### 1 · Obsidian integration — HIGH coverage ✅
+
+**Dedicated tests:** `test/test_obsidian.sh` (orchestrator),
+`test/test_ruby_converter.rb` (23 runs / 70 assertions),
+`test/test_resolver.js` (DOM-shim resolver suite)
+
+All three rendering paths (Ruby converter → JSON index → JS resolver) have
+dedicated unit tests plus a build smoke test asserting `wiki-index.json`
+shape. Best-covered subsystem in the repo.
+
+### 2 · Jekyll plugins — HIGH coverage ✅ *(was the #1 gap)*
+
+**Dedicated tests:** `test/test_plugins.rb` (19 runs / 29 assertions, T-011),
+wired into the core suite (`test_core.sh` → "Plugin Unit Specs").
+
+| Source | Lines | Covered by |
+|--------|------:|------------|
+| `_plugins/preview_image_generator.rb` | 350 | `test_plugins.rb` (config, path normalization, index dedupe, filename sanitization, existence checks) |
+| `_plugins/content_statistics_generator.rb` | 69 | `test_plugins.rb` (script discovery incl. theme fallback) |
+| `_plugins/admin_page_urls.rb` | 16 | `test_plugins.rb` (hook output, filtering, sorting) |
+| `_plugins/theme_version.rb` | 88 | ❌ none — see T-019 |
+
+### 3 · Release tooling — MODERATE coverage ⚠️ *(was the #2 gap)*
+
+| Source | Lines | Covered by |
+|--------|------:|------------|
+| `scripts/lib/changelog.sh` | ~400 | `scripts/test/lib/test_changelog.sh` (categorization, message cleaning, Unreleased folding, insertion/normalization) |
+| `scripts/lib/version.sh`, `gem.sh`, `git.sh`, `validation.sh` | — | `scripts/test/lib/test_*.sh` (84 assertions total incl. the T-015 locale guard) |
+| `scripts/lib/migrate.sh` | 265 | ❌ none — see T-019 |
+
+### 4 · Modular installer — MODERATE coverage ⚠️
+
+**Dedicated tests:** `test/test_installer.sh` (profile matrix, deploy
+plug-ins, agent files), `test/test_install_*.sh` (6 focused e2e suites,
+all gating CI since T-012).
+
+Remaining gaps (see T-020):
+
+- **`scripts/lib/install/wizard_interactive.sh`** (189 lines): the prompt
+  helpers and `wizard_interactive_run` have zero CI coverage (the `--ai`
+  tier needs `OPENAI_API_KEY`; the interactive tier needs a TTY).
+- **`scripts/lib/install/upgrade.sh`** (184 lines): the migration/upgrade
+  path for an existing site has no dedicated assertions.
+
+### 5 · Consumer audit tooling — MODERATE coverage ✅
+
+`scripts/bin/{audit-consumer,manifest,sync-plugins}` + `scripts/lib/audit.sh`
+are covered by `test/test_audit.sh` (18 assertions against gem/remote
+fixtures), gating CI via the `audit` suite.
+
+### 6 · SCSS / assets — INDIRECT coverage ⚠️
+
+Playwright smoke tier asserts CSS load, Bootstrap tokens, and behavioral DOM
+on every code PR. The pixel-snapshot tier exists but is warn-only until its
+baselines are refreshed (T-013). No SCSS unit tests.
+
+### 7 · Layouts / includes — INDIRECT coverage ⚠️
+
+Front matter validated by `test_core.sh` and `scripts/lint-pages --strict`
+(all 163 pages, schema-driven); rendering confirmed by Jekyll build smoke
+tests; live DOM checked by the Playwright smoke tier (including the T-009
+secret-exposure regression test).
+
+---
+
+## 🔴 Lowest-covered subsystems (filed as follow-up tasks)
+
+| Rank | Subsystem | Source lines | Dedicated tests | Backlog task |
+|------|-----------|-------------:|-----------------|--------------|
+| 1 | `scripts/lib/migrate.sh` + `_plugins/theme_version.rb` | 353 | 0 | T-019 |
+| 2 | Installer interactive wizard + upgrade path | 373 | ~0 in CI | T-020 |
+
+(The previous baseline's #1 gap — Jekyll plugins, 523 lines / 0 tests — was
+closed by T-011 on 2026-06-12; `changelog.sh` was closed by the
+`test_changelog.sh` suite during the framework's first wave.)
+
+---
+
+## Methodology notes
+
+- Line counts from `wc -l` on 2026-06-12; they drift as files change.
+- "Dedicated tests" = test files that explicitly import, source, or name the
+  module under test (verified with `grep -l`).
+- Indirect coverage (a module called by a higher-level test but not directly
+  asserted) is noted but not counted as "covered" for baseline purposes.
+- No numeric percentage yet: no line-instrumentation tool is wired into CI.
+  A future task should wire `simplecov` (Ruby) and `bashcov`/`kcov` (shell)
+  to replace this structural estimate with measured percentages.

--- a/test/test_core.sh
+++ b/test/test_core.sh
@@ -232,6 +232,16 @@ test_yaml_syntax() {
     return 0
 }
 
+# Test plugin unit specs (T-011: content statistics, preview images, admin URLs)
+test_plugin_unit_specs() {
+    if command -v ruby &>/dev/null; then
+        ruby "$SCRIPT_DIR/test_plugins.rb" > /dev/null 2>&1
+    else
+        log_warning "ruby not available, skipping plugin unit specs"
+        return 0
+    fi
+}
+
 test_gemspec_validity() {
     log_info "Validating gemspec file..."
     
@@ -627,6 +637,7 @@ run_core_tests() {
     run_test "Gemspec Validity" "test_gemspec_validity" "unit"
     run_test "Package.json Validity" "test_package_json_validity" "unit"
     run_test "Version Consistency" "test_version_consistency" "unit"
+    run_test "Plugin Unit Specs" "test_plugin_unit_specs" "unit"
     
     # Integration Tests
     log_info "=== INTEGRATION TESTS ==="

--- a/test/test_plugins.rb
+++ b/test/test_plugins.rb
@@ -1,0 +1,245 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+#
+# test_plugins.rb — Standalone unit tests for the previously-uncovered
+# Jekyll plugins (T-011):
+#
+#   _plugins/admin_page_urls.rb              (pre_render hook)
+#   _plugins/content_statistics_generator.rb (after_init hook helpers)
+#   _plugins/preview_image_generator.rb      (config/path/index logic)
+#
+# Follows the test_ruby_converter.rb pattern: stub Jekyll/Liquid just enough
+# that requiring the plugins doesn't boot Jekyll, then drive the pure logic
+# with Structs. Runs standalone: `ruby test/test_plugins.rb`.
+#
+
+require 'minitest/autorun'
+require 'tmpdir'
+require 'fileutils'
+
+# --- Minimal Jekyll/Liquid stubs (capture hook blocks so tests can fire them)
+module Jekyll
+  module Hooks
+    @registered = {}
+
+    def self.register(owner, event, &block)
+      (@registered[[owner, event]] ||= []) << block
+    end
+
+    def self.fire(owner, event, payload)
+      Array(@registered[[owner, event]]).each { |b| b.call(payload) }
+    end
+  end
+
+  class Logger
+    def info(*); end
+    def warn(*); end
+    def debug(*); end
+  end
+
+  def self.logger
+    @logger ||= Logger.new
+  end
+
+  class Generator
+    def self.safe(*); end
+    def self.priority(*); end
+  end
+end
+
+module Liquid
+  class Tag
+    def initialize(*); end
+  end
+
+  class Template
+    def self.register_filter(*); end
+    def self.register_tag(*); end
+  end
+end
+
+require_relative '../_plugins/admin_page_urls'
+require_relative '../_plugins/content_statistics_generator'
+require_relative '../_plugins/preview_image_generator'
+
+FakePage = Struct.new(:output_ext, :url)
+FakeSite = Struct.new(:pages, :data, :config, :source, :theme, :collections) do
+  def respond_to_missing?(name, _ = false)
+    name == :posts ? false : super
+  end
+end
+FakeDoc = Struct.new(:data, :site, :relative_path, :basename_without_ext)
+
+# ---------------------------------------------------------------------------
+class AdminPageUrlsTest < Minitest::Test
+  def fire(pages)
+    site = FakeSite.new(pages, {}, {}, nil, nil, nil)
+    Jekyll::Hooks.fire(:site, :pre_render, site)
+    site.data['admin_page_urls']
+  end
+
+  def test_collects_sorted_pipe_delimited_admin_urls
+    urls = fire([
+      FakePage.new('.html', '/about/settings/theme/'),
+      FakePage.new('.html', '/about/config/'),
+      FakePage.new('.html', '/docs/intro/')
+    ])
+    assert_equal '|/about/config/|/about/settings/theme/|', urls
+  end
+
+  def test_excludes_non_html_outputs
+    urls = fire([FakePage.new('.json', '/about/feed.json'),
+                 FakePage.new('.html', '/about/config/')])
+    assert_equal '|/about/config/|', urls
+  end
+
+  def test_empty_when_no_admin_pages
+    assert_equal '', fire([FakePage.new('.html', '/docs/intro/')])
+  end
+end
+
+# ---------------------------------------------------------------------------
+class ContentStatisticsGeneratorTest < Minitest::Test
+  def test_finds_script_in_site_source
+    Dir.mktmpdir do |dir|
+      FileUtils.mkdir_p(File.join(dir, '_data'))
+      script = File.join(dir, '_data', 'generate_statistics.rb')
+      File.write(script, '# stub')
+      site = FakeSite.new([], {}, {}, dir, nil, nil)
+      assert_equal script, Jekyll::ContentStatisticsBuild.generator_script(site)
+    end
+  end
+
+  def test_falls_back_to_theme_root
+    Dir.mktmpdir do |site_dir|
+      Dir.mktmpdir do |theme_dir|
+        FileUtils.mkdir_p(File.join(theme_dir, '_data'))
+        script = File.join(theme_dir, '_data', 'generate_statistics.rb')
+        File.write(script, '# stub')
+        theme = Struct.new(:root_dir).new(theme_dir)
+        site = FakeSite.new([], {}, {}, site_dir, theme, nil)
+        assert_equal script, Jekyll::ContentStatisticsBuild.generator_script(site)
+      end
+    end
+  end
+
+  def test_nil_when_script_missing_everywhere
+    Dir.mktmpdir do |dir|
+      site = FakeSite.new([], {}, {}, dir, nil, nil)
+      assert_nil Jekyll::ContentStatisticsBuild.generator_script(site)
+    end
+  end
+end
+
+# ---------------------------------------------------------------------------
+class PreviewImageGeneratorTest < Minitest::Test
+  PIG = Jekyll::PreviewImageGenerator
+
+  def site_with(config: {}, source: Dir.tmpdir, collections: {})
+    FakeSite.new([], {}, { 'preview_images' => config }, source, nil, collections)
+  end
+
+  def doc_with(data, site, relative_path: 'pages/_posts/example.md', basename: 'example')
+    FakeDoc.new(data, site, relative_path, basename)
+  end
+
+  # --- config -------------------------------------------------------------
+  def test_config_merges_site_overrides_onto_defaults
+    cfg = PIG.config(site_with(config: { 'provider' => 'xai' }))
+    assert_equal 'xai', cfg['provider']
+    assert_equal 'assets/images/previews', cfg['output_dir'] # default kept
+  end
+
+  def test_config_handles_missing_block
+    site = FakeSite.new([], {}, {}, Dir.tmpdir, nil, {})
+    assert_equal PIG::DEFAULTS, PIG.config(site)
+  end
+
+  # --- normalize_preview_path ----------------------------------------------
+  def test_normalize_adds_assets_prefix
+    assert_equal '/assets/images/p.png',
+                 PIG.normalize_preview_path('/images/p.png', PIG::DEFAULTS)
+  end
+
+  def test_normalize_leaves_prefixed_and_http_paths
+    assert_equal '/assets/images/p.png',
+                 PIG.normalize_preview_path('/assets/images/p.png', PIG::DEFAULTS)
+    assert_equal 'http://x/p.png', PIG.normalize_preview_path('http://x/p.png', PIG::DEFAULTS)
+  end
+
+  def test_normalize_respects_auto_prefix_off
+    cfg = PIG::DEFAULTS.merge('auto_prefix' => false)
+    assert_equal '/images/p.png', PIG.normalize_preview_path('/images/p.png', cfg)
+  end
+
+  # --- has_preview? / preview_path edge cases ------------------------------
+  def test_missing_front_matter_key_is_not_a_preview
+    site = site_with
+    refute PIG.has_preview?(doc_with({}, site))
+    assert_nil PIG.preview_path(doc_with({}, site))
+  end
+
+  def test_text_description_is_rejected
+    site = site_with
+    doc = doc_with({ 'preview' => 'a lovely banner of mountains' }, site)
+    refute PIG.has_preview?(doc)
+    assert_nil PIG.preview_path(doc)
+  end
+
+  def test_external_url_counts_as_preview
+    site = site_with
+    doc = doc_with({ 'preview' => 'https://cdn.example/p.png' }, site)
+    assert PIG.has_preview?(doc)
+    assert_equal 'https://cdn.example/p.png', PIG.preview_path(doc)
+  end
+
+  def test_local_preview_must_exist_on_disk
+    Dir.mktmpdir do |dir|
+      site = site_with(source: dir)
+      doc = doc_with({ 'preview' => '/images/previews/p.png' }, site)
+      refute PIG.has_preview?(doc), 'missing file should not count'
+
+      FileUtils.mkdir_p(File.join(dir, 'assets', 'images', 'previews'))
+      File.write(File.join(dir, 'assets', 'images', 'previews', 'p.png'), 'x')
+      assert PIG.has_preview?(doc), 'existing file should count'
+      assert_equal '/assets/images/previews/p.png', PIG.preview_path(doc)
+    end
+  end
+
+  # --- build_index (empty collections, duplicate slugs) --------------------
+  def collection_with(docs)
+    Struct.new(:docs).new(docs)
+  end
+
+  def test_build_index_with_empty_collections
+    site = site_with(config: { 'collections' => ['docs'] }, collections: {})
+    index = PIG.build_index(site)
+    assert_equal({}, index['documents'])
+    assert_equal [], index['missing']
+  end
+
+  def test_build_index_deduplicates_by_relative_path
+    Dir.mktmpdir do |dir|
+      site = site_with(config: { 'collections' => %w[docs quickstart] }, source: dir)
+      dup = doc_with({ 'title' => 'Dup' }, site, relative_path: 'pages/_docs/dup.md', basename: 'dup')
+      site.collections = { 'docs' => collection_with([dup]), 'quickstart' => collection_with([dup]) }
+      index = PIG.build_index(site)
+      assert_equal 1, index['documents'].size, 'same relative_path indexed once'
+      assert_equal 1, index['missing'].size
+      assert_equal 'docs', index['documents']['pages/_docs/dup.md']['collection']
+    end
+  end
+
+  # --- generate_filename ----------------------------------------------------
+  def test_generate_filename_sanitizes_slug
+    site = site_with
+    doc = doc_with({ 'slug' => 'Héllo World! (v2)' }, site, basename: 'ignored')
+    assert_equal 'h-llo-world-v2-preview.png', PIG.generate_filename(doc)
+  end
+
+  def test_generate_filename_falls_back_to_basename
+    site = site_with
+    doc = doc_with({}, site, basename: 'my-post')
+    assert_equal 'my-post-preview.png', PIG.generate_filename(doc)
+  end
+end


### PR DESCRIPTION
## Summary

Two more framework tasks done — closes **#127 (T-011)** and **#119 (T-005)** on the backlog sync.

## T-011 — Plugin unit specs

`test/test_plugins.rb`: **19 Minitest specs** for the three previously-untested plugins, following the `test_ruby_converter.rb` standalone pattern (Jekyll/Liquid stubbed, no server, hook blocks captured and fired directly):

- `preview_image_generator.rb` (350 lines): config merge onto defaults, `assets_prefix`/`auto_prefix` path normalization, text-description rejection, external-URL handling, on-disk existence checks, **index dedupe by relative path**, empty-collection handling, filename sanitization
- `content_statistics_generator.rb`: generator-script discovery (site source → theme-root fallback → nil)
- `admin_page_urls.rb`: pipe-delimited output, non-HTML filtering, sorting, empty case

Wired into `test_core.sh` as the "Plugin Unit Specs" unit test, so it gates every code PR.

## T-005 — Coverage baseline

`docs/development/coverage-baseline.md`: structural coverage survey of every subsystem, refreshed from the closed #122's survey against today's tree. Notably, **two of the three gaps that survey found have since been closed** (plugins by T-011 in this PR; `changelog.sh` by the framework's first wave). The remaining zero-coverage surfaces are filed as:

- **T-019**: `scripts/lib/migrate.sh` (265 lines) + `_plugins/theme_version.rb` (88 lines)
- **T-020**: installer interactive wizard + upgrade path (~373 lines, no CI coverage)

## Validation

- `./scripts/bin/test` — 10/10 (including the new core unit test)
- `test_plugins.rb` — 19 runs / 29 assertions, standalone
- `lint-pages --strict`, docs front matter, markdownlint on the new doc — clean
- `sync-backlog --check` — 19 tasks valid; `next_id` → 21

Remaining open framework tasks after this: T-007 (navbar WCAG), T-010 (quickstart docs), T-013 (snapshot baselines), T-018 (config sync), plus the new T-019/T-020.

No version bump.

https://claude.ai/code/session_01B5Ae9uqneVqkQXZrmz9Qqm

---
_Generated by [Claude Code](https://claude.ai/code/session_01B5Ae9uqneVqkQXZrmz9Qqm)_