### PR TITLE
fix(admin): sync config-page copy with live config and redact the Raw tab (T-018)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Admin config page sync (T-018)**: the page's config copy is now byte-synced with the live `_config.yml` (raw-wrapped so Liquid-looking comment text renders literally) and `validate` fails on drift; the **visible Raw-YAML tab** now applies the same sensitive-line redaction as the hidden copy element (it previously showed the raw file — the stale copy was the only thing keeping the live PostHog key off that tab); the raw-tab security test targets the real `code#cfg-raw-yaml` element and asserts presence instead of silently skipping
+
 ### Added
 - **Plugin unit specs (T-011)**: 19 Minitest specs for the previously-untested `preview_image_generator.rb`, `content_statistics_generator.rb`, and `admin_page_urls.rb` plugins (config merge, path normalization, index dedupe by relative path, hook output, edge cases); wired into the core suite as "Plugin Unit Specs"
 - **Coverage baseline (T-005)**: structural survey recorded at `docs/development/coverage-baseline.md` — 10/10 suites green; the two remaining zero-coverage subsystems filed as T-019 (migrate.sh + theme_version.rb) and T-020 (installer wizard/upgrade)

--- a/_data/backlog.yml
+++ b/_data/backlog.yml
@@ -465,7 +465,7 @@ tasks:
 
   - id: T-018
     title: "Admin config page displays a stale copy of _config.yml — keep it in sync safely"
-    status: open
+    status: done
     priority: P2
     area: feat
     risk: standard
@@ -479,13 +479,20 @@ tasks:
       refresh would inject the live `phc_` api_key into the *visible* Raw-YAML
       tab — any sync mechanism must sanitize the visible tab the same way
       T-009 sanitizes the hidden copy element, or redact at sync time.
+      Done 2026-06-12: copy synced (wrapped in Liquid raw markers so config
+      comments mentioning Liquid render literally); scripts/bin/validate
+      gains a drift check that fails when the copy diverges; the visible
+      Raw-YAML tab now renders the same sanitized capture as the hidden
+      element (live phc_ key verified redacted in both); the raw-tab
+      Playwright test targets code#cfg-raw-yaml and asserts presence
+      instead of silently skipping.
     acceptance:
       - "The config shown at /about/config/ matches the live `_config.yml` (automated sync step or build-time check that fails on drift)."
       - "The visible Raw-YAML tab applies the same sensitive-line redaction as the hidden `cfg-full-yaml` element."
       - "`test/visual/security.spec.js` raw-tab test passes without its silent skip path (locator matches the actual `code#cfg-raw-yaml` element)."
     links: { issue: null, pr: null, roadmap: "1.13" }
     created: 2026-06-11
-    updated: 2026-06-11
+    updated: 2026-06-12
 
   - id: T-019
     title: "Unit tests for migrate.sh and theme_version.rb (coverage rank #1)"

--- a/pages/_about/settings/_config.yml
+++ b/pages/_about/settings/_config.yml
@@ -1,5 +1,5 @@
-# Welcome to Jekyll!
-# Configuration file for Jekyll.
+{% raw %}
+# Welcome to the configuration file for Jekyll.
 # Full docs at: http://jekyllrb.com/docs/configuration/
 # YAML docs at: https://yaml.org/spec/1.2.2/
 # ---------------------------------------------------------------------------------
@@ -26,91 +26,210 @@
 
 # Site Settings ###################################################################
 
-## Site Information ---------------------------------------------------------------
+site_configured          : true   # Tells the theme this site has been personalised
 
 founder                  : "Amr Abdel-Motaleb"
-title                    : IT-Journey
+remote_theme             : "bamr87/zer0-mistakes"
+gem                      : &gem "jekyll-theme-zer0"
+# theme                    : "jekyll-theme-zer0"
+
+## Github Information
+github_user              : &github_user "bamr87"
+repository_name          : &github_repository "zer0-mistakes"
+repository               : [*github_user, "/", *github_repository] # GitHub username/repo-name
+local_repo               : &local_repo "zer0-mistakes"
+branch                   : &branch "main"
+repo_map                 : "/sitemap/"
+portfolio                : &portfolio [*github_user, '.', 'github.io']
+
+## Site Information ---------------------------------------------------------------
+
+title                    : &title "zer0-mistakes"
 title_url                : "/"
-title_icon               : "globe"
-subtitle                 : "zer0 to her0"
+title_icon               : "robot"
+subtitle                 : ""
 subtitle_url             : "localhost"
 subtitle_icon            : "code"
 title_separator          : "|" # Appears in the web browser tab name
-domain                   : &domain "it-journey.dev"
-baseurl                  : "" # the subpath of your site, e.g. /blog - Use this if you want this whole repo to be a domain branch
-url                      : 'https://it-journey.dev' # the base hostname & protocol for your site, e.g. http://example.com
-public_folder            : "/assets"
-port                     : 4002 # Jekyll Serve Dev port
+domain                   : &domain "zer0-mistakes"
+domain_ext               : &domain_ext "com"
+baseurl                  : &baseurl "" # the subpath of your site, e.g. /blog - Use this if you want this whole repo to be a domain branch
+url_test                 : &url_test [ 'https', '://', *github_user, '.', *domain, '.', *domain_ext ] # the base hostname & protocol for your site, e.g. http://example.com
+domain_url               : &domain_url [ 'https', '://', *domain, '.', *domain_ext ]
+github_io_url            : &github_io_url [ 'https', '://', *github_user, '.', *domain, '.', *domain_ext, '/', *github_repository ]
+url                      : &url https://zer0-mistakes.com
+public_folder            : assets # path to the public folder
+port                     : 4000 # Jekyll Serve Dev port
 dg_port                  : 4001 # TODO: Doppelganger site. Use this if you want to switch between parallel deployments
