### PR TITLE
fix(content): render mermaid on 12 pages, restore Obsidian graph, migration tests (T-019)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Mermaid diagrams now render on 12 more pages**: pages with ```mermaid``` code fences but no `mermaid: true` front-matter flag (about, several feature/dev docs, all four quickstart guides) were showing raw code instead of diagrams — the flag gates the renderer include. Added the flag; verified all 34 diagrams across the site parse with valid Mermaid syntax and render to SVG in a browser
+- **Obsidian graph view restored**: the `/docs/obsidian/graph/` page (roadmap v1.4 force-directed knowledge graph) had been deleted as a "stub" but its `full-graph.html` include, `obsidian-graph.js`, the docs index link, and 5 inbound wiki-links all still referenced it — a 404 to a shipped feature. Restored the page (it renders 161 nodes / 269 edges from the live wiki-index with zero console errors)
 - **Migration & theme-version coverage (T-019)**: `scripts/test/lib/test_migrate.sh` (14 assertions for Jekyll-site detection, theme-connection classification, and version-gap logic) and `ThemeVersionGeneratorTest` in `test/test_plugins.rb` — the two largest remaining zero-coverage subsystems from the T-005 baseline
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Migration & theme-version coverage (T-019)**: `scripts/test/lib/test_migrate.sh` (14 assertions for Jekyll-site detection, theme-connection classification, and version-gap logic) and `ThemeVersionGeneratorTest` in `test/test_plugins.rb` — the two largest remaining zero-coverage subsystems from the T-005 baseline
+
 ### Fixed
 - **Navbar & site accessibility (T-007)**: resolved all WCAG 2.1 AA violations that kept three axe-core audits frozen — dropped the redundant ARIA `menubar`/`menuitem` roles from the nav (the nav landmark already provides semantics; menubars require menuitem children the search/settings buttons weren't), added an `aria-label` to the site-subtitle home link, kept the admin/footer separator a list item, gave the theme-preview disabled tab a `role="tab"` and an icon-only button an `aria-label`, made code blocks a single keyboard-focusable scroll region, and underlined prose links so they're distinguishable without color. The three `test.fixme` blocks in `test/visual/accessibility.spec.js` are now live `test()` calls — verified 0 violations across the homepage, FAQ, and all 8 admin pages (23/23 a11y, 223/223 smoke tier)
 

--- a/_data/backlog.yml
+++ b/_data/backlog.yml
@@ -504,7 +504,7 @@ tasks:
 
   - id: T-019
     title: "Unit tests for migrate.sh and theme_version.rb (coverage rank #1)"
-    status: open
+    status: done
     priority: P2
     area: tests
     risk: standard
@@ -516,13 +516,18 @@ tasks:
       detection, theme connection, admin-page install/verify, version-gap
       detection) plus _plugins/theme_version.rb (88 lines) as the largest
       remaining zero-coverage surface (353 lines).
+      Done 2026-06-13: scripts/test/lib/test_migrate.sh (14 assertions:
+      detect_jekyll_site, validate_theme_connection classification for
+      remote/gem/local, detect_version_gap min-version logic) and
+      ThemeVersionGeneratorTest in test_plugins.rb (remote/unknown-gem/none
+      branches, gem scan stubbed for determinism).
     acceptance:
       - "scripts/test/lib/test_migrate.sh exercises detect_jekyll_site, validate_theme_connection, and detect_version_gap against fixture directories."
       - "test/test_plugins.rb (or a sibling spec) covers theme_version.rb's version resolution."
       - "./scripts/bin/test stays green with the new specs included."
     links: { issue: null, pr: null, roadmap: "1.14" }
     created: 2026-06-12
-    updated: 2026-06-12
+    updated: 2026-06-13
 
   - id: T-020
     title: "CI coverage for installer interactive wizard and upgrade path (coverage rank #2)"

