### PR TITLE
feat(content-review): AI content reviewer framework with Claude Code agent

### DIFF
--- a/.claude/agents/content-reviewer.md
+++ b/.claude/agents/content-reviewer.md
@@ -1,0 +1,152 @@
+---
+name: content-reviewer
+description: >-
+  Reviews new or changed Jekyll content (Markdown under pages/**) on a pull
+  request for SEO, consistency, polish, style, accessibility, and technical
+  accuracy. USE WHEN a PR adds or edits posts, docs, quickstart, notes, about,
+  or quest pages and you want an editorial + SEO review before merge. Pairs
+  with the deterministic tier in scripts/content-review.rb. DO NOT USE FOR
+  code/theme changes (use /code-review) or front-matter-only normalization
+  (use /frontmatter-maintainer).
+tools: Read, Grep, Glob, Bash
+model: sonnet
+---
+
+# Content Reviewer Agent
+
+You are the **content reviewer** for the Zer0-Mistakes Jekyll theme. Your job is
+to review the *published content* a pull request adds or changes — the prose,
+front matter, and structure of Markdown files under `pages/**` — and return an
+actionable editorial + SEO review. You do **not** review Ruby/Liquid/SCSS/JS;
+that is `/code-review`'s job.
+
+You are read-only by default. Propose specific fixes; do not rewrite files unless
+the orchestrator explicitly asks you to apply changes.
+
+## Inputs & configuration
+
+Everything you need is in the repo — read it, don't assume:
+
+- **Thresholds & focus**: `.github/config/content_review.yml`. Thresholds are
+  **per collection** (`defaults` deep-merged with `collections.<name>`). Treat
+  the *effective* values for the file's collection as the source of truth for
+  every numeric target you cite — don't apply post limits to a note.
+- **Required front matter per collection**: `.github/config/frontmatter_schema.yml`.
+- **SEO/AIEO reference**: `pages/_docs/seo/` (`meta-tags.md`, `aieo.md`).
+
+### Assigned resources (skills · instructions · prompts)
+
+The reviewer is wired to these — use them rather than reinventing checks. The
+deterministic tier already tells you which instruction files apply per file
+(the `instructions` array in its JSON output).
+
+| Type | Resource | Use it for |
+| --- | --- | --- |
+| Skill | [`content-review`](../../.github/skills/content-review/SKILL.md) | The end-to-end review pipeline (this agent's playbook) |
+| Skill | [`validate-build`](../../.github/skills/validate-build/SKILL.md) | Confirm content still builds when you suggest structural changes |
+| Prompt | [`/content-review`](../../.github/prompts/content-review.prompt.md) | Interactive twin of this agent |
+| Prompt | [`/frontmatter-maintainer`](../../.github/prompts/frontmatter-maintainer.prompt.md) | Hand off bulk front-matter normalization |
+| Instructions | `content-review.instructions.md` | Baseline rules for every content file |
+| Instructions | per-collection, e.g. `documentation.instructions.md` (docs/quickstart), `obsidian.instructions.md` (`pages/_docs/obsidian/**`) | Collection-specific authoring rules |
+
+**Per-collection rule loading:** for each changed file, read every path listed
+in that file's `instructions` array (from the deterministic JSON) before
+judging it. Apply the collection's rules, not a generic standard.
+
+## Procedure
+
+1. **Find the changed content files.** Use the list handed to you, or:
+   ```bash
+   git diff --name-only --diff-filter=ACMR origin/main...HEAD | grep -E '^pages/.*\.md$'
+   ```
+   Skip anything matching the `scope.exclude` globs in the config.
+
+2. **Run the deterministic tier first** so you don't spend reasoning on the
+   mechanical checks it already covers:
+   ```bash
+   ruby scripts/content-review.rb --changed --base origin/main \
+     --json /tmp/content-review.json --summary /tmp/content-review.md --quiet
+   ```
+   Read `/tmp/content-review.json`. Treat its findings as *given* — your job is
+   the judgment layer the script can't do. Each entry carries its `collection`,
+   per-collection `score`/`fail_under`, and the `instructions` files that govern
+   it.
+
+3. **Load the governing rules per file.** For each entry, read the paths in its
+   `instructions` array (baseline + collection-specific) so you review docs
+   against the documentation guidelines, posts as articles, notes as short-form,
+   and so on.
+
+4. **Read each changed file in full** and review the dimensions below. Focus on
+   what changed in the PR; don't relitigate untouched content unless the change
+   makes it inconsistent.
+
+## What to review
+
+Weigh each finding by the focus list in `content_review.yml` (`ai_review.focus`).
+
+- **SEO / AIEO**
+  - Title and `description` read naturally *and* sit in range (the script
+    flags length; you judge whether they're compelling and keyword-bearing).
+  - `description` is a complete, self-contained sentence — never truncated to
+    hit the cap.
+  - `keywords` (when present) are genuinely searched phrases, not tag dumps.
+  - The first ~100 words answer the page's implied question (featured-snippet /
+    AI-answer friendly). Headings phrased as the questions readers ask.
+  - Internal links to related content exist where natural (topic clustering).
+
+- **Consistency**
+  - Terminology and casing match `style.terminology` and the rest of the site
+    (e.g. *GitHub*, *Jekyll*, *Markdown*, *front matter*, *Bootstrap 5*).
+  - Voice: second person, active, present tense for instructions.
+  - Front matter conventions (categories/tags as lists, ISO-8601 dates, sensible
+    `categories`/`tags` reused from existing taxonomy — check with a quick grep).
+
+- **Polish & clarity**
+  - No fluff, dead links, TODOs, or placeholder text left in.
+  - Logical heading hierarchy; sections scannable; lists used where apt.
+  - Code blocks are runnable and language-tagged; commands match the repo's real
+    tooling (Docker-first, `scripts/bin/*`, `bundle exec jekyll …`).
+
+- **Accessibility**
+  - Every image has meaningful alt text; heading levels never skip.
+  - Link text is descriptive (no "click here").
+
+- **Technical accuracy**
+  - Claims about the theme/Jekyll/Bootstrap are correct (verify against the repo
+    when unsure — grep for the include/config you're describing).
+  - No leaked secrets or real tokens; use placeholders.
+
+## Output format
+
+Return a single Markdown review the orchestrator can post to the PR. Be concrete
+and quote the file + line. Group by file, ordered worst-first.
+
+```markdown
+## 🤖 Content Review
+
+**Verdict:** ✅ Approve | 💬 Comment | 🔧 Request changes
+<one-sentence rationale>
+
+### `pages/_posts/2026-…-foo.md` — 🟡 acceptable (3 findings)
+- 🔴 **SEO** — Description is truncated mid-sentence; rewrite to a complete
+  120–155 char sentence. Suggested: "<concrete rewrite>"
+- 🟡 **Consistency** — "Github" → "GitHub" (3×, lines 12, 40, 55).
+- 🔵 **Polish** — The intro buries the lede; lead with what the reader builds.
+
+### Summary
+<2–3 sentences: biggest themes, what to fix before merge vs. nice-to-have>
+```
+
+Severity legend: 🔴 must-fix before merge · 🟡 should-fix · 🔵 nice-to-have.
+
+## Rules of engagement
+
+- **Prefer suggestions over edits.** Give the exact replacement text so a human
+  (or a follow-up agent) can apply it in seconds.
+- **Stay in your lane**: content only. If you spot a code/theme bug, note it in
+  one line under "Out of scope" — don't fix it here.
+- **Don't block on taste.** Reserve 🔴 for objective problems (missing required
+  field, broken link, truncated description, missing alt text, factual error).
+- **Be concise.** A reviewer should be able to act on every line you write.
+- **No secrets, no model identifiers** in anything you output to the PR.

--- a/.cursor/commands/content-review.md
+++ b/.cursor/commands/content-review.md
@@ -1,0 +1,45 @@
+---
+agent: agent
+mode: agent
+description: "Review new/changed Jekyll content for SEO, consistency, polish, accessibility, and technical accuracy (per-collection)"
+tools: [run_in_terminal, read_file, grep_search, file_search, get_changed_files]
+---
+
+# Content Review for Zer0-Mistakes
+
+Mirror of [`.github/prompts/content-review.prompt.md`](../../.github/prompts/content-review.prompt.md).
+Review the content this branch/PR adds or changes and return an actionable
+editorial + SEO review. Thresholds and authoring rules are resolved **per
+collection** from `.github/config/content_review.yml`.
+
+## Commands
+
+| Command | Action | Modifies files? |
+|---|---|---|
+| `review` | Review changed files, report findings (default) | No |
+| `fix` | Review **and** apply safe, high-confidence fixes | Yes |
+| `score` | Run the deterministic tier only, print scores | No |
+
+## Procedure
+
+1. Resolve scope — files changed vs `origin/main` matching `pages/**/*.md`,
+   honouring `scope.exclude` in the config.
+2. Run the deterministic tier first:
+   ```bash
+   ruby scripts/content-review.rb --changed --base origin/main \
+     --json /tmp/content-review.json --summary /tmp/content-review.md
+   ```
+3. For each file, read the `instructions` paths the script lists (baseline +
+   collection-specific, e.g. `documentation.instructions.md` for docs), then
+   judge SEO/AIEO, consistency, polish, accessibility, and accuracy.
+4. Report worst-first with a verdict (✅ approve / 💬 comment / 🔧 request
+   changes) and findings tagged 🔴 must-fix · 🟡 should-fix · 🔵 nice-to-have,
+   each with a concrete suggested rewrite.
+
+## Rules
+
+- Content only — no Ruby/Liquid/SCSS/JS review (that's `/code-review`).
+- Prefer suggestions with exact replacement text. In `fix` mode apply only
+  objective fixes and **always bump `lastmod`** on edited files.
+- Reserve 🔴 for objective problems (missing required field, broken link,
+  truncated description, missing alt text, factual error) — not taste.

--- a/.github/config/content_review.yml
+++ b/.github/config/content_review.yml
@@ -1,0 +1,207 @@
+# =========================================================================
+# Content Review Configuration
+# =========================================================================
+# Single source of truth for the AI content reviewer framework.
+#
+# Consumed by:
+#   - scripts/content-review.rb            (deterministic, no-API tier)
+#   - .claude/agents/content-reviewer.md   (Claude Code agent tier)
+#   - .github/workflows/ai-content-review.yml
+#   - .github/instructions/content-review.instructions.md
+#
+# Thresholds are PER COLLECTION. The collection set mirrors `collections:` in
+# _config.yml; required FRONTMATTER fields are NOT duplicated here — they live
+# in .github/config/frontmatter_schema.yml (the canonical schema). Each
+# collection also names the governing `instructions:` file(s) so the reviewer
+# loads the right authoring rules (e.g. docs → documentation.instructions.md).
+#
+# Effective rules for a file = deep-merge(defaults, collections[<collection>]).
+# =========================================================================
+
+config_version: "2.0"
+
+# -------------------------------------------------------------------------
+# Which files get reviewed
+# -------------------------------------------------------------------------
+scope:
+  include:
+    - "pages/_posts/**/*.md"
+    - "pages/_docs/**/*.md"
+    - "pages/_quickstart/**/*.md"
+    - "pages/_notes/**/*.md"
+    - "pages/_notebooks/**/*.md"
+    - "pages/_about/**/*.md"
+    - "pages/_quests/**/*.md"
+    - "pages/_hobbies/**/*.md"
+    - "pages/*.md"
+  exclude:
+    - "**/README.md"
+    - "**/index.html"
+    - "_site/**"
+    - ".jekyll-cache/**"
+    - "node_modules/**"
+
+# -------------------------------------------------------------------------
+# Defaults — inherited by every collection, overridden per collection below.
+# -------------------------------------------------------------------------
+defaults:
+  # SEO thresholds (search + AI-engine optimization). Aligned with
+  # pages/_docs/seo/ (meta-tags.md, aieo.md).
+  seo:
+    title: { min_length: 30, max_length: 60 }
+    description: { min_length: 120, max_length: 160 }
+    keywords: { min: 3, max: 10, recommended: true }
+    require_preview_image: false
+    slug_max_words: 8
+
+  # Content quality thresholds.
+  quality:
+    min_word_count: 100
+    max_word_count: 3500
+    min_h2_headings: 1
+    max_heading_skip: 1
+    require_code_fence_language: true
+    require_image_alt_text: true
+    max_avg_sentence_words: 30
+    flag_bare_urls: true
+
+  # Style & consistency (the agent weighs these; the script checks the
+  # mechanical subset — terminology casing).
+  style:
+    terminology:
+      "Github": "GitHub"
+      "Jekyl": "Jekyll"
+      "Javascript": "JavaScript"
+      "Bootstrap5": "Bootstrap 5"
+      "front-matter": "front matter"
+      "frontmatter": "front matter"
+    voice: "Second person, active voice, present tense for instructions."
+    oxford_comma: true
+
+  # Scoring → weighted 0–100.
+  scoring:
+    weights: { error: 15, warning: 5, info: 1 }
+    thresholds: { excellent: 90, acceptable: 70, failing: 0 }
+    fail_under: 70
+
+  # Baseline authoring rules for any content file.
+  instructions:
+    - .github/instructions/content-review.instructions.md
+
+# -------------------------------------------------------------------------
+# Per-collection overrides (keys mirror _config.yml `collections:`).
+# Only specify what differs from `defaults`; everything else is inherited.
+# -------------------------------------------------------------------------
+collections:
+  posts:
+    # Full-length articles — strongest SEO + length expectations.
+    quality:
+      min_word_count: 300
+    seo:
+      require_preview_image: true
+    instructions:
+      - .github/instructions/content-review.instructions.md
+
+  docs:
+    # Public documentation — governed by the documentation guidelines.
+    quality:
+      min_word_count: 80          # reference pages can be concise
+      max_word_count: 4000
+    instructions:
+      - .github/instructions/content-review.instructions.md
+      - .github/instructions/documentation.instructions.md
+
+  quickstart:
+    # Short, action-oriented getting-started guides.
+    quality:
+      min_word_count: 150
+      max_word_count: 2500
+    seo:
+      keywords: { min: 3, max: 10, recommended: true }
+    instructions:
+      - .github/instructions/content-review.instructions.md
+      - .github/instructions/documentation.instructions.md
+
+  quests:
+    # Long-form tutorials / learning paths.
+    quality:
+      min_word_count: 400
+      max_word_count: 6000
+    instructions:
+      - .github/instructions/content-review.instructions.md
+
+  notes:
+    # Short-form knowledge notes — relax length and keyword pressure.
+    quality:
+      min_word_count: 50
+    seo:
+      keywords: { recommended: false }
+    instructions:
+      - .github/instructions/content-review.instructions.md
+
+  notebooks:
+    # Mostly generated from Jupyter — relax prose-quality checks.
+    quality:
+      min_word_count: 30
+      require_code_fence_language: false
+    seo:
+      keywords: { recommended: false }
+    instructions:
+      - .github/instructions/content-review.instructions.md
+
+  hobbies:
+    quality:
+      min_word_count: 50
+    seo:
+      keywords: { recommended: false }
+    instructions:
+      - .github/instructions/content-review.instructions.md
+
+  about:
+    # Profile / about pages — short, relaxed SEO.
+    quality:
+      min_word_count: 40
+      min_h2_headings: 0
+    seo:
+      description: { min_length: 0, max_length: 160 }
+      keywords: { recommended: false }
+    instructions:
+      - .github/instructions/content-review.instructions.md
+
+  pages:
+    # Top-level landing/utility pages — relax word count.
+    quality:
+      min_word_count: 40
+      min_h2_headings: 0
+    instructions:
+      - .github/instructions/content-review.instructions.md
+
+# -------------------------------------------------------------------------
+# AI (Claude Code agent) tier
+# -------------------------------------------------------------------------
+ai_review:
+  enabled: true                  # gated on ANTHROPIC_API_KEY at runtime
+  model: "claude-sonnet-4-6"
+  max_files_per_run: 20
+  post_inline_comments: true
+  focus:
+    - seo
+    - consistency
+    - polish
+    - accessibility
+    - technical_accuracy
+  # Skills / prompts the reviewer agent is allowed to invoke.
+  skills:
+    - content-review
+    - validate-build
+  prompts:
+    - content-review
+    - frontmatter-maintainer
+
+# -------------------------------------------------------------------------
+# Strictness per context (mirrors content_rules.yml convention)
+# -------------------------------------------------------------------------
+strictness:
+  ci: warn          # PR reviews advise; they do not block merges by default
+  pre_commit: warn
+  manual: warn

--- a/.github/instructions/README.md
+++ b/.github/instructions/README.md
@@ -21,10 +21,12 @@ This directory contains file-specific instructions for GitHub Copilot to provide
 │   ├── obsidian.instructions.md      # Obsidian vault integration (wiki-links, JS resolver, Ruby plugin)
 │   ├── sass.instructions.md          # Sass partials, Bootstrap overrides, CSS custom properties
 │   ├── version-control.instructions.md  # Git workflow and releases
-│   └── backlog.instructions.md       # Tactical backlog schema + sync contract
+│   ├── backlog.instructions.md       # Tactical backlog schema + sync contract
+│   └── content-review.instructions.md   # AI content reviewer: SEO/quality + resolution
 ├── prompts/                         # Reusable agent/chat prompts (.prompt.md)
 │   ├── commit-publish.prompt.md      # Full release pipeline
 │   ├── frontmatter-maintainer.prompt.md  # Front matter audit / fix
+│   ├── content-review.prompt.md      # Content SEO/consistency/polish review
 │   ├── repo-audit.prompt.md          # Review repo → file backlog tasks
 │   ├── backlog-implement.prompt.md   # Implement next backlog task → PR
 │   └── seed.prompt.md                # Theme rebuild blueprint
@@ -55,6 +57,7 @@ GitHub Copilot automatically applies these instructions based on the files you'r
 | `sass.instructions.md`            | `_sass/**`, `assets/css/**`        | Sass partial layering, Bootstrap variable overrides, no-double-Bootstrap rule |
 | `version-control.instructions.md` | `CHANGELOG.md`, `**/version.*`, `*.gemspec`, `package.json` | Git workflow, semantic versioning, releases        |
 | `backlog.instructions.md`         | `_data/backlog.yml`, `scripts/sync-backlog.*`, `.github/workflows/backlog-sync.yml` | Tactical backlog schema, sync contract, ownership rules |
+| `content-review.instructions.md`  | `pages/**/*.md`, `.github/config/content_review.yml`, `.claude/agents/content-reviewer.md`, `scripts/content-review.rb`, `.github/workflows/ai-content-review.yml` | AI content reviewer: per-collection SEO/quality targets, review resolution |
 
 ## 📖 Main Instructions (copilot-instructions.md)
 

--- a/.github/instructions/content-review.instructions.md
+++ b/.github/instructions/content-review.instructions.md
@@ -1,0 +1,145 @@
+---
+applyTo: "pages/**/*.md,.github/config/content_review.yml,.claude/agents/content-reviewer.md,scripts/content-review.rb,.github/workflows/ai-content-review.yml"
+description: "Authoring + review-resolution rules for the AI content reviewer framework — SEO targets, content quality, and how to act on review feedback"
+date: 2026-06-13T15:45:00.000Z
+lastmod: 2026-06-13T15:45:00.000Z
+---
+
+# AI Content Review — Authoring & Resolution
+
+This file governs the **AI content reviewer framework**: how content under
+`pages/**` is reviewed on pull requests and how contributors (human or agent)
+resolve the feedback. It is the prose contract behind three artifacts:
+
+| Artifact | Role |
+| --- | --- |
+| [`scripts/content-review.rb`](../../scripts/content-review.rb) | Deterministic tier — frontmatter + SEO + structure, no API key |
+| [`.claude/agents/content-reviewer.md`](../../.claude/agents/content-reviewer.md) | Claude Code agent tier — editorial / consistency / polish |
+| [`.github/workflows/ai-content-review.yml`](../workflows/ai-content-review.yml) | Runs both tiers on every content PR |
+
+Thresholds live in [`.github/config/content_review.yml`](../config/content_review.yml);
+required front matter lives in
+[`.github/config/frontmatter_schema.yml`](../config/frontmatter_schema.yml).
+**Those configs win** — quote their numbers, don't invent new ones here.
+
+### Thresholds are per collection
+
+Quality and SEO limits are **derived per collection** from the site's
+collections, not applied as one flat rule. The effective rules for a file are
+`deep-merge(defaults, collections.<name>)` in `content_review.yml`, and each
+collection names the governing instruction file(s):
+
+| Collection | Lens | Also governed by |
+| --- | --- | --- |
+| `posts` | Full articles (≥300 words, preview image) | this file |
+| `docs` | Public documentation | [`documentation.instructions.md`](documentation.instructions.md) |
+| `quickstart` | Short action guides | [`documentation.instructions.md`](documentation.instructions.md) |
+| `quests` | Long-form tutorials (≥400 words) | this file |
+| `notes` / `hobbies` | Short-form (keywords optional) | this file |
+| `notebooks` | Generated (relaxed prose checks) | this file |
+| `about` / `pages` | Landing/profile (relaxed length) | this file |
+| `pages/_docs/obsidian/**` | Vault content | [`obsidian.instructions.md`](obsidian.instructions.md) |
+
+The numbers in §1–§2 below are the **defaults**; a collection may tighten or
+relax them. Always grade a file by its own collection's effective values.
+
+---
+
+## 1. SEO targets (default — collections may override)
+
+| Field | Target | Why |
+| --- | --- | --- |
+| `title` | 30–60 chars | Google truncates ~60; under 30 reads thin |
+| `description` | 120–160 chars (optimal 120–155), complete sentence | Meta snippet / AI answer |
+| `keywords` | 3–10 real search phrases (recommended) | AIEO discoverability |
+| First ~100 words | Answer the page's implied question | Featured snippets / LLM answers |
+| Headings | Phrased as the questions readers ask | Scannability + snippet capture |
+
+See [`pages/_docs/seo/meta-tags.md`](../../pages/_docs/seo/meta-tags.md) and
+[`pages/_docs/seo/aieo.md`](../../pages/_docs/seo/aieo.md) for the rendered
+implementation.
+
+### Pitfalls (do not repeat)
+- ❌ Cutting a `description` mid-sentence to hit the cap — rewrite tighter.
+- ❌ `keywords` used as a tag dump instead of searched phrases.
+- ❌ `categories: blog` (bare string) — must be a YAML list `[blog]`.
+
+---
+
+## 2. Content quality (default — collections may override)
+
+- **Word count**: 100–3500 words (posts ≥300, quests ≥400, notes ≥50, …).
+  Split, don't trim meaningful content.
+- **Headings**: ≥1 H2; never skip a level (no H2 → H4).
+- **Code fences**: always language-tagged (```` ```bash ````, ```` ```ruby ````).
+- **Images**: every image needs meaningful alt text.
+- **Links**: descriptive text (never "click here"); no bare URLs in prose.
+- **No placeholders**: strip TODOs, lorem ipsum, and dead links before merge.
+
+---
+
+## 3. Consistency & style
+
+- Canonical casing (from `content_review.yml` → `style.terminology`):
+  *GitHub*, *Jekyll*, *JavaScript*, *Markdown*, *front matter*, *Bootstrap 5*.
+- Voice: second person, active, present tense for instructions.
+- Reuse existing `categories`/`tags` taxonomy — grep before inventing new ones.
+- Commands must match the repo's real tooling (Docker-first, `scripts/bin/*`,
+  `bundle exec jekyll …`).
+
+---
+
+## 4. Scoring & severity
+
+The deterministic tier scores each file 0–100 (`scoring` in the config):
+
+| Score | Verdict | Action |
+| --- | --- | --- |
+| ≥ 90 | 🟢 excellent | merge |
+| ≥ 70 | 🟡 acceptable | merge; address nits when convenient |
+| < 70 | 🔴 needs work | fix before merge |
+
+The agent tier tags findings 🔴 must-fix · 🟡 should-fix · 🔵 nice-to-have.
+**Reviews advise; they do not auto-block merges** (`strictness.ci: warn`).
+
+---
+
+## 5. Resolving review feedback
+
+Work in this order — cheapest, highest-impact first:
+
+1. **Front matter** (missing required fields, list-vs-string, ISO dates).
+2. **SEO** (title/description length, keywords).
+3. **Structure** (headings, code-fence languages, alt text).
+4. **Prose** (clarity, consistency, accuracy).
+
+Then re-run locally before pushing:
+
+```bash
+ruby scripts/content-review.rb --files pages/_<collection>/path/to/file.md
+# or everything changed vs main:
+ruby scripts/content-review.rb --changed --base origin/main
+```
+
+Always update `lastmod` on any file you edit.
+
+---
+
+## 6. Out of scope (open a separate PR)
+
+- ❌ Editing the reviewer itself (`scripts/content-review.rb`,
+  `.claude/agents/content-reviewer.md`, the workflow) inside a content PR.
+- ❌ Code/theme bugs — note them under "Out of scope" and use `/code-review`.
+- ❌ Renaming/restructuring directories or changing permalinks in bulk.
+
+---
+
+## 7. Running it manually
+
+```bash
+# Deterministic tier on whatever changed vs main:
+ruby scripts/content-review.rb --changed --base origin/main
+
+# Full editorial pass (Claude Code), via the reusable prompt:
+/content-review
+```

--- a/.github/prompts/content-review.prompt.md
+++ b/.github/prompts/content-review.prompt.md
@@ -1,0 +1,82 @@
+---
+mode: agent
+description: "Review new/changed Jekyll content for SEO, consistency, polish, accessibility, and technical accuracy"
+tools: [run_in_terminal, read_file, grep_search, file_search, get_changed_files]
+date: 2026-06-13T15:45:00.000Z
+lastmod: 2026-06-13T15:45:00.000Z
+---
+
+# Content Review
+
+When invoked with `/content-review`, review the content this branch/PR adds or
+changes and return an actionable editorial + SEO review. This is the interactive
+twin of the `content-reviewer` Claude Code agent and the
+[`ai-content-review.yml`](../workflows/ai-content-review.yml) workflow. Operate
+as a CLI with explicit commands.
+
+## Commands
+
+| Command | Action | Modifies files? |
+|---|---|---|
+| `review` | Review changed files, report findings (default) | No |
+| `fix` | Review **and** apply safe, high-confidence fixes | Yes |
+| `score` | Run the deterministic tier only, print scores | No |
+
+## Options
+
+```
+--base <ref>      diff base for changed files (default: origin/main)
+--files <glob>    review specific files instead of the diff
+--collection <c>  limit to one collection (posts|docs|quickstart|notes|about|quests)
+--strict          treat scores < 70 as failures (non-zero exit)
+```
+
+## Procedure
+
+1. **Resolve scope.** Default to files changed vs `--base`:
+   ```bash
+   git diff --name-only --diff-filter=ACMR origin/main...HEAD | grep -E '^pages/.*\.md$'
+   ```
+   Honour the `scope.exclude` globs in
+   [`.github/config/content_review.yml`](../config/content_review.yml).
+
+2. **Run the deterministic tier first** (frontmatter + SEO + structure):
+   ```bash
+   ruby scripts/content-review.rb --changed --base origin/main \
+     --json /tmp/content-review.json --summary /tmp/content-review.md
+   ```
+   Read the JSON; treat its findings as given.
+
+3. **Read each file and judge** the dimensions in
+   [`content-review.instructions.md`](../instructions/content-review.instructions.md):
+   SEO/AIEO, consistency, polish, accessibility, technical accuracy. Verify any
+   factual claim about the theme against the repo (grep the include/config).
+
+4. **Report** in this shape, worst file first:
+
+   ```markdown
+   ## 🤖 Content Review
+
+   **Verdict:** ✅ Approve | 💬 Comment | 🔧 Request changes — <one line>
+
+   ### `pages/_posts/…md` — 🟡 acceptable (N findings)
+   - 🔴 SEO — <problem> → Suggested: "<concrete rewrite>"
+   - 🟡 Consistency — "Github" → "GitHub" (lines 12, 40)
+   - 🔵 Polish — <nice-to-have>
+
+   ### Summary
+   <must-fix vs nice-to-have>
+   ```
+
+   Severity: 🔴 must-fix · 🟡 should-fix · 🔵 nice-to-have.
+
+## Rules
+
+- Content only — no Ruby/Liquid/SCSS/JS review (that's `/code-review`). Note any
+  code bug in one line under "Out of scope".
+- Prefer suggestions with exact replacement text over silent edits. In `fix`
+  mode, only apply objective fixes (front matter, terminology, alt text, fenced
+  languages) and **always bump `lastmod`** on edited files.
+- Reserve 🔴 for objective problems (missing required field, broken link,
+  truncated description, missing alt text, factual error) — not taste.
+- Re-run `ruby scripts/content-review.rb --changed` after any `fix`.

--- a/.github/skills/content-review/SKILL.md
+++ b/.github/skills/content-review/SKILL.md
@@ -1,0 +1,75 @@
+---
+name: content-review
+description: "**WORKFLOW SKILL** — Review new/changed Jekyll content (Markdown under pages/**) for SEO, consistency, polish, accessibility, and technical accuracy, using PER-COLLECTION thresholds. USE FOR: reviewing a content PR before merge, auditing a post/doc/quickstart/note you just wrote, pre-publish SEO + style checks, resolving AI-content-review feedback. INVOKES: scripts/content-review.rb (deterministic tier), the content-reviewer Claude Code agent, .github/config/content_review.yml, the per-collection .github/instructions/*.instructions.md. DO NOT USE FOR: code/theme review (use /code-review), bulk front-matter-only normalization (use /frontmatter-maintainer), or releases (use commit-publish)."
+---
+
+# Content Review
+
+Run the Zer0-Mistakes two-tier content review on whatever a branch/PR changes.
+Tier 1 is deterministic (no API key); tier 2 is the editorial Claude Code agent.
+Thresholds and authoring rules are resolved **per collection** — docs follow the
+documentation guidelines, posts are graded as articles, notes as short-form, etc.
+
+## When to use
+
+- Reviewing a PR that adds or edits content under `pages/**`.
+- Before publishing a post/doc/quickstart/note/quest you just drafted.
+- Resolving feedback from the [`ai-content-review.yml`](../../workflows/ai-content-review.yml) workflow.
+
+## Inputs (source of truth)
+
+| File | Provides |
+| --- | --- |
+| [`.github/config/content_review.yml`](../../config/content_review.yml) | Per-collection SEO/quality thresholds, scoring, focus, assigned skills/prompts |
+| [`.github/config/frontmatter_schema.yml`](../../config/frontmatter_schema.yml) | Required front-matter fields per collection |
+| `.github/instructions/content-review.instructions.md` | Baseline authoring + resolution rules |
+| per-collection instructions (e.g. `documentation.instructions.md`) | Collection-specific rules (named in each file's review output) |
+
+## Pipeline
+
+### 1. Deterministic tier (always — no secrets)
+
+```bash
+# Everything changed vs main:
+ruby scripts/content-review.rb --changed --base origin/main \
+  --json /tmp/content-review.json --summary /tmp/content-review.md
+
+# Or specific files:
+ruby scripts/content-review.rb --files "pages/_posts/2026-…-foo.md"
+```
+
+Each result carries `collection`, per-collection `score`/`fail_under`, the
+governing `instructions` array, and categorized `issues`. **Stop and read the
+JSON** before reasoning further — don't re-derive the mechanical checks.
+
+### 2. Editorial tier (Claude Code agent)
+
+Delegate the judgment layer to the [`content-reviewer`](../../../.claude/agents/content-reviewer.md)
+agent (or the [`/content-review`](../../prompts/content-review.prompt.md) prompt).
+For each file, it reads the `instructions` paths the deterministic tier listed,
+then reviews: SEO/AIEO, consistency, polish, accessibility, technical accuracy.
+
+### 3. Report
+
+Use the agent's output format — verdict (✅ approve / 💬 comment / 🔧 request
+changes), per-file findings tagged 🔴 must-fix · 🟡 should-fix · 🔵 nice-to-have,
+each with a concrete suggested rewrite. Reviews advise; they don't auto-block
+(`strictness.ci: warn`).
+
+## Resolving findings (order)
+
+1. Front matter (required fields, list-vs-string, ISO dates)
+2. SEO (title/description length, keywords)
+3. Structure (headings, code-fence languages, alt text)
+4. Prose (clarity, consistency, accuracy)
+
+Re-run `ruby scripts/content-review.rb --changed` after fixing, and **always
+bump `lastmod`** on any file you edit.
+
+## Reporting back
+
+| Tier | Status |
+| --- | --- |
+| Deterministic (avg score / failing files) | ✅ / ⚠️ |
+| Editorial findings (🔴 / 🟡 / 🔵 counts) | … |
+| Verdict | ✅ / 💬 / 🔧 |

--- a/.github/workflows/ai-content-review.yml
+++ b/.github/workflows/ai-content-review.yml
@@ -1,0 +1,136 @@
+name: AI Content Review
+
+# Reviews new/changed Jekyll content on pull requests in two tiers:
+#   1. Deterministic SEO + quality checks (scripts/content-review.rb) — always
+#      runs, no secrets required, works on fork PRs.
+#   2. Claude Code content-reviewer agent — runs only when ANTHROPIC_API_KEY is
+#      configured, for editorial/consistency/polish review.
+# See .github/instructions/content-review.instructions.md for the contract.
+
+on:
+  pull_request:
+    paths:
+      - "pages/**/*.md"
+      - ".github/config/content_review.yml"
+      - ".claude/agents/content-reviewer.md"
+      - "scripts/content-review.rb"
+  workflow_dispatch:
+    inputs:
+      base:
+        description: "Base git ref to diff against"
+        required: false
+        default: "origin/main"
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
+concurrency:
+  group: content-review-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  # ---------------------------------------------------------------------------
+  # Tier 1 — deterministic checks (always)
+  # ---------------------------------------------------------------------------
+  deterministic-review:
+    name: SEO & quality checks
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.3"
+
+      - name: Determine base ref
+        id: base
+        run: |
+          base="${{ github.event.inputs.base || format('origin/{0}', github.base_ref) }}"
+          echo "ref=${base}" >> "$GITHUB_OUTPUT"
+
+      - name: Run content review
+        id: review
+        run: |
+          ruby scripts/content-review.rb \
+            --changed --base "${{ steps.base.outputs.ref }}" \
+            --json /tmp/content-review.json \
+            --summary /tmp/content-review.md \
+            --quiet || true
+          # Surface a build-log copy too.
+          cat /tmp/content-review.md || true
+
+      - name: Post / update PR comment
+        if: github.event_name == 'pull_request'
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: ai-content-review
+          path: /tmp/content-review.md
+
+      - name: Upload results
+        uses: actions/upload-artifact@v4
+        with:
+          name: content-review-results
+          path: |
+            /tmp/content-review.json
+            /tmp/content-review.md
+          retention-days: 30
+          if-no-files-found: ignore
+
+  # ---------------------------------------------------------------------------
+  # Gate — is the Claude Code tier available? (secret present, not a fork PR)
+  # ---------------------------------------------------------------------------
+  gate:
+    name: Check AI availability
+    runs-on: ubuntu-latest
+    outputs:
+      ai_enabled: ${{ steps.check.outputs.enabled }}
+    steps:
+      - id: check
+        env:
+          KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        run: |
+          if [ -n "$KEY" ]; then
+            echo "enabled=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::ANTHROPIC_API_KEY not set — skipping Claude Code content review (deterministic tier still ran)."
+          fi
+
+  # ---------------------------------------------------------------------------
+  # Tier 2 — Claude Code content-reviewer agent
+  # ---------------------------------------------------------------------------
+  ai-review:
+    name: Claude Code content review
+    needs: [deterministic-review, gate]
+    if: ${{ github.event_name == 'pull_request' && needs.gate.outputs.ai_enabled == 'true' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Claude content review
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          prompt: |
+            Use the content-reviewer subagent to review the Markdown content
+            files changed in pull request #${{ github.event.pull_request.number }}
+            (base: ${{ github.base_ref }}). Follow
+            .github/instructions/content-review.instructions.md and the
+            thresholds in .github/config/content_review.yml. Post a single
+            consolidated review comment on the PR using the agent's output
+            format. Focus on SEO, consistency, polish, accessibility, and
+            technical accuracy. Do not modify files.
+          claude_args: |
+            --model claude-sonnet-4-6
+            --max-turns 20
+            --allowedTools "Task,Read,Grep,Glob,Bash(git diff:*),Bash(ruby scripts/content-review.rb:*)"

--- a/.github/workflows/ai-content-review.yml
+++ b/.github/workflows/ai-content-review.yml
@@ -37,6 +37,8 @@ jobs:
   deterministic-review:
     name: SEO & quality checks
     runs-on: ubuntu-latest
+    outputs:
+      has_content: ${{ steps.review.outputs.has_content }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -64,6 +66,13 @@ jobs:
             --quiet || true
           # Surface a build-log copy too.
           cat /tmp/content-review.md || true
+          # Did any in-scope content files actually change? Gates the AI tier.
+          count=$(ruby -rjson -e 'puts (JSON.parse(File.read("/tmp/content-review.json"))["files"] || []).length' 2>/dev/null || echo 0)
+          if [ "${count:-0}" -gt 0 ]; then
+            echo "has_content=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_content=false" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Post / update PR comment
         if: github.event_name == 'pull_request'
@@ -108,7 +117,7 @@ jobs:
   ai-review:
     name: Claude Code content review
     needs: [deterministic-review, gate]
-    if: ${{ github.event_name == 'pull_request' && needs.gate.outputs.ai_enabled == 'true' }}
+    if: ${{ github.event_name == 'pull_request' && needs.gate.outputs.ai_enabled == 'true' && needs.deterministic-review.outputs.has_content == 'true' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,6 +62,7 @@ should load them manually):
 | `docs/**`, `pages/_docs/**`, `*docs*.md` | `.github/instructions/documentation.instructions.md` |
 | `CHANGELOG.md`, `**/version.*`, `*.gemspec`, `package.json` | `.github/instructions/version-control.instructions.md` |
 | `_data/backlog.yml`, `scripts/sync-backlog.*`, `.github/workflows/backlog-sync.yml` | `.github/instructions/backlog.instructions.md` |
+| `pages/**/*.md`, `.github/config/content_review.yml`, `.claude/agents/content-reviewer.md`, `scripts/content-review.rb`, `.github/workflows/ai-content-review.yml` | `.github/instructions/content-review.instructions.md` |
 
 ### Reusable prompts
 
@@ -70,6 +71,7 @@ should load them manually):
 | Full release pipeline (analyze → validate → version → publish → verify) | `.github/prompts/commit-publish.prompt.md` |
 | Add a new Obsidian wiki-link / embed / callout syntax across all rendering paths | `.github/prompts/obsidian-add-syntax.prompt.md` |
 | Front matter audit / fix across content | `.github/prompts/frontmatter-maintainer.prompt.md` |
+| Review content for SEO / consistency / polish (per-collection) | `.github/prompts/content-review.prompt.md` |
 | Rebuild the theme from scratch (deep blueprint) | `.github/prompts/seed.prompt.md` |
 | Review the repo and file tactical tasks into the backlog | `.github/prompts/repo-audit.prompt.md` |
 | Implement the next open backlog task and open a PR | `.github/prompts/backlog-implement.prompt.md` |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,29 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- **AI content reviewer framework**: a two-tier reviewer that runs on every PR
+  touching `pages/**/*.md` and integrates with Claude Code agents to ensure SEO
+  is met and content is consistent, polished, and styled to the collection's
+  guidelines.
+  - **Deterministic tier** — `scripts/content-review.rb` (Ruby, stdlib-only, no
+    API key, works on fork PRs) scores each file 0–100 for front matter, SEO
+    (title/description length, keywords), structure (headings, code-fence
+    languages, image alt text, bare URLs), and terminology. Thresholds are
+    derived **per collection** (posts as articles, docs under the documentation
+    guidelines, notes/notebooks as short-form, etc.).
+  - **Claude Code agent tier** — `.claude/agents/content-reviewer.md` reviews
+    tone, clarity, consistency, accessibility, and technical accuracy, loading
+    each file's governing instruction files (baseline + collection-specific).
+  - **Automation** — `.github/workflows/ai-content-review.yml` posts the
+    deterministic summary as a sticky PR comment (always) and runs the Claude
+    Code agent when `ANTHROPIC_API_KEY` is configured.
+  - **Config & guidance** — `.github/config/content_review.yml` (per-collection
+    thresholds + assigned skills/prompts), `.github/instructions/content-review.instructions.md`,
+    the `/content-review` prompt + Cursor command, and the `content-review` skill.
+
 ## [1.17.1] - 2026-06-13
 
 ### Changed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,12 +22,19 @@ files you touch:
   canonical detailed conventions (architecture, commit/release workflow).
 - `.github/instructions/*.instructions.md` — file-scoped rules; each file has
   an `applyTo:` glob in its front matter (layouts, includes, scripts, install,
-  obsidian, sass, testing, documentation, version-control, backlog). Read the
-  matching file before editing those paths.
+  obsidian, sass, testing, documentation, version-control, backlog,
+  content-review). Read the matching file before editing those paths.
 - `.github/prompts/*.prompt.md` — reusable multi-step workflows
   (`commit-publish`, `repo-audit`, `backlog-implement`, `obsidian-add-syntax`,
-  `frontmatter-maintainer`, `seed`). Mirrored as Cursor commands in
-  `.cursor/commands/`.
+  `frontmatter-maintainer`, `content-review`, `seed`). Mirrored as Cursor
+  commands in `.cursor/commands/`.
+- **AI content reviewer** — reviews content PRs (Markdown under `pages/**`) for
+  SEO, consistency, polish, accessibility, and accuracy. Two tiers:
+  `scripts/content-review.rb` (deterministic, per-collection thresholds from
+  `.github/config/content_review.yml`) and the
+  `.claude/agents/content-reviewer.md` Claude Code agent, run on PRs by
+  `.github/workflows/ai-content-review.yml`. Skill:
+  `.github/skills/content-review/`.
 - `_data/backlog.yml` — tactical task backlog (source of truth; synced to
   GitHub Issues by `.github/workflows/backlog-sync.yml`). See
   [`docs/systems/continuous-evolution.md`](./docs/systems/continuous-evolution.md).

--- a/scripts/content-review.rb
+++ b/scripts/content-review.rb
@@ -1,0 +1,452 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# =============================================================================
+# content-review.rb
+# =============================================================================
+#
+# Deterministic (no-API) tier of the AI content reviewer framework.
+#
+# Scores Jekyll content files for SEO and content quality using the thresholds
+# in .github/config/content_review.yml and the required-field schema in
+# .github/config/frontmatter_schema.yml. Designed to run anywhere — locally,
+# in CI, and on fork PRs without secrets — so contributors get fast, mechanical
+# feedback before (and independently of) the Claude Code agent tier.
+#
+# Usage:
+#   ruby scripts/content-review.rb --changed --base origin/main   # diff vs base
+#   ruby scripts/content-review.rb --files "a.md b.md"            # explicit files
+#   ruby scripts/content-review.rb --files a.md --json out.json --summary out.md
+#   ruby scripts/content-review.rb --changed --strict            # non-zero on fail
+#
+# Options:
+#   --files LIST      Space/newline-separated markdown files to review
+#   --changed         Review files changed vs --base (git diff)
+#   --base REF        Base git ref for --changed (default: origin/main)
+#   --config PATH     content_review.yml (default: .github/config/content_review.yml)
+#   --schema PATH     frontmatter_schema.yml (default: .github/config/frontmatter_schema.yml)
+#   --json PATH       Write machine-readable JSON results
+#   --summary PATH    Write a Markdown summary (suitable for a PR comment)
+#   --strict          Exit non-zero if any file scores below the fail threshold
+#   --quiet           Suppress the human-readable stdout table
+#   --help            Show this help
+#
+# Exit codes:
+#   0  clean (or warn mode)
+#   1  one or more files below fail threshold (only when --strict)
+#   2  invalid arguments / no files
+#   3  config or parse error
+#
+# No gem dependencies beyond the Ruby stdlib.
+# =============================================================================
+
+require 'yaml'
+require 'json'
+require 'optparse'
+require 'date'
+
+# Content is UTF-8; force it so checks don't trip on emoji/accents under a
+# US-ASCII locale (common on minimal CI runners).
+Encoding.default_external = Encoding::UTF_8
+Encoding.default_internal = Encoding::UTF_8
+
+ROOT = File.expand_path('..', __dir__)
+
+# --- Severity helpers --------------------------------------------------------
+SEVERITIES = %w[error warning info].freeze
+
+Issue = Struct.new(:severity, :category, :message)
+
+# --- Options -----------------------------------------------------------------
+options = {
+  files: nil,
+  changed: false,
+  base: ENV['CONTENT_REVIEW_BASE'] || 'origin/main',
+  config: File.join(ROOT, '.github', 'config', 'content_review.yml'),
+  schema: File.join(ROOT, '.github', 'config', 'frontmatter_schema.yml'),
+  json: nil,
+  summary: nil,
+  strict: false,
+  quiet: false
+}
+
+parser = OptionParser.new do |o|
+  o.banner = 'Usage: ruby scripts/content-review.rb [options]'
+  o.on('--files LIST', 'Files to review (space/newline separated)') { |v| options[:files] = v }
+  o.on('--changed', 'Review files changed vs --base') { options[:changed] = true }
+  o.on('--base REF', 'Base git ref for --changed') { |v| options[:base] = v }
+  o.on('--config PATH', 'content_review.yml path') { |v| options[:config] = v }
+  o.on('--schema PATH', 'frontmatter_schema.yml path') { |v| options[:schema] = v }
+  o.on('--json PATH', 'Write JSON results') { |v| options[:json] = v }
+  o.on('--summary PATH', 'Write Markdown summary') { |v| options[:summary] = v }
+  o.on('--strict', 'Exit non-zero on failing files') { options[:strict] = true }
+  o.on('--quiet', 'Suppress stdout table') { options[:quiet] = true }
+  o.on('-h', '--help', 'Show help') { puts o; exit 0 }
+end
+
+begin
+  parser.parse!(ARGV)
+rescue OptionParser::ParseError => e
+  warn "Error: #{e.message}"
+  warn parser
+  exit 2
+end
+
+# --- Load configuration ------------------------------------------------------
+def load_yaml(path)
+  YAML.safe_load(File.read(path), permitted_classes: [Date, Time], aliases: true) || {}
+rescue StandardError => e
+  warn "Failed to read #{path}: #{e.message}"
+  exit 3
+end
+
+unless File.exist?(options[:config])
+  warn "Config not found: #{options[:config]}"
+  exit 3
+end
+
+CONFIG = load_yaml(options[:config])
+SCHEMA = File.exist?(options[:schema]) ? load_yaml(options[:schema]) : {}
+
+# Backward-compatible: v2 uses `defaults:`, but fall back to top-level keys.
+DEFAULTS = CONFIG['defaults'] || CONFIG
+COLLECTION_CFG = CONFIG['collections'] || {}
+DEFAULT_FAIL_UNDER = ((DEFAULTS['scoring'] || {})['fail_under'] || 70).to_i
+
+# Recursively merge `override` onto `base` (override wins; hashes merge deep).
+def deep_merge(base, override)
+  return base if override.nil?
+  return override unless base.is_a?(Hash) && override.is_a?(Hash)
+
+  merged = base.dup
+  override.each do |k, v|
+    merged[k] = merged.key?(k) ? deep_merge(merged[k], v) : v
+  end
+  merged
+end
+
+# Effective rules for a collection = deep-merge(defaults, collections[name]).
+# `collections.*` in frontmatter_schema.yml may differ from content_review.yml;
+# here we only merge the review config, not the schema.
+def effective_config(collection)
+  base = DEFAULTS
+  override = collection ? (COLLECTION_CFG[collection] || {}) : {}
+  deep_merge(base, override)
+end
+
+# --- Resolve the list of files ----------------------------------------------
+def git_changed_files(base)
+  merge_base = `git merge-base #{base} HEAD 2>/dev/null`.strip
+  ref = merge_base.empty? ? base : merge_base
+  out = `git diff --name-only --diff-filter=ACMR #{ref} HEAD 2>/dev/null`
+  out.split("\n").map(&:strip).reject(&:empty?)
+end
+
+def excluded?(path, config)
+  patterns = (config['scope'] || {})['exclude'] || []
+  patterns.any? { |g| File.fnmatch(g, path, File::FNM_PATHNAME | File::FNM_EXTGLOB) }
+end
+
+def included?(path, config)
+  patterns = (config['scope'] || {})['include'] || []
+  patterns.any? { |g| File.fnmatch(g, path, File::FNM_PATHNAME | File::FNM_EXTGLOB) }
+end
+
+raw_files =
+  if options[:files]
+    options[:files].split(/[\s\n]+/).map(&:strip).reject(&:empty?)
+  elsif options[:changed]
+    git_changed_files(options[:base])
+  else
+    warn 'Nothing to review: pass --files or --changed.'
+    exit 2
+  end
+
+files = raw_files
+        .select { |f| f.end_with?('.md') }
+        .select { |f| included?(f, CONFIG) && !excluded?(f, CONFIG) }
+        .select { |f| File.exist?(File.join(ROOT, f)) || File.exist?(f) }
+        .uniq
+
+if files.empty?
+  puts 'No in-scope content files to review.'
+  # Still emit empty artifacts so downstream steps don't choke.
+  File.write(options[:json], JSON.pretty_generate({ 'files' => [], 'average_score' => nil })) if options[:json]
+  File.write(options[:summary], "## 📝 Content Review\n\nNo in-scope content files changed.\n") if options[:summary]
+  exit 0
+end
+
+# --- Front matter + body parsing --------------------------------------------
+def split_front_matter(text)
+  if text =~ /\A---\s*\n(.*?)\n---\s*\n?(.*)\z/m
+    [Regexp.last_match(1), Regexp.last_match(2)]
+  else
+    [nil, text]
+  end
+end
+
+def parse_front_matter(yaml_text)
+  return {} if yaml_text.nil? || yaml_text.strip.empty?
+
+  YAML.safe_load(yaml_text, permitted_classes: [Date, Time], aliases: true) || {}
+rescue StandardError
+  nil # signals a parse error
+end
+
+# Remove fenced code blocks so prose checks don't trip on code.
+def strip_code_fences(body)
+  body.gsub(/^```.*?^```/m, '').gsub(/`[^`]*`/, '')
+end
+
+# --- Collection detection ----------------------------------------------------
+def detect_collection(path, schema)
+  collections = schema['collections'] || {}
+  # Match specific collections before the generic top-level `pages` pattern.
+  ordered = collections.sort_by { |name, _| name == 'pages' ? 1 : 0 }
+  ordered.each do |name, spec|
+    pattern = spec['path_pattern']
+    next unless pattern
+
+    return name if File.fnmatch(pattern, path, File::FNM_PATHNAME | File::FNM_EXTGLOB)
+  end
+  nil
+end
+
+# --- Individual checks -------------------------------------------------------
+def check_frontmatter(fm, collection, schema)
+  issues = []
+  return [Issue.new('error', 'frontmatter', 'No front matter block found')] if fm.nil?
+  return [Issue.new('error', 'frontmatter', 'Front matter is not valid YAML')] if fm == :parse_error
+
+  spec = (schema['collections'] || {})[collection]
+  required = spec ? (spec['required'] || []) : []
+  required.each do |field|
+    val = fm[field]
+    if val.nil? || (val.respond_to?(:empty?) && val.empty?)
+      issues << Issue.new('error', 'frontmatter', "Missing required field: `#{field}`")
+    end
+  end
+
+  # categories/tags should be lists, not bare strings.
+  %w[categories tags].each do |field|
+    next unless fm.key?(field)
+
+    issues << Issue.new('warning', 'frontmatter', "`#{field}` should be a YAML list, not a bare string") if fm[field].is_a?(String)
+  end
+  issues
+end
+
+def check_seo(fm, seo)
+  issues = []
+  return issues if fm.nil? || fm == :parse_error
+
+  title = fm['title'].to_s
+  unless title.empty?
+    t = (seo['title'] || {})
+    min = (t['min_length'] || 30).to_i
+    max = (t['max_length'] || 60).to_i
+    if title.length < min
+      issues << Issue.new('warning', 'seo', "Title is #{title.length} chars (aim for #{min}–#{max})")
+    elsif title.length > max
+      issues << Issue.new('warning', 'seo', "Title is #{title.length} chars — over #{max}, will truncate in search results")
+    end
+  end
+
+  desc = fm['description'].to_s
+  d = (seo['description'] || {})
+  dmin = (d['min_length'] || 120).to_i
+  dmax = (d['max_length'] || 160).to_i
+  if desc.empty?
+    issues << Issue.new('warning', 'seo', 'No meta description — add a 120–160 char `description`')
+  elsif desc.length < dmin
+    issues << Issue.new('warning', 'seo', "Description is #{desc.length} chars (aim for #{dmin}–#{dmax})")
+  elsif desc.length > dmax
+    issues << Issue.new('warning', 'seo', "Description is #{desc.length} chars — over #{dmax}, will truncate")
+  end
+
+  kw = (seo['keywords'] || {})
+  if kw['recommended']
+    keywords = fm['keywords']
+    if keywords.nil?
+      issues << Issue.new('info', 'seo', 'No `keywords` — a 3–10 item list aids AI-engine optimization (AIEO)')
+    elsif keywords.is_a?(Array)
+      kmin = (kw['min'] || 3).to_i
+      kmax = (kw['max'] || 10).to_i
+      issues << Issue.new('info', 'seo', "Only #{keywords.length} keyword(s) — aim for #{kmin}–#{kmax}") if keywords.length < kmin
+      issues << Issue.new('info', 'seo', "#{keywords.length} keywords — trim to #{kmax} most relevant") if keywords.length > kmax
+    end
+  end
+
+  if seo['require_preview_image']
+    has_image = %w[preview image og_image].any? { |k| !fm[k].to_s.empty? }
+    issues << Issue.new('info', 'seo', 'No preview/social image set') unless has_image
+  end
+  issues
+end
+
+def check_quality(body, quality)
+  issues = []
+  prose = strip_code_fences(body)
+  words = prose.split(/\s+/).reject(&:empty?)
+  wc = words.length
+
+  min_wc = (quality['min_word_count'] || 100).to_i
+  max_wc = (quality['max_word_count'] || 3500).to_i
+  if wc < min_wc
+    issues << Issue.new('warning', 'quality', "Only ~#{wc} words — below the #{min_wc}-word minimum (reads as a stub)")
+  elsif wc > max_wc
+    issues << Issue.new('info', 'quality', "~#{wc} words — over #{max_wc}; consider splitting into multiple pages")
+  end
+
+  # Heading structure (ignore headings inside code fences).
+  headings = body.gsub(/^```.*?^```/m, '').scan(/^(#{'#'}{1,6})\s+\S/).map { |m| m[0].length }
+  h2_plus = headings.count { |lvl| lvl >= 2 }
+  min_h2 = (quality['min_h2_headings'] || 1).to_i
+  issues << Issue.new('info', 'quality', "Fewer than #{min_h2} H2 heading(s) — add sections for scannability") if h2_plus < min_h2
+
+  max_skip = (quality['max_heading_skip'] || 1).to_i
+  headings.each_cons(2) do |a, b|
+    if b - a > max_skip
+      issues << Issue.new('warning', 'quality', "Heading level jumps from H#{a} to H#{b} — don't skip levels")
+      break
+    end
+  end
+
+  # Code fences must declare a language.
+  if quality['require_code_fence_language']
+    body.scan(/^```([^\n]*)\n/).each do |m|
+      info = m[0].strip
+      issues << Issue.new('info', 'quality', 'Code fence without a language (use ```bash, ```ruby, …)') if info.empty?
+    end
+  end
+
+  # Images must have alt text.
+  if quality['require_image_alt_text']
+    body.scan(/!\[(.*?)\]\(([^)]*)\)/).each do |alt, src|
+      issues << Issue.new('warning', 'accessibility', "Image missing alt text: `#{src}`") if alt.strip.empty?
+    end
+  end
+
+  # Bare URLs.
+  if quality['flag_bare_urls']
+    bare = strip_code_fences(body).scan(%r{(?<![("<\]])\bhttps?://[^\s)>\]]+}).reject { |u| u.include?('](') }
+    issues << Issue.new('info', 'quality', "#{bare.length} bare URL(s) — wrap as [text](url)") unless bare.empty?
+  end
+  issues
+end
+
+def check_style(body, style)
+  issues = []
+  prose = strip_code_fences(body)
+  (style['terminology'] || {}).each do |wrong, right|
+    next if wrong.to_s.empty?
+
+    if prose.match?(/\b#{Regexp.escape(wrong)}\b/)
+      issues << Issue.new('info', 'style', "Use \"#{right}\" instead of \"#{wrong}\"")
+    end
+  end
+  issues
+end
+
+# --- Scoring -----------------------------------------------------------------
+def score_for(issues, weights)
+  penalty = issues.sum { |i| (weights[i.severity] || 0).to_i }
+  [100 - penalty, 0].max
+end
+
+def verdict(score, scoring)
+  th = scoring['thresholds'] || {}
+  return '🟢 excellent' if score >= (th['excellent'] || 90).to_i
+  return '🟡 acceptable' if score >= (th['acceptable'] || 70).to_i
+
+  '🔴 needs work'
+end
+
+# --- Run ---------------------------------------------------------------------
+results = []
+
+files.each do |rel|
+  abs = File.exist?(rel) ? rel : File.join(ROOT, rel)
+  text = File.read(abs, encoding: 'UTF-8')
+  fm_text, body = split_front_matter(text)
+  fm = parse_front_matter(fm_text)
+  fm = :parse_error if fm.nil? && !fm_text.nil?
+
+  collection = detect_collection(rel, SCHEMA)
+  eff = effective_config(collection)
+  weights = (eff['scoring'] || {})['weights'] || { 'error' => 15, 'warning' => 5, 'info' => 1 }
+  fail_under = ((eff['scoring'] || {})['fail_under'] || DEFAULT_FAIL_UNDER).to_i
+
+  issues = []
+  issues.concat(check_frontmatter(fm == :parse_error ? :parse_error : fm, collection, SCHEMA))
+  issues.concat(check_seo(fm, eff['seo'] || {}))
+  issues.concat(check_quality(body, eff['quality'] || {}))
+  issues.concat(check_style(body, eff['style'] || {}))
+
+  score = score_for(issues, weights)
+  results << {
+    'file' => rel,
+    'collection' => collection,
+    'score' => score,
+    'fail_under' => fail_under,
+    'verdict' => verdict(score, eff['scoring'] || {}),
+    'instructions' => eff['instructions'] || [],
+    'issues' => issues.map { |i| { 'severity' => i.severity, 'category' => i.category, 'message' => i.message } }
+  }
+end
+
+avg = results.empty? ? nil : (results.sum { |r| r['score'] } / results.length.to_f).round(1)
+failing = results.select { |r| r['score'] < r['fail_under'] }
+
+# --- Markdown summary --------------------------------------------------------
+def render_summary(results, avg, fail_under)
+  lines = []
+  lines << '## 📝 AI Content Review — deterministic checks'
+  lines << ''
+  lines << "Reviewed **#{results.length}** file(s) · average score **#{avg}/100** · pass threshold **#{fail_under}** (per-collection)."
+  lines << ''
+  lines << '| File | Collection | Score | Verdict |'
+  lines << '| --- | --- | ---: | --- |'
+  results.sort_by { |r| r['score'] }.each do |r|
+    lines << "| `#{r['file']}` | #{r['collection'] || '—'} | #{r['score']}/#{r['fail_under']} | #{r['verdict']} |"
+  end
+  lines << ''
+
+  emoji = { 'error' => '❌', 'warning' => '⚠️', 'info' => 'ℹ️' }
+  results.each do |r|
+    next if r['issues'].empty?
+
+    lines << "<details><summary><code>#{r['file']}</code> — #{r['issues'].length} item(s), score #{r['score']}</summary>"
+    lines << ''
+    r['issues'].sort_by { |i| SEVERITIES.index(i['severity']) || 9 }.each do |i|
+      lines << "- #{emoji[i['severity']] || '•'} **#{i['category']}** — #{i['message']}"
+    end
+    lines << ''
+    lines << '</details>'
+    lines << ''
+  end
+
+  lines << '---'
+  lines << '_Deterministic tier (frontmatter + SEO + structure). The Claude Code'
+  lines << 'content-reviewer agent covers tone, clarity, and accuracy separately._'
+  lines.join("\n") + "\n"
+end
+
+summary_md = render_summary(results, avg, DEFAULT_FAIL_UNDER)
+
+# --- Outputs -----------------------------------------------------------------
+File.write(options[:json], JSON.pretty_generate({ 'files' => results, 'average_score' => avg, 'default_fail_under' => DEFAULT_FAIL_UNDER })) if options[:json]
+File.write(options[:summary], summary_md) if options[:summary]
+
+unless options[:quiet]
+  results.sort_by { |r| r['score'] }.each do |r|
+    puts "#{r['verdict'].ljust(14)} #{r['score'].to_s.rjust(3)}  #{r['file']}"
+    r['issues'].each { |i| puts "    [#{i['severity']}] #{i['category']}: #{i['message']}" }
+  end
+  puts ''
+  puts "Average: #{avg}/100  (#{results.length} file(s), default threshold #{DEFAULT_FAIL_UNDER})"
+  puts "Failing: #{failing.map { |r| r['file'] }.join(', ')}" unless failing.empty?
+end
+
+exit 1 if options[:strict] && !failing.empty?
+exit 0


### PR DESCRIPTION
## Summary

Builds an **AI content reviewer framework** that runs on every pull request touching `pages/**/*.md`, integrating with **Claude Code agents** to ensure SEO considerations are met and content is consistent, polished, and styled to each collection's guidelines. Modeled on the framework in `bamr87/it-journey`, adapted to this repo's native conventions (config-driven validation, Ruby/Bash tooling, layered agent guidance).

The reviewer is **two-tier**:

1. **Deterministic tier** — `scripts/content-review.rb` (Ruby, stdlib-only, no API key, works on fork PRs). Scores each file `0–100` for:
   - front matter (required fields from `frontmatter_schema.yml`, list-vs-string)
   - SEO (title 30–60, description 120–160, keywords 3–10)
   - structure (H2 presence, no heading skips, code-fence languages, image alt text, bare URLs)
   - terminology/casing (GitHub, Jekyll, Markdown, front matter, …)
2. **Claude Code agent tier** — `.claude/agents/content-reviewer.md` reviews tone, clarity, consistency, accessibility, and technical accuracy, loading each file's governing instruction files.

### Per-collection thresholds (per review feedback)
Quality and SEO limits are **derived per collection** from the site's collections — `defaults` deep-merged with `collections.<name>` in `.github/config/content_review.yml`. Each collection also names the instruction file(s) that govern it, so **docs are reviewed under `documentation.instructions.md`**, posts as full articles (≥300 words + preview image), quests as long-form, notes/notebooks/hobbies as short-form, etc.

### Reviewer wired to skills · instructions · prompts
The `content-reviewer` agent is explicitly assigned its resources: the `content-review` and `validate-build` **skills**, the `/content-review` and `/frontmatter-maintainer` **prompts**, and the baseline + per-collection **instructions** (the deterministic tier emits each file's `instructions` array so the agent loads the right rules).

## Files
| File | Role |
| --- | --- |
| `scripts/content-review.rb` | Deterministic SEO/quality analyzer (per-collection) |
| `.claude/agents/content-reviewer.md` | Claude Code editorial agent |
| `.github/workflows/ai-content-review.yml` | PR automation (sticky comment + gated agent run) |
| `.github/config/content_review.yml` | Per-collection thresholds + assigned skills/prompts |
| `.github/instructions/content-review.instructions.md` | Authoring + resolution rules |
| `.github/prompts/content-review.prompt.md` + `.cursor/commands/content-review.md` | `/content-review` workflow |
| `.github/skills/content-review/SKILL.md` | Review-pipeline skill |
| `CLAUDE.md`, `AGENTS.md`, `.github/instructions/README.md`, `CHANGELOG.md` | Registration |

## How the workflow behaves
- **Always** runs the deterministic tier and posts/updates a single sticky PR comment (no secret required — fork PRs get feedback too).
- Runs the Claude Code agent **only when `ANTHROPIC_API_KEY` is configured** (gated job; logs a notice and skips gracefully otherwise).
- Reviews **advise, they do not block merges** (`strictness.ci: warn`).

## Validation
- `ruby -c scripts/content-review.rb` → Syntax OK
- YAML parses for the new config + workflow
- Ran the analyzer across the full content corpus (58 files) with no errors (avg 81.9/100) and confirmed per-collection thresholds + instruction mapping (docs → `content-review` + `documentation` instructions; notes graded short-form)
- `--changed --base origin/main` correctly reports no in-scope changes on a parity branch

## Setup note
To enable the agent tier, add an `ANTHROPIC_API_KEY` repository secret and install the Claude GitHub App. Until then, the deterministic tier runs on its own.

https://claude.ai/code/session_014phQptg8y56CDCz8WA3gBG

---
_Generated by [Claude Code](https://claude.ai/code/session_014phQptg8y56CDCz8WA3gBG)_