-og_image                 : '/images/wizard-on-journey.png'
-
-### Github Information
-github_user              : &github_user "bamr87"
-github_site              : 'bamr87.github.io'
+og_image                 : '/assets/images/wizard-on-journey.png'
 
 ### Owner Information -------------------------------------------------------------
 
 name                     : &name "Amr"
-email                    : "amr@it-journey.dev"
+email                    : "amr@zer0-mistakes.com"
 description              : >- # this means to ignore newlines until the next variable
-  Collection of articles, notes, and tutorials to build a website
-  or headless CMS using Jekyll and Github Pages.
-  This is my journey from zer0 to her0.
-
-repository_name          : &github_repository "it-journey"
-repository               : [*github_user, "/", *github_repository] # GitHub username/repo-name
-local_repo               : *github_repository
-repo_map                 : "_about/"
-github_base_url          : [*github_user, '.' , *site_domain] # the base hostname & protocol for your site, e.g. http://example.com
-portfolio                : [*github_user, '.', 'github.io']
+  "Jekyll and Bootstrap 5 theme for perfectionists.
+  Step-by-step instructions to build your blog, portfolio,
+  and documentation site with no mistakes, unless you're a n00b."
+level                    : 'n00b'
 
 ## Maintainer Information----------------------------------------------------------
 
 maintainers:
-  - name: "Amr"
-    profile: "/github.com/bamr87"
+  - name: *name
+    profile: ["https://github.com", "/", *github_user]
   - name: "Vacant"
     profile: "/github.com"
-
-## Admin Information----------------------------------------------------------
-
-jekyll_admin:
-  # hidden_links:
-  #   - posts
-  #   - pages
-  #   - staticfiles
-  #   - datafiles
-  #   - configuration
-  homepage: "pages"
 
 ## Personalization ----------------------------------------------------------------
 
 locale                   : "en-US"
-home_dir_pc              : &home-win 'C:\Users\amrab\'
-home_dir_mac             : &home-mac '/Users/bamr87/'
-local_git_pc             : [ *home-win, 'github' ]
-local_git_mac            : [ *home-mac, 'github' ]
+home_dir                 : &home '/Users/bamr87/'
+local_git                : [ *home, 'github' ]
 logo                     : /assets/images/gravatar-small.png  # path of logo image to display in the masthead, e.g. "/assets/images/88x88.png"
-logo_link                : 'https://www.it-journey.dev'
+logo_link                : [ *url, *baseurl ] # URL to link the logo to, e.g. "/"
 
-teaser                   : /assets/images/favicon_gpt_computer_retro.png # path of fallback teaser image, e.g. "/assets/images/500x300.png"
-info_banner              : /assets/images/info-banner-mountain-wizard.png # path of fallback teaser image, e.g. "/assets/images/500x300.png"
+teaser                   : '/assets/images/favicon_gpt_computer_retro.png' # path of fallback teaser image, e.g. "/assets/images/500x300.png"
+info_banner              : '/assets/images/info-banner-mountain-wizard.png' # path of fallback teaser image, e.g. "/assets/images/500x300.png"
+
+## Preview Image Generation (AI-powered) #####################################
+# Settings for automatic preview image generation using AI
+# Used by: scripts/generate-preview-images.sh
+
+preview_images:
+  enabled                : true
+  provider               : 'openai'           # openai, stability, local
+  model                  : 'gpt-image-2'      # gpt-image-2, dall-e-3, dall-e-2, stable-diffusion
+  size                   : '1536x1024'        # Landscape for GPT Image banners; DALL-E 3 also supports 1792x1024
+  quality                : 'auto'             # auto for GPT Image models; standard/hd for DALL-E 3
+  style                  : 'retro pixel art, 8-bit video game aesthetic, vibrant colors, nostalgic, clean pixel graphics'
+  output_dir             : 'assets/images/previews'
+  # Path normalization: allows omitting /assets/ prefix in frontmatter
+  # e.g., preview: /images/previews/my-image.png becomes /assets/images/previews/my-image.png
+  assets_prefix          : '/assets'          # Prefix to prepend to relative preview paths
+  auto_prefix            : true               # Auto-add assets_prefix if path doesn't start with it
+  # Additional style modifiers applied to all prompts
+  style_modifiers        : 'pixelated, retro gaming style, CRT screen glow effect, limited color palette'
+
 breadcrumbs              : true # true, false (default)
 words_per_minute         : 200
 _posts_file_structure    : "year-month-day-title.md"