--- a/_data/backlog.yml
+++ b/_data/backlog.yml
@@ -56,7 +56,7 @@
 meta:
   title: "zer0-mistakes Backlog"
   updated: 2026-06-12
-  next_id: 21
+  next_id: 22
 
 tasks:
   # --- Housekeeping (seeded so the loop has work on day one) ------------------
@@ -550,3 +550,26 @@ tasks:
     links: { issue: null, pr: null, roadmap: "1.14" }
     created: 2026-06-12
     updated: 2026-06-12
+
+  - id: T-021
+    title: "Vendor cytoscape.js so the Obsidian graph works without a CDN"
+    status: open
+    priority: P3
+    area: feat
+    risk: standard
+    effort: S
+    source: audit
+    summary: >-
+      The Obsidian full-graph page (_includes/obsidian/full-graph.html) loads
+      cytoscape.js from cdn.jsdelivr.net — the only runtime CDN dependency left
+      in the theme, contradicting the vendored-assets principle (Bootstrap,
+      Icons, Mermaid are all under assets/vendor/). It also makes the graph
+      fail under strict CSP or offline. Vendor cytoscape@3.30.0 under
+      assets/vendor/ and reference it locally, matching the Mermaid pattern.
+    acceptance:
+      - "cytoscape.min.js committed under assets/vendor/ and referenced via a local path."
+      - "full-graph.html no longer references cdn.jsdelivr.net."
+      - "The graph page renders nodes/edges with the vendored file (no network)."
+    links: { issue: null, pr: null, roadmap: null }
+    created: 2026-06-13
+    updated: 2026-06-13

--- a/pages/_about/features/README.md
+++ b/pages/_about/features/README.md
@@ -26,6 +26,7 @@ technical_requirements:
 difficulty_level: intermediate
 estimated_reading_time: 10 minutes
 draft: false
+mermaid: true
 ---
 
 # Zer0-Mistakes Features Documentation

--- a/pages/_about/index.md
+++ b/pages/_about/index.md
@@ -22,6 +22,7 @@ permalink: /about/
 slug: about
 collection: about
 order: 1
+mermaid: true
 ---
 
 {{ site.description }}

--- a/pages/_docs/development/ci-cd.md
+++ b/pages/_docs/development/ci-cd.md
@@ -20,6 +20,7 @@ prerequisites:
     - Understanding of GitHub Actions
 sidebar:
     nav: docs
+mermaid: true
 ---
 
 # CI/CD Pipeline

--- a/pages/_docs/development/index.md
+++ b/pages/_docs/development/index.md
@@ -16,6 +16,7 @@ difficulty: intermediate
 estimated_reading_time: 5 minutes
 sidebar:
     nav: docs
+mermaid: true
 ---
 
 # Contributing to Zer0-Mistakes

--- a/pages/_docs/features/cookie-consent.md
+++ b/pages/_docs/features/cookie-consent.md
@@ -18,6 +18,7 @@ difficulty: intermediate
 estimated_reading_time: 15 minutes
 sidebar:
     nav: docs
+mermaid: true
 ---
 
 # Cookie Consent Management

--- a/pages/_docs/features/jupyter-notebooks.md
+++ b/pages/_docs/features/jupyter-notebooks.md
@@ -21,6 +21,7 @@ prerequisites:
     - Jupyter notebooks to convert
 sidebar:
     nav: docs
+mermaid: true
 ---
 
 # Jupyter Notebook Integration

--- a/pages/_docs/features/preview-image-generator.md
+++ b/pages/_docs/features/preview-image-generator.md
@@ -20,6 +20,7 @@ prerequisites:
     - Or Stability AI API key
 sidebar:
     nav: docs
+mermaid: true
 ---
 
 # AI Preview Image Generator

--- a/pages/_docs/features/site-search.md
+++ b/pages/_docs/features/site-search.md
@@ -17,6 +17,7 @@ difficulty: intermediate
 estimated_reading_time: 10 minutes
 sidebar:
     nav: docs