+
+# UI navigation behaviour --------------------------------------------------
+# Optional consolidation of the mobile sidebar + main-menu offcanvases into
+# a single tabbed drawer (Browse / Menu / Settings). Default false to avoid
+# disrupting existing forks. See _includes/navigation/unified-drawer.html.
+navigation:
+  unified_mobile_drawer  : false  # true to opt into the single-drawer pattern
+
+# Opt-in user override hooks. When true, the theme loads:
+#   - assets/css/user-overrides.css  (after main.css, wins over theme rules)
+#   - assets/js/user-overrides.js    (after the theme JS bundle)
+# Ship these files in your fork; they are not bundled with the theme.
+user_overrides           : false
+
+# Runtime Appearance panel inside the Settings offcanvas (Track 6).
+# Adds light/dark/auto color-mode buttons + a primary-color picker that
+# writes to localStorage["zer0-appearance"] and updates --zer0-color-primary
+# without a page reload. Falls back gracefully when disabled.
+appearance_panel         : true
 
 ## Identity #####################################################################
 
 author:
   name                   : *name # *name is a YAML reference pointing to the &anchor earlier
   avatar                 : "/assets/images/gravatar-small.png"
-  email_hash             : '71d7a4fc9712df49e13d606e620f89c7' # https://en.gravatar.com/site/check/{ site.email }
+  email_hash             : &email_hash '71d7a4fc9712df49e13d606e620f89c7' # https://en.gravatar.com/site/check/{ site.email }
   gravatar               : [ 'https://s.gravatar.com/avatar/', *email_hash, '?s=80' ]
   bio                    : "IT nerd trying to be an IT hero"
   location               : "Denver, CO"
   twitter_username       : "bamr87"
   github_username        : *github_user
 
+## Site Analytics #############################################################
+
+google_analytics         : 'G-ZBDKNMC168'
+
+# PostHog Analytics Configuration
+# https://posthog.com/docs/libraries/js
+posthog:
+  enabled                : true
+  api_key                : 'phc_RRFmtqxRUI4XFDoI4KXUYMbTzPvhiu4A07qdSsAaXgg'
+  api_host               : 'https://us.i.posthog.com'
+  person_profiles        : 'identified_only'  # Options: 'always', 'identified_only', 'never'
+  autocapture            : true   # Automatically capture clicks, form submissions, etc.
+  capture_pageview       : true   # Track page views
+  capture_pageleave      : true   # Track when users leave pages
+  session_recording      : false  # Enable session recordings (privacy consideration)
+  disable_cookie         : false  # Set to true for cookieless tracking
+  respect_dnt            : true    # Respect Do Not Track browser setting
+  cross_subdomain_cookie : false  # Enable if you have multiple subdomains
+  secure_cookie          : true   # Use secure cookies in production
+  persistence            : 'localStorage+cookie'  # Options: 'localStorage+cookie', 'cookie', 'memory'
+  custom_events:
+    track_downloads      : true   # Track PDF, ZIP, etc. downloads
+    track_external_links : true   # Track clicks to external websites
+    track_search         : true   # Track search queries
+    track_scroll_depth   : true   # Track how far users scroll
+  privacy:
+    mask_all_text        : false  # Mask all text in session recordings
+    mask_all_inputs      : true   # Mask form inputs in session recordings
+    ip_anonymization     : false  # Anonymize IP addresses
+
+# Nanobar - Page Loading Progress Bar #############################################
+# Visual loading indicator shown on every page load.
+# Library: https://github.com/jacoborus/nanobar
+nanobar:
+  enabled       : true              # Master switch — set false to disable entirely
+  # Visual styling (any valid CSS values; CSS variables / var() are supported)
+  color         : "var(--bs-primary)" # Bar (progress) color
+  background    : "transparent"      # Track background behind the bar
+  height        : "3px"              # Bar thickness (e.g. 2px, 4px, 0.25rem)
+  # Placement
+  position      : "navbar"           # top | bottom | navbar (under header)
+  z_index       : 9999               # Stacking order
+  # Loading simulation — percentages applied in order on DOMContentLoaded.
+  # With step_delay_ms = 0 the bar fills instantly and is essentially invisible
+  # on fast pages. Increase to slow / make the animation perceivable.
+  steps         : [20, 55, 85, 100]
+  step_delay_ms : 180                # Delay between steps in ms (0 = instant burst)
+  # Advanced (rarely needs changing)
+  classname     : "nanobar"          # Class added to the injected element
+  id            : "top-progress-bar" # DOM id of the injected element
+  target        : ""                 # CSS selector to mount inside; "" = fixed to viewport
+
+## AI Chat Configuration #####################################################
+# Frontend chatbot that provides AI-powered assistance with page context
+# The API key should be stored in GitHub secrets and injected at build time
+# via a config overlay (e.g., --config _config.yml,_config_secrets.yml)
+#
+# Security Note: For production use, consider routing requests through a
+# server-side proxy to avoid exposing the API key in client-side code.
+
+ai_chat:
+  enabled                : true
+  provider               : 'openai'           # AI provider (openai)
+  auth_mode              : 'proxy'            # 'proxy' (recommended) or 'direct'
+  proxy_ready            : false              # Set true only when your proxy endpoint is deployed
+  model                  : 'gpt-4o-mini'      # Chat model to use
+  api_key                : ''                  # Leave empty in source. Inject at build time:
+                                               # 1. Store as GitHub secret: OPENAI_API_KEY
+                                               # 2. In CI, create _config_secrets.yml with the key
+                                               # 3. Build: jekyll build --config _config.yml,_config_secrets.yml
+  endpoint               : '/api/chat'        # Proxy endpoint (same-origin) for production safety
+  max_tokens             : 1024               # Max response length
+  temperature            : 0.7                # Response creativity (0-1)
+  strict_context         : true               # Ground answers to current page context only
+  out_of_scope_message   : "I can only answer from the content on this page."
+  system_prompt          : >-
+    You are a helpful assistant for the Zer0-Mistakes website,
+    a Jekyll theme and developer blog. Answer questions about the
+    current page content and help users navigate the site.
+    Be concise and friendly.
+  welcome_message        : "Hi! I'm the Zer0 assistant. Ask me anything about this page or site."
+  placeholder            : "Ask about this page..."
+  context_max_length     : 2000               # Max chars of page content sent as context
+  icon                   : 'bi-robot'         # Bootstrap icon for chat button
 
 ## Site verification #############################################################
 
@@ -126,8 +245,8 @@ baidu_site_verification  : null
 default_icon: "bi" ## Bootstrap Icons https://icons.getbootstrap.com/
 
 links:
-  - label: "BASH Consulting"
-    url: "https://bashconsultants.com"
+  - label: "Portfolio"
+    url: [ 'https://', *github_user, '.github.io/']
     icon: "bi-link"
   - label: "X"
     icon: "bi-twitter-x"
@@ -148,34 +267,33 @@ youtube:
 
 powered_by:
   - name: "Ruby"
-    version: "2.7.4"
+    version: "3.3"
     url: "https://www.ruby-lang.org/"
     icon: "bi-gem"
   - name: "Jekyll"
-    version: "3.9.5"
+    version: "3.10"
     url: "https://jekyllrb.com/"
     icon: "bi-joystick"
   - name: "Bootstrap"
-    version: "5.2.0"
+    version: "5.3.3"
     url: "https://getbootstrap.com/"
     icon: "bi-bootstrap"
-  - name: "JQuery"
+  - name: "jQuery"
     url: "https://jquery.com/"
     icon: "bi-filetype-js"
   - name: "MathJax"
-    version: "1.0"
     url: "https://www.mathjax.org/"
     icon: "bi-calculator"
   - name: "GitHub Pages"
-    version: "231"
+    version: "232"
     url: "https://pages.github.com/"
     icon: "bi-github"
-  - name: "docker"
-    version: "20.10.8"
+  - name: "Docker"
     url: "https://www.docker.com/"
     icon: "bi-docker"
 
-### Plugins 
+### Plugins  #####################################################################
+
 # https://docs.github.com/en/pages/setting-up-a-github-pages-site-with-jekyll/about-github-pages-and-jekyll#plugins
 # http://jekyllrb.com/docs/plugins/
 
@@ -183,23 +301,55 @@ powered_by:
 
 plugins:
   - github-pages
+  - jekyll-remote-theme
   - jekyll-feed
   - jekyll-sitemap
   - jekyll-seo-tag
   - jekyll-paginate
-  # - jekyll-assets
-  # - jekyll-mermaid  # https://mermaidjs.github.io/
-  # - jekyll-admin # https://github.com/jekyll/jekyll-admin
-  # - jekyll-redirect-from
-  # - bootstrap
-  # - jekyll-spaceship
-  # - jemoji # Doesn't work for some reason
-  # - jekyll-postcss
+  - jekyll-relative-links
+  # jekyll-redirect-from is on the GitHub Pages whitelist and powers Obsidian
+  # `aliases:` → URL redirects (see pages/_docs/obsidian/syntax-reference.md).
+  - jekyll-redirect-from
+  # jekyll-include-cache (on the GitHub Pages whitelist) provides the
+  # {% include_cached %} tag used by setup-banner.html and other includes to
+  # collapse per-page renders of stable content into a single cached render.
+  - jekyll-include-cache
+  # Note: jekyll-mermaid is NOT in GitHub Pages whitelist - it only provides {% mermaid %} Liquid tag
+  # Mermaid diagrams work without this plugin via client-side JavaScript (see _includes/components/mermaid.html)
+  - jekyll-mermaid
 
-# https://github.blog/2022-02-14-include-diagrams-markdown-files-mermaid/
+# Project resource links (used by landing page and includes)
+resources:
+  github_repo: [ 'https://github.com/', *github_user, '/', *github_repository ]
+  github_fork: [ 'https://github.com/', *github_user, '/', *github_repository, '/fork' ]
+  contributing: [ 'https://github.com/', *github_user, '/', *github_repository, '/blob/', *branch, '/CONTRIBUTING.md' ]
+  rubygems:
+    name: *gem
+    url: [ 'https://rubygems.org/gems/', *gem ]
+  docker:
+    image: [ *github_user, '/', *github_repository ]
+    hub_url: [ 'https://hub.docker.com/r/', *github_user, '/', *github_repository ]
+
+## Gisgus Plugin #################################################################
+
+gisgus:
+  enabled: true
+  data-repo-id: "MDEwOlJlcG9zaXRvcnkyODM4MjI1NzM"
+  data-category-id: "DIC_kwDOEOrJ7c4CAn8D"
+
+## Mermaid Diagram Configuration #################################################
+# Mermaid diagrams support both native markdown code blocks and div syntax
+# Usage: 
+#   1. Add 'mermaid: true' to page front matter
+#   2. Use ```mermaid ... ``` code blocks OR <div class="mermaid">...</div>
+# 
+# GitHub Pages Compatible: Yes (client-side; script bundled under assets/vendor/)
+# Update file: npm install && npm run vendor:mermaid (copies from node_modules/mermaid, not jsDelivr)
+# Plugin: jekyll-mermaid is OPTIONAL (not needed for GitHub Pages)
+# Documentation: https://mermaid.js.org/
 
 mermaid:
-  src: 'mermaid/src/mermaid.js'
+  src: '/assets/vendor/mermaid/mermaid.min.js'
 
 ## Conversion
 # Markdown Options https://jekyllrb.com/docs/configuration/markdown/
@@ -253,7 +403,7 @@ collections:
     permalink: /:collection/:path/:name/
   quickstart:
     output: true
-    permalink: /:collection/:categories/:name/
+    permalink: /:collection/:name/
   about:
     output: true
     permalink: /:collection/:categories/:name/
@@ -267,8 +417,6 @@ paginate_path: "/pages/:num/"
 
 # Defaults https://jekyllrb.com/docs/configuration/front-matter-defaults/
 
-nav-file: '_data/navigation/map.yml'
-
 defaults:
   # ALL
   - 
@@ -278,11 +426,11 @@ defaults:
       layout: root
       author_profile: false
       read_time: true
-      comments: # true
+      comments: false # true
       share: true
       related: true
       sidebar:
-        nav: main
+        nav: tree
     permalink: /:collection/:name/
 
   # pages
@@ -298,7 +446,7 @@ defaults:
       related: true
       toc_sticky: true
       sidebar:
-        nav: searchCats
+        nav: categories
     permalink: /:path/:name/
 
   # pages/_about
@@ -311,7 +459,7 @@ defaults:
       share: true
       related: true
       sidebar:
-        nav: about
+        nav: tree
 
   # pages/_quickstart
   - 
@@ -323,21 +471,22 @@ defaults:
       share: true
       related: true
       sidebar:
-        nav: quickstart
+        nav: tree
 
-  # _posts
+  # pages/_posts
   - 
     scope:
       path: pages/_posts
     values:
       layout: article
+      post_type: standard
+      index: false
+      sidebar: true
       author_profile: true
       read_time: true
       comments: # true
       share: true
       related: true
-      sidebar:
-        nav: dynamic
       # permalink: /:collection/:name/
 
   # pages/_docs
@@ -349,39 +498,12 @@ defaults:
       # category: docs
       author_profile: true
       read_time: true
+      sidebar:
+        nav: tree
       comments: # true
       share: true
       related: true
-      sidebar:
-        nav: docs
     # permalink: /docs/:category/:name/
-
-  # pages/_quests
-  - 
-    scope:
-      path: pages/_quests
-    values:
-      layout: *pages
-      author_profile: true
-      read_time: true
-      comments: # true
-      share: true
-      related: true
-      sidebar:
-        nav: dynamic
-      permalink: /:categories/:slug
-
-  # pages/_hobbies
-  - 
-    scope:
-      path: pages/_hobbies
-      type: hobbies
-    values:
-      layout: *pages
-      share: false
-      author_profile: false
-      sidebar:
-        nav: hobbies
 
   # pages/_notes
   - 
@@ -389,11 +511,32 @@ defaults:
       path: pages/_notes
       type: notes
     values:
-      layout: *pages
-      share: false
-      author_profile: false
+      layout: note
+      collection: notes
+      author_profile: true
+      read_time: true
+      comments: true
+      share: true
+      related: true
       sidebar:
-        nav: dynamic
+        nav: auto
+
+  # pages/_notebooks
+  - 
+    scope:
+      path: pages/_notebooks
+      type: notebooks
+    values:
+      layout: notebook
+      collection: notebooks
+      author_profile: true
+      read_time: true
+      comments: true
+      share: true
+      related: true
+      jupyter_metadata: true
+      sidebar:
+        nav: auto
 
 # Exclude from processing.
 # The following items will not be processed, by default.
@@ -402,18 +545,73 @@ defaults:
 #
 # Excluded items can be processed by explicitly listing the directories or
 # their entries' file path in the `include:` list.
+#
+# NOTE: When _config_dev.yml is layered on top (--config _config.yml,_config_dev.yml),
+# the dev file MUST repeat this full list — Jekyll replaces, not merges, the exclude key.
 
 exclude:
+  # ── Jekyll cache ─────────────────────────────────────────────────────────
   - .sass-cache/
   - .jekyll-cache/
-  - .obsidian
+
+  # ── Obsidian vault working files ─────────────────────────────────────────
+  - .obsidian/
+  - "*.canvas"
+  - "*.excalidraw.md"
+
+  # ── IDE / editor config (dot-prefix dirs hidden by default; listed for clarity) ─
+  - .cursor/
+  - .devcontainer/
+  - .frontmatter/
+  - .github/
+  - .vscode/
+
+  # ── Ruby / Bundler ────────────────────────────────────────────────────────
+  - Gemfile
   - Gemfile.lock
   - gemfiles/
-  - Gemfile
+  - jekyll-theme-zer0.gemspec
+  - lib/
+  - pkg/
+  - vendor/bundle/
+  - vendor/cache/
+  - vendor/gems/
+  - vendor/ruby/
+
+  # ── Node.js ───────────────────────────────────────────────────────────────
   - node_modules/
-  - vendor/
-  # - "*.sh"
+  - package.json
+  - package-lock.json
+
+  # ── Shell scripts and automation ──────────────────────────────────────────
+  - scripts/
+  - "*.sh"
+
+  # ── Docker configuration ──────────────────────────────────────────────────
+  - docker/
+  - docker-compose.yml
+  - docker-compose.test.yml
+
+  # ── Build / task runners ──────────────────────────────────────────────────
+  - Makefile
+  - Rakefile
+
+  # ── Project tooling metadata ──────────────────────────────────────────────
+  - AGENTS.md
+  - docs/
+  - frontmatter.json
+  - logs/
+  - templates/
+  - vendor-manifest.json
+  - "*.code-workspace"
+
+  # ── Submodules, tests, and authoring scaffolding ──────────────────────────
   - submodules/