+mermaid: true
 ---
 
 # Site Search

--- a/pages/_docs/obsidian/graph.md
+++ b/pages/_docs/obsidian/graph.md
@@ -1,0 +1,14 @@
+---
+title: "Obsidian Graph View"
+description: "Interactive force-directed map of every wiki-link in the site, mirroring Obsidian's local graph."
+preview: /images/previews/obsidian-graph-view.png
+layout: default
+permalink: /docs/obsidian/graph/
+categories: [Documentation, Obsidian]
+tags: [obsidian, graph, navigation]
+backlinks: false
+sitemap: false
+lastmod: "2026-04-24T15:06:30Z"
+---
+
+{% include obsidian/full-graph.html %}

--- a/pages/_quickstart/github-setup.md
+++ b/pages/_quickstart/github-setup.md
@@ -31,6 +31,7 @@ quickstart:
   step: 3
   next: /quickstart/personalization/
   prev: /quickstart/jekyll-setup/
+mermaid: true
 ---
 
 # GitHub Setup & Deployment

--- a/pages/_quickstart/index.md
+++ b/pages/_quickstart/index.md
@@ -25,6 +25,7 @@ keywords:
         - ai installation
         - cross-platform
         - bootstrap 5
+mermaid: true
 ---
 
 # Quick Start Guide

--- a/pages/_quickstart/jekyll-setup.md
+++ b/pages/_quickstart/jekyll-setup.md
@@ -30,6 +30,7 @@ quickstart:
     step: 2
     next: /quickstart/github-setup/
     prev: /quickstart/machine-setup/
+mermaid: true
 ---
 
 # Jekyll Setup

--- a/pages/_quickstart/machine-setup.md
+++ b/pages/_quickstart/machine-setup.md
@@ -18,6 +18,7 @@ quickstart:
   step: 1
   next: /quickstart/jekyll-setup/
   prev: /quickstart/
+mermaid: true
 ---
 
 # Machine Setup