+  - test/
+  - tests/
+  - MERMAID-*.md
+  - MERMAID-*/
+  - pages/_notes/_templates/
 
 # Sass/SCSS
 sass:
@@ -424,49 +622,56 @@ sass:
   # load_paths:
   #   - /usr/local/bundle/gems/bootstrap-5.3.3/assets/stylesheets
 
-atom_feed:
-path                   : # blank (default) uses feed.xml
 
 ## Style Settings -------------------------------------------------------------
 
 # theme                  : "zer0-mistakes-jekyll"
 # remote_theme           : "bamr87/zer0-mistakes"
-theme_skin               : "dark" # "air", "aqua", "contrast", "dark", "dirt", "neon", "mint", "plum", "sunrise"
+theme_skin               : "air" # "air", "aqua", "dirt", "neon", "mint", "plum", "sunrise"
+
+# SVG background layers (fffuel.co style) — gradient, pattern, noise per skin
+theme_background:
+  enabled: true           # Master toggle for SVG backgrounds
+  gradient_opacity: 0.6   # Hero/header gradient layer opacity
+  texture_opacity: 0.04   # Body noise texture overlay opacity
+  pattern_opacity: 0.08   # Surface/card pattern overlay opacity
+  blend_mode: overlay     # CSS mix-blend-mode for all layers
 
 # style                  : "default" # "default", "dark", "light", "solarized-dark", "solarized-light"
 # remote_style           : "bamr87/zer0-mistakes"
 
-
-
+# NOTE: Hex codes MUST be quoted — unquoted `#007bff` is parsed as a YAML
+# comment and the key resolves to null. These values feed
+# _includes/core/tokens-inline.html → --zer0-color-*.
 theme_color:
-  main: #007bff
-  secondary: #6c757d
-  red: #a11111
-  yellow: #ffe900
-  teal: #376986
-  blue: #007bff
-  green: #28a745
-  purple: #6f42c1
-  pink: #e83e8c
-  orange: #fd7e14
-  brown: #795548
-  cyan: #17a2b8
-  indigo: #6610f2
-  lime: #cddc39
-  amber: #ffc107
-  deep_orange: #ff5722
-  deep_purple: #673ab7
-  light_blue: #03a9f4
-  light_green: #8bc34a
-  light_purple: #9c27b0
-  light_red: #f44336
-  light_yellow: #ffeb3b
-  light_teal: #009688
+  main:         "#007bff"
+  secondary:    "#6c757d"
+  red:          "#a11111"
+  yellow:       "#ffe900"
+  teal:         "#376986"
+  blue:         "#007bff"
+  green:        "#28a745"
+  purple:       "#6f42c1"
+  pink:         "#e83e8c"
+  orange:       "#fd7e14"
+  brown:        "#795548"
+  cyan:         "#17a2b8"
+  indigo:       "#6610f2"
+  lime:         "#cddc39"
+  amber:        "#ffc107"
+  deep_orange:  "#ff5722"
+  deep_purple:  "#673ab7"
+  light_blue:   "#03a9f4"
+  light_green:  "#8bc34a"
+  light_purple: "#9c27b0"
+  light_red:    "#f44336"
+  light_yellow: "#ffeb3b"
+  light_teal:   "#009688"
 
 ## Copyright Settings --------------------------------------------------------------
 
 cr_year: 2024
-cr_entity: "Amr"
+cr_entity: *name
 cr_lisense: "MIT"
 
 ## Sitemap Settings --------------------------------------------------------------
@@ -476,3 +681,4 @@ cr_lisense: "MIT"
 
 sitemap_include: ["html", "xml"]
 sitemap_exclude: ["secret.html", "private"]
+{% endraw %}

--- a/pages/_about/settings/config.md
+++ b/pages/_about/settings/config.md
@@ -11,6 +11,25 @@ permalink: /about/config/
 sidebar: false
 ---
 
+{% comment %}
+  Shared sanitized config render (T-009/T-018). Both the visible Raw-YAML
+  tab and the hidden copy-source element use this capture, so the live
+  PostHog key (and any other secret-shaped line) never reaches the DOM in
+  either place. Pure Liquid line filter (works on GitHub Pages where the
+  sanitize_config_yaml plugin filter is a silent no-op) + the plugin filter
+  as defense-in-depth on plugin-enabled builds. cfg_nl captures exactly one
+  newline — keep both tags flush-left. Fail-closed: if the split degraded,
+  the whole config matches the probe and renders as one redaction marker.
+  Lines are HTML-escaped; copy buttons read textContent, which decodes
+  entities back to the original characters.
+{% endcomment %}
+{% capture cfg_full_raw %}{% include_relative _config.yml %}{% endcapture %}
+{% capture cfg_nl %}
+{% endcapture %}{% assign cfg_lines = cfg_full_raw | split: cfg_nl %}
+{% capture cfg_sanitized %}{% for cfg_line in cfg_lines %}{% assign cfg_probe = cfg_line | downcase %}{% if cfg_probe contains 'api_key' or cfg_probe contains 'secret' or cfg_probe contains 'password' or cfg_probe contains 'token' or cfg_probe contains 'phc_' %}# [redacted]{% else %}{{ cfg_line | sanitize_config_yaml | escape }}{% endif %}
+{% endfor %}{% endcapture %}
+
+
 <!-- Quick-reference cards -->
 <div class="row g-3 mb-4">
   <div class="col-6 col-lg-3">
@@ -95,7 +114,7 @@ sidebar: false
         <i class="bi bi-clipboard"></i> Copy
       </button>
     </div>
-    <pre class="bg-dark text-light p-3 rounded" style="max-height:600px;overflow:auto;font-size:.8rem"><code id="cfg-raw-yaml">{% include_relative _config.yml %}</code></pre>
+    <pre class="bg-dark text-light p-3 rounded" style="max-height:600px;overflow:auto;font-size:.8rem"><code id="cfg-raw-yaml">{{ cfg_sanitized }}</code></pre>
   </div>
 
   <!-- ═══════ Quick Actions Tab ═══════ -->
@@ -112,16 +131,21 @@ sidebar: false
             <h6 class="mt-3"><i class="bi bi-terminal me-1"></i> Bash</h6>
 ```bash
 cd ~/github/{{ site.local_repo }}
-cp {{ page.config-file }} {{ page.config-dir }}/{{ page.config-file }}
+# Wraps the copy in Liquid raw markers so config comments that mention
+# Liquid tags render literally (scripts/bin/validate checks for drift).
+# The awk string-splits keep this page itself Liquid-safe.
+awk 'BEGIN{print "{" "% raw %" "}"} {print} END{print "{" "% endraw %" "}"}' \
+  {{ page.config-file }} > {{ page.config-dir }}/{{ page.config-file }}
 ```
 
 <h6 class="mt-3"><i class="bi bi-windows me-1"></i> PowerShell</h6>
 
 ```powershell
 cd ~/github/{{ site.local_repo }}
-cp {{ page.config-file }} {{ page.config-dir }}/config-utf16.txt
-Get-Content {{ page.config-dir }}/config-utf16.txt |
-  Set-Content -Encoding UTF8 {{ page.config-dir }}/{{ page.config-file }}
+$raw = "{" + "% raw %" + "}"; $end = "{" + "% endraw %" + "}"
+$body = Get-Content {{ page.config-file }} -Raw
+Set-Content -Encoding UTF8 {{ page.config-dir }}/{{ page.config-file }} `
+  -Value ($raw + "`n" + $body + $end + "`n")
 ```
           </div>
         </div>
@@ -220,24 +244,8 @@ Get-Content {{ page.config-dir }}/config-utf16.txt |
 </div>
 
 <!-- Hidden full YAML used by the viewer's "Copy Full Config" button.
-     Sanitized twice (T-009), belt and braces:
-     1. Pure-Liquid line filter — any line mentioning api_key, secret,
-        password, token, or a phc_ PostHog key becomes "# [redacted]".
-        This is the layer that protects GitHub Pages builds, where custom
-        plugins (and therefore Liquid filters) do not run.
-     2. sanitize_config_yaml (_plugins/sanitize_config_filter.rb) masks
-        values on plugin-enabled builds; on GitHub Pages the unknown
-        filter is a silent no-op, which is why layer 1 must exist.
-     cfg_nl captures exactly one newline (both tags flush-left — keep them
-     that way). If the split ever degraded, the whole config would match the
-     probe and collapse to a single redaction marker: fail-closed, never raw.
-     Lines are HTML-escaped; the copy button reads textContent, which
-     decodes entities back to the original characters. -->
-{% capture cfg_full_raw %}{% include_relative _config.yml %}{% endcapture %}
-{% capture cfg_nl %}
-{% endcapture %}{% assign cfg_lines = cfg_full_raw | split: cfg_nl %}
-<pre id="cfg-full-yaml" class="d-none">{% for cfg_line in cfg_lines %}{% assign cfg_probe = cfg_line | downcase %}{% if cfg_probe contains 'api_key' or cfg_probe contains 'secret' or cfg_probe contains 'password' or cfg_probe contains 'token' or cfg_probe contains 'phc_' %}# [redacted]{% else %}{{ cfg_line | sanitize_config_yaml | escape }}{% endif %}
-{% endfor %}</pre>
+     Same sanitized render as the Raw-YAML tab (see capture at page top). -->
+<pre id="cfg-full-yaml" class="d-none">{{ cfg_sanitized }}</pre>
 
 <!-- Config Utility JS (must load after DOM) -->
 <script src="{{ '/assets/js/config-utility.js' | relative_url }}" defer></script>

--- a/scripts/bin/validate
+++ b/scripts/bin/validate
@@ -404,6 +404,23 @@ classified_files = %w[
     pages/_about/settings/_config.yml
     .github/ISSUE_TEMPLATE/config.yml
 ]
+
+# T-018: the admin config page renders pages/_about/settings/_config.yml via
+# include_relative (Liquid cannot reach the repo root). Fail on drift so the
+# page never shows a stale copy; refresh with:
+#   cp _config.yml pages/_about/settings/_config.yml
+settings_copy = 'pages/_about/settings/_config.yml'
+if File.file?(settings_copy)
+  live = File.read('_config.yml', encoding: 'UTF-8')
+  copy_lines = File.read(settings_copy, encoding: 'UTF-8').lines
+  # The copy is wrapped in {% raw %}/{% endraw %} so include_relative renders
+  # the config text literally (the live file mentions Liquid tags in comments).
+  refresh = "{ echo '{% raw %}'; cat _config.yml; echo '{% endraw %}'; } > #{settings_copy}"
+  assert(copy_lines.first.to_s.strip == '{% raw %}' && copy_lines.last.to_s.strip == '{% endraw %}',
+         "#{settings_copy} must be wrapped in raw/endraw; refresh it: #{refresh}")
+  assert(copy_lines[1..-2].join == live,
+         "#{settings_copy} has drifted from _config.yml; refresh it: #{refresh}")
+end
 classified_files.concat(Dir.glob('_data/**/*config*.{yml,yaml}'))
 
 unclassified_files = config_like_files.sort - classified_files.select { |file| File.file?(file) }

--- a/test/visual/security.spec.js
+++ b/test/visual/security.spec.js
@@ -42,25 +42,32 @@ test.describe('Security — secret exposure prevention', () => {
   });
 
   test('raw YAML tab does not expose API keys', async ({ page }) => {
-    // Try clicking Raw YAML tab
-    const rawTab = page.locator('[role="tab"]', { hasText: /raw/i });
-    if (await rawTab.count() === 0) {
-      test.skip();
-      return;
-    }
-    await rawTab.first().click();
-    await page.waitForTimeout(300);
+    // T-018: the Raw-YAML tab renders the same sanitized capture as the
+    // hidden copy element. The element is `code#cfg-raw-yaml` (the old
+    // `pre#cfg-raw-yaml` locator silently skipped this test for months —
+    // assert presence instead of skipping).
+    const rawContent = page.locator('code#cfg-raw-yaml');
+    await expect(rawContent, 'Raw-YAML tab element must exist').toHaveCount(1);
 