--- a/scripts/test/lib/run_tests.sh
+++ b/scripts/test/lib/run_tests.sh
@@ -128,6 +128,7 @@ main() {
     source "$TEST_DIR/test_gem.sh"
     source "$TEST_DIR/test_analyze_commits.sh"
     source "$TEST_DIR/test_locale_independence.sh"
+    source "$TEST_DIR/test_migrate.sh"
     
     # Summary
     echo -e "\n${BLUE}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"

--- a/scripts/test/lib/test_migrate.sh
+++ b/scripts/test/lib/test_migrate.sh
@@ -1,0 +1,88 @@
+#!/bin/bash
+
+# Unit tests for migrate.sh library (T-019)
+#
+# Drives the pure-logic migration helpers against throwaway fixture
+# directories: site detection, theme-connection classification, and
+# version-gap detection. The template-rendering functions
+# (install_admin_pages / verify_admin_pages) need the full template
+# pipeline and are exercised by the installer e2e suites; these unit
+# tests focus on the detection logic that has had zero coverage.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+LIB_DIR="$(cd "$SCRIPT_DIR/../../lib" && pwd)"
+
+export DRY_RUN=true
+export INTERACTIVE=false
+export VERBOSE=false
+
+source "$LIB_DIR/common.sh"
+source "$LIB_DIR/migrate.sh"
+
+set +e
+
+print_suite_header "migrate.sh"
+
+_mktmp() { mktemp -d "${TMPDIR:-/tmp}/migrate-test-XXXXXX"; }
+
+# --- detect_jekyll_site ---------------------------------------------------
+echo "Testing detect_jekyll_site..."
+
+d=$(_mktmp)
+assert_false "detect_jekyll_site '$d'" "No _config.yml → not a Jekyll site"
+
+touch "$d/_config.yml"
+assert_false "detect_jekyll_site '$d'" "_config.yml alone is not enough"
+
+touch "$d/Gemfile"
+assert_true "detect_jekyll_site '$d'" "_config.yml + Gemfile → Jekyll site"
+rm -rf "$d"
+
+d=$(_mktmp); touch "$d/_config.yml"; mkdir -p "$d/_layouts"
+assert_true "detect_jekyll_site '$d'" "_config.yml + _layouts/ → Jekyll site"
+rm -rf "$d"
+
+# --- validate_theme_connection -------------------------------------------
+echo "Testing validate_theme_connection..."
+
+d=$(_mktmp)
+printf 'remote_theme: "bamr87/zer0-mistakes"\n' > "$d/_config.yml"
+assert_true "validate_theme_connection '$d'" "remote_theme detected"
+validate_theme_connection "$d" >/dev/null 2>&1
+assert_equals "remote" "$THEME_CONNECTION_TYPE" "remote connection type set"
+rm -rf "$d"
+
+d=$(_mktmp)
+printf 'theme: jekyll-theme-zer0\n' > "$d/_config.yml"
+assert_true "validate_theme_connection '$d'" "gem theme detected"
+validate_theme_connection "$d" >/dev/null 2>&1
+assert_equals "gem" "$THEME_CONNECTION_TYPE" "gem connection type set"
+rm -rf "$d"
+
+d=$(_mktmp)
+printf 'title: My Site\n' > "$d/_config.yml"
+printf 'gem "jekyll-theme-zer0", path: "../theme"\n' > "$d/Gemfile"
+assert_true "validate_theme_connection '$d'" "local path gem detected"
+validate_theme_connection "$d" >/dev/null 2>&1
+assert_equals "local" "$THEME_CONNECTION_TYPE" "local connection type set"
+rm -rf "$d"
+
+d=$(_mktmp)
+printf 'title: Unrelated Site\n' > "$d/_config.yml"
+assert_false "validate_theme_connection '$d'" "no theme connection → 1"
+rm -rf "$d"
+
+# --- detect_version_gap ---------------------------------------------------
+echo "Testing detect_version_gap..."
+
+d=$(_mktmp)
+assert_true "detect_version_gap '$d'" "no Gemfile.lock → pass (cannot check)"
+
+printf '    jekyll-theme-zer0 (1.14.0)\n' > "$d/Gemfile.lock"
+assert_true "detect_version_gap '$d'" "modern version >= min → pass"
+
+printf '    jekyll-theme-zer0 (0.22.5)\n' > "$d/Gemfile.lock"
+assert_false "detect_version_gap '$d'" "version below 0.22.10 min → gap detected"
+rm -rf "$d"
+
+echo -e "\n${GREEN}migrate.sh tests complete${NC}"

--- a/test/test_plugins.rb
+++ b/test/test_plugins.rb
@@ -61,6 +61,7 @@ end
 require_relative '../_plugins/admin_page_urls'
 require_relative '../_plugins/content_statistics_generator'
 require_relative '../_plugins/preview_image_generator'
+require_relative '../_plugins/theme_version'
 
 FakePage = Struct.new(:output_ext, :url)
 FakeSite = Struct.new(:pages, :data, :config, :source, :theme, :collections) do
@@ -241,5 +242,45 @@ class PreviewImageGeneratorTest < Minitest::Test
     site = site_with
     doc = doc_with({}, site, basename: 'my-post')
     assert_equal 'my-post-preview.png', PIG.generate_filename(doc)
+  end
+end
+
+# ---------------------------------------------------------------------------
+class ThemeVersionGeneratorTest < Minitest::Test
+  # site.config is a plain Hash for this generator
+  def run_generator(config)
+    site = Struct.new(:config).new(config)
+    # Silence the gem scan so the test is deterministic regardless of which
+    # jekyll-theme-* gems happen to be installed in the runner. Save/restore
+    # the original Gem::Specification.each around the run.
+    original = Gem::Specification.method(:each)
+    Gem::Specification.define_singleton_method(:each) { |*| nil }
+    begin
+      Jekyll::ThemeVersionGenerator.new.generate(site)
+    ensure
+      Gem::Specification.define_singleton_method(:each, original)
+    end
+    site.config['theme_specs']
+  end
+
+  def test_remote_theme_records_latest
+    specs = run_generator({ 'remote_theme' => 'bamr87/zer0-mistakes' })
+    assert_equal 1, specs.length
+    assert_equal 'zer0-mistakes', specs.first['name']
+    assert_equal 'remote', specs.first['type']
+    assert_equal 'latest', specs.first['version']
+    assert_equal 'bamr87/zer0-mistakes', specs.first['repository']
+  end
+
+  def test_unknown_gem_theme_records_unknown_version
+    specs = run_generator({ 'theme' => 'jekyll-theme-does-not-exist-xyz' })
+    assert_equal 1, specs.length
+    assert_equal 'jekyll-theme-does-not-exist-xyz', specs.first['name']
+    assert_equal 'unknown', specs.first['version']
+    assert_equal 'gem', specs.first['type']
+  end
+
+  def test_no_theme_config_yields_empty_specs
+    assert_equal [], run_generator({})
   end
 end


### PR DESCRIPTION
## Summary

Addresses two direct user requests — **"every page with a mermaid diagram renders properly"** and **"the obsidian graphs for each page are complete and accurate"** — plus completes backlog **T-019** (closes #127's sibling coverage work). 

## Mermaid: 12 pages were silently broken

Pages with ` ```mermaid ` fences but no `mermaid: true` front-matter flag were rendering **raw code instead of diagrams** — the renderer include is gated on `page.mermaid`. Found 16 such pages; 4 are in the production-excluded `docs/` tree (GitHub renders those natively), leaving **12 published pages fixed**: `_about/index`, `_about/features/README`, `_docs/development/{ci-cd,index}`, `_docs/features/{jupyter-notebooks,site-search,cookie-consent,preview-image-generator}`, and **all four quickstart guides**.

Verified: all **34 mermaid diagrams site-wide parse with valid syntax** (via the vendored mermaid parser), and a browser render of a fixed page produced 1 SVG with 0 unconverted fences.

## Obsidian graph: the graph page was a 404

The `/docs/obsidian/graph/` page (the roadmap v1.4 force-directed knowledge graph) had been **deleted as a "stub"** in `2ffb820d`, but its `full-graph.html` include, `obsidian-graph.js`, the docs index link, and **5 inbound wiki-links** all still pointed at it — a broken link to a shipped feature, and the reason the graph was "incomplete." Restored the page; an in-browser test confirms it renders **161 nodes / 269 edges** from the live wiki-index with **0 console errors**, and the 5 "Obsidian Graph View" wiki-links resolve again.

Also audited the wiki-index itself: 145 entries, **0 missing title/url, 0 duplicates, 0 empties** — the graph is complete. The handful of remaining dangling edges are intentional `[[...]]` syntax examples in the obsidian docs, which the graph is *designed* to surface as red nodes. Filed **T-021** to vendor cytoscape.js (the graph's last runtime CDN dependency, inconsistent with the theme's no-CDN principle).

## T-019: migration & theme-version coverage

`scripts/test/lib/test_migrate.sh` (14 assertions) and `ThemeVersionGeneratorTest` in `test/test_plugins.rb` — the two largest zero-coverage subsystems from the T-005 baseline.

## Validation

- `./scripts/bin/test` — 10/10 suites; lib suite 98/98
- `lint-pages --strict` — 164 pages clean
- Mermaid syntax — 34/34 valid; in-browser render confirmed
- Obsidian graph — in-browser render confirmed (161 nodes/269 edges, 0 errors)

No version bump.

https://claude.ai/code/session_01B5Ae9uqneVqkQXZrmz9Qqm

---
_Generated by [Claude Code](https://claude.ai/code/session_01B5Ae9uqneVqkQXZrmz9Qqm)_