-    const rawContent = page.locator('pre#cfg-raw-yaml, [role="tabpanel"]:visible pre');
-    if (await rawContent.count() === 0) {
-      test.skip();
-      return;
+    // textContent is readable without activating the tab
+    const text = await rawContent.textContent();
+    const sensitivePatterns = [
+      /api_key\s*:/i,
+      /secret\s*:/i,
+      /password\s*:/i,
+      /token\s*:/i,
+      /phc_[a-zA-Z0-9]{20,}/,
+      /sk_[a-zA-Z0-9]{20,}/,
+      /ghp_[a-zA-Z0-9]{20,}/,
+    ];
+    for (const pattern of sensitivePatterns) {
+      expect(
+        pattern.test(text),
+        `Raw-YAML tab should not contain sensitive data matching ${pattern}`
+      ).toBe(false);
     }
-    const text = await rawContent.first().textContent();
-    // Should not contain actual API key values
-    expect(text).not.toMatch(/phc_[a-zA-Z0-9]{20,}/);
-    expect(text).not.toMatch(/sk_[a-zA-Z0-9]{20,}/);
-    expect(text).not.toMatch(/ghp_[a-zA-Z0-9]{20,}/);
+    // Sanity: the sanitized config actually rendered (not an empty element)
+    expect(text).toMatch(/remote_theme|theme_skin/);
   });
 
   test('page source does not contain common secret patterns', async ({ page }) => {


### PR DESCRIPTION
## Summary

Implements **T-018** — the last of the config-page security thread that began with T-009. Closes **#143** on the backlog sync.

## The problem chain

The admin config page renders a copy of `_config.yml` via `include_relative` (Liquid can't reach the repo root). That copy had drifted stale — and the investigation revealed *why* it was stale: the live config mentions Liquid tags in comments (`{% raw %}{% mermaid %}{% endraw %}`, `{% raw %}{% include_cached %}{% endraw %}`), and `include_relative` **parses Liquid in included files**, so a naive sync breaks the build with `Unknown tag` errors. Meanwhile the **visible Raw-YAML tab showed the unsanitized file** — the staleness of the copy was the only thing keeping the live PostHog key off that tab.

## The fix

- **Sync mechanism**: the copy is the live config wrapped in `raw`/`endraw` markers, so the exact text renders literally (truer than before — Liquid in comments used to get substituted). `scripts/bin/validate` now **fails on drift**, with the refresh one-liner in the error message.
- **Visible-tab redaction**: one shared sanitized Liquid capture feeds both the Raw-YAML tab and the hidden copy element — same line filter, same escape, same plugin-filter defense-in-depth.
- **Test de-masked**: the raw-tab security test had been silently skipping for months (its locator targeted `pre#cfg-raw-yaml`; the id is on `<code>`). It now asserts the element exists and checks the full sensitive-pattern set.
- The page's "Regenerate Config" snippets are rewritten with string-split tag construction so the page itself stays Liquid-safe.

## Verified

- Built page renders the **full live config** with **10 sensitive lines redacted in both elements**; no `phc_`/`api_key:`/`secret:`/`password:`/`token:` matches anywhere in either
- Liquid-in-comments renders literally (`{% raw %}{{ site.title }}{% endraw %}` displays as text)
- `validate --quick` green in UTF-8 **and** C locales; drift check verified to fail on a divergent copy
- `./scripts/bin/test` — 10/10

Remaining open backlog after this: T-007 (navbar WCAG), T-010 (quickstart docs), T-013 (snapshot baselines), T-019/T-020 (coverage follow-ups).

No version bump.

https://claude.ai/code/session_01B5Ae9uqneVqkQXZrmz9Qqm

---
_Generated by [Claude Code](https://claude.ai/code/session_01B5Ae9uqneVqkQXZrmz9Qqm)_