### PR TITLE
docs(content): resolve AI content-review findings across 3 pages

### DIFF
--- a/pages/_about/features/jekyll.md
+++ b/pages/_about/features/jekyll.md
@@ -1,19 +1,24 @@
 ---
-title: Jeykll
-preview: /images/previews/jeykll.png
+title: "Jekyll Cheatsheet: Setup, Liquid Filters & Templates"
+description: "A practical Jekyll reference covering installation, Liquid filters, layout templates, folder structure, permalinks, and paginator variables."
+preview: /images/previews/jekyll.png
 permalink: /notes/jekyll/
-lastmod: 2025-12-20T22:15:46.473Z
+lastmod: 2026-06-14T14:30:00.000Z
 published: false
 draft: true
 ---
 
-# Jeykll
+# Jekyll Cheatsheet
+
+Use this reference for common Jekyll setup commands, Liquid template syntax, folder conventions, and built-in filters.
 
 {% raw %}
 [Cheatsheet](https://learn-the-web.algonquindesign.ca/topics/jekyll-cheat-sheet/)
 
 Setup and use
 Installation
+
+> For this theme, the recommended setup is Docker: `docker-compose up` (see the project README).
 
 All these commands should be executed in Terminal, one-by-one, in order.
 
@@ -41,7 +46,7 @@ bundle install
 
 ☛ Jekyll installation.
 
-Starting & stopping
+Starting and stopping
 
 First, open your Jekyll folder in Terminal using the GitHub app shortcut—⌃`
 
@@ -51,9 +56,8 @@ Start Jekyll:
 bundle exec jekyll serve
 ```
 
-View your website in a browser:
+View your website in a browser at `http://localhost:4000/`.
 
-'http://localhost:4000/'
 Stop Jekyll:
 
 Control + C
@@ -96,12 +100,12 @@ index.html
 meat-eaters.html
 ```
 
-Files & paths
+Files and paths
 Linking pages
 
 With permalink: pretty turned on the .html extension can be left off URLs.
 
-\*All links & hrefs & srcs should always start with a forward slash: /
+\*All links and hrefs and srcs should always start with a forward slash: /
 
 ```html
 <a href="/plant-eaters/">Plant eaters</a>
@@ -130,17 +134,17 @@ Linking images
 Link images like normal, make sure to start with a /
 
 ```html
-<img src="/images/trex.jpg" alt="" />
+<img src="/images/trex.jpg" alt="Tyrannosaurus Rex dinosaur" />
 ```
 
 Or for GitHub Pages folder hosting:
 
 ```html
-<img src="{{site.baseurl}}/images/trex.jpg" alt="" />
+<img src="{{site.baseurl}}/images/trex.jpg" alt="Tyrannosaurus Rex dinosaur" />
 ```
 
 Layouts
-Common header & footer
+Common header and footer
 
 First create a new file inside the \_layouts folder, name it whatever you want. Inside that file put the common
 HTML.
@@ -166,14 +170,13 @@ At the top of each page use YAML front matter to denote which layout to use:
 
 index.html
 
-````yaml
+```html
 ---
 layout: default
 ---
 
-```html
 <h1>Homepage</h1>
-````
+```
 
 Layouts can be nested by including a different layout at the top of a layout HTML file.
 
@@ -227,10 +230,10 @@ Use an if-statement inside the `<a>` tag to add the .current class.
 >
 ```
 
-Data, includes & posts
+Data, includes and posts
 Data
 
-Data files allow us to separate content from it’s presentation HTML.
+Data files allow us to separate content from its presentation HTML.
 
 Put data files in the \_data folder.
 
@@ -341,7 +344,7 @@ The if-statement can be used to do different things based on certain conditions.
 ```
 
 Template filters
-Check out the complete Liquid for Designers resource & Jekyll’s filter docs.
+Check out the complete Liquid for Designers resource and Jekyll’s filter docs.
 
 Date
 
@@ -404,7 +407,7 @@ Will convert an object or array into JSON.
 
 ## Add Class or ID to markdown element
 
-https://boringrails.com/tips/jekyll-css-class
+[Adding CSS classes to Markdown elements (Boring Rails)](https://boringrails.com/tips/jekyll-css-class)
 
 {% endraw %}
 
@@ -443,7 +446,7 @@ https://boringrails.com/tips/jekyll-css-class
 ## Jekyll Commands
 
 ```shell
-jekyll --help
+bundle exec jekyll --help
 ```
 
 ```
@@ -475,7 +478,7 @@ Subcommands:
 ### `build` Command
 
 ```shell
-jekyll help build
+bundle exec jekyll help build
 ```
 
 ```
@@ -500,9 +503,10 @@ Options:
 ### `serve` Command
 
 ```shell
-jekyll help serve
+bundle exec jekyll help serve
 ```
 
+```
 jekyll serve [options]
 
 Options:
@@ -517,25 +521,24 @@ Build Options:
 --force_polling Force watch to use polling
 
 plus all build options (see build command)
-
-````
+```
 
 
 ## Jekyll Quickstart
 
 ```shell
-jekyll new my-site
+bundle exec jekyll new my-site
 # => New jekyll site installed in ~/my-site
 cd my-site
-jekyll build
+bundle exec jekyll build
      # => Configuration file: ~/_config.yml
      #                Source: ~/my-site
      #           Destination: ~/my-site/_site
      #          Generating... done.
-jekyll serve
+bundle exec jekyll serve
      # =>     Server address: http://127.0.0.1:4000/
      #      Server running... press ctrl-c to stop.
-````
+```
 
 Browse your site e.g. open the page @ `http://127.0.0.1:4000`
 
@@ -662,7 +665,7 @@ Excerpt
 Out-of-excerpt
 ```
 
-### Tips & Tricks
+### Tips and Tricks
 
 **Including images and resources**
 
@@ -681,22 +684,6 @@ Drafts are unpublished posts without a date.
 |   ├── week-4-kramdown.md
 |   └── week-5-feedparser.md
 ```
-
-## `_layouts` Folder
-
-TBD
-
-## `_includes` Folder
-
-TBD
-
-## `_data` Folder
-
-TBD
-
-## `_COLLECTION` Folder (e.g `_books`, `_albums`, etc.)
-
-TBD
 
 ## Global Variables
 
@@ -904,15 +891,6 @@ page.previous     --  The previous post relative to the position of the current 
 
 **Escape (XML, CGI, URI) Filters**
 
-````liquid
-{% raw %}
-{{ page.content | xml_escape }}      -- Escape some text for use in XML
-{{ "foo,bar;baz?" | cgi_escape }}    -- CGI escape a string for use in a URL;
- # => foo%2Cbar%3Bbaz%3F                replaces any special characters with appropriate %XX replacements
-{{ "foo, bar \baz?" | uri_escape }}  -- URI escape a string
- # => foo,%20bar%20%5Cbaz?
-{% endraw %}
-
 ```liquid
 {% raw %}
 {{ page.content | xml_escape }}      -- Escape some text for use in XML
@@ -921,38 +899,10 @@ page.previous     --  The previous post relative to the position of the current 
 {{ "foo, bar \baz?" | uri_escape }}  -- URI escape a string
  # => foo,%20bar%20%5Cbaz?
 {% endraw %}
-````
+```
 
 **Convert (`markdownify`, `slugify`, `sassify`, `jsonify`) Filters**
 
-````liquid
-{% raw %}
-{{ page.excerpt | markdownify }}        -- Convert a Markdown-formatted string into HTML
-{{ site.data.projects | jsonify }}      -- Convert Hash or Array to JSON
-{{ some_scss | scssify }}               -- Convert a SCSS-formatted string into CSS
-{{ some_sass | sassify }}               -- Convert a Sass-formatted string into CSS
-
-{{ "The _config.yml file" | slugify }}            -- Convert a string into a lowercase URL "slug";
- # => the-config-yml-file                            with option 'pretty': spaces and non-alphanumeric chars
-{{ "The _config.yml file" | slugify: 'pretty' }}     except for ._~!$&'()+,;=@
- # => the-_config.yml-file
-
-{{ "The _config.yml file" | slugify }}            -- Convert a string into a lowercase URL "slug";
- # => the-config-yml-file                            with option 'pretty': spaces and non-alphanumeric chars
-{{ "The _config.yml file" | slugify: 'pretty' }}     except for ._~!$&'()+,;=@
- # => the-_config.yml-file
-
-{{ "The _config.yml file" | slugify }}            -- Convert a string into a lowercase URL "slug";
- # => the-config-yml-file                            with option 'pretty': spaces and non-alphanumeric chars
-{{ "The _config.yml file" | slugify: 'pretty' }}     except for ._~!$&'()+,;=@
- # => the-_config.yml-file
-
-{{ "The _config.yml file" | slugify }}            -- Convert a string into a lowercase URL "slug";
- # => the-config-yml-file                            with option 'pretty': spaces and non-alphanumeric chars
-{{ "The _config.yml file" | slugify: 'pretty' }}     except for ._~!$&'()+,;=@
- # => the-_config.yml-file
-{% endraw %}
-
 ```liquid
 {% raw %}
 {{ page.excerpt | markdownify }}        -- Convert a Markdown-formatted string into HTML
@@ -965,7 +915,7 @@ page.previous     --  The previous post relative to the position of the current 
 {{ "The _config.yml file" | slugify: 'pretty' }}     except for ._~!$&'()+,;=@
  # => the-_config.yml-file
 {% endraw %}
-````
+```
 
 **Misc Filters**
 
@@ -978,43 +928,10 @@ page.previous     --  The previous post relative to the position of the current 
 {% endraw %}
 ```
 
-````liquid
-{% raw %}
-{{ page.content | number_of_words }}         -- Count the number of words in some text
- # => 1337
-{{ page.tags | array_to_sentence_string }}   -- Convert an array into a sentence. Useful for listing tags
- # => foo, bar, and baz
-{% endraw %}
-
-```liquid
-{% raw %}
-{{ page.content | number_of_words }}         -- Count the number of words in some text
- # => 1337
-{{ page.tags | array_to_sentence_string }}   -- Convert an array into a sentence. Useful for listing tags
- # => foo, bar, and baz
-{% endraw %}
-
-```liquid
-{% raw %}
-{{ page.content | number_of_words }}         -- Count the number of words in some text
- # => 1337
-{{ page.tags | array_to_sentence_string }}   -- Convert an array into a sentence. Useful for listing tags
- # => foo, bar, and baz
-{% endraw %}
-````
-
 ### Jekyll Tags
 
 **Include Tag**
 
-````liquid
-{% raw %}
-{% include footer.html %}                  -- Searches for include file in _includes folder
-{% include footer.html param="value" %}       You can also pass parameters to an include
-
-{% include_relative somedir/footer.html %} -- Searches for include file relative to the file where used
-{% endraw %}
-
 ```liquid
 {% raw %}
 {% include footer.html %}                  -- Searches for include file in _includes folder
@@ -1022,7 +939,7 @@ page.previous     --  The previous post relative to the position of the current 
 
 {% include_relative somedir/footer.html %} -- Searches for include file relative to the file where used
 {% endraw %}
-````
+```
 
 **Code Syntax Highlighting Tag**
 
@@ -1136,25 +1053,22 @@ body {
 }
 ```
 
+Note: Front matter (minimal) is required at the top of the file:
+
 ```yaml
-Note: Front matter (minimal)
+---
+---
 ```
 
----
-
----
-
-````
-
-or with comments
+or with comments:
 
 ```yaml
 ---
 # ensure Jekyll converts scss to css
 ---
-````
+```
 
-required; ensures Jekyll converts `style.scss` to `style.css`;
+The empty front matter is required; it ensures Jekyll converts `style.scss` to `style.css`;
 include all partials (e.g. `_settings.scss`, and so on) with `@import` directives.
 
 (Source: [jekyll-sass-converter gem](https://github.com/jekyll/jekyll-sass-converter))

--- a/pages/_about/features/jekyll.md
+++ b/pages/_about/features/jekyll.md
@@ -182,7 +182,7 @@ Layouts can be nested by including a different layout at the top of a layout HTM
 
 Page variables
 
-To pass information from a page to a layout you can use YAML frontmatter.
+To pass information from a page to a layout you can use YAML front matter.
 
 `index.html`
 
@@ -190,7 +190,7 @@ To pass information from a page to a layout you can use YAML frontmatter.
 ---
 layout: default
 title: Plant Eaters
-preview: /images/previews/jeykll.png
+preview: /images/previews/jekyll.png
 ---
 ```
 
@@ -449,7 +449,7 @@ Will convert an object or array into JSON.
 bundle exec jekyll --help
 ```
 
-```
+```text
 jekyll 2.5.3 -- Jekyll is a blog-aware, static site generator in Ruby
 
 Usage:
@@ -481,7 +481,7 @@ Subcommands:
 bundle exec jekyll help build
 ```
 
-```
+```text
 jekyll build -- Build your site
 
 Usage:
@@ -506,7 +506,7 @@ Options:
 bundle exec jekyll help serve
 ```
 
-```
+```text
 jekyll serve [options]
 
 Options:
@@ -546,7 +546,7 @@ Browse your site e.g. open the page @ `http://127.0.0.1:4000`
 
 Minimial:
 
-```
+```text
 ├── _config.yml                        # site configuration
 ├── _posts                             # blog posts
 |   ├── 2015-01-01-week-1-factbook.md  #   filename format => YEAR-MONTH-DAY-TITLE.MARKUP
@@ -563,7 +563,7 @@ Minimial:
 
 will result in (with `permalink: date`):
 
-```
+```text
 └── _site                                  # output build folder; site gets generated here
     ├── css
     |   └── styles.css                     # styles for pages (copied 1:1 as is)
@@ -581,7 +581,7 @@ will result in (with `permalink: date`):
 
 or result in (with `permalink: /:title.html`):
 
-```
+```text
 └── _site                           # output build folder; site gets generated here
     ├── css
     |   └── styles.css                     # styles for pages (copied 1:1 as is)
@@ -598,7 +598,7 @@ Note: See the `jekyll-minimal-theme` starter kit for an example
 
 With post drafts, page collections, data stores and shared building blocks:
 
-```
+```text
 ├── _config.yml                        # site configuration
 ├── _posts                             # blog posts
 |   ├── 2015-01-01-week-1-factbook.md  #  filename format => YEAR-MONTH-DAY-TITLE.MARKUP
@@ -636,7 +636,7 @@ The post file name must follow the format: _YEAR-MONTH-DAY-TITLE.MARKUP_
 The permalinks can be customized for each post,
 but the date and markup language are determined by the file name.
 
-```
+```text
 ├── _posts
 |   ├── 2015-01-01-week-1-factbook.md    # e.g. date=2015-01-01, markup=md
 |   ├── 2015-01-08-week-2-hoe.md         #      date=2015-01-08, markup=md
@@ -645,17 +645,17 @@ but the date and markup language are determined by the file name.
 
 ### Front Matter
 
-```
+```yaml
 ---
 layout: post
 title:  "Week #3 - slideshow gem - a free web alternative to PowerPoint and Keynote in Ruby"
-preview: /images/previews/jeykll.png
+preview: /images/previews/jekyll.png
 ---
 ```
 
 **Excerpt**
 
-```
+```yaml
 ---
 excerpt_separator: <!--more-->
 ---
@@ -669,7 +669,7 @@ Out-of-excerpt
 
 **Including images and resources**
 
-```
+```markdown
 ![Ruby under a Microscope Book Cover]({{site.url}}/i/book-ruby-under-a-microscope.png)
 
 [Hoe PDF Booklet](http://docs.seattlerb.org/hoe/Hoe.pdf); 6 Pages
@@ -679,7 +679,7 @@ Out-of-excerpt
 
 Drafts are unpublished posts without a date.
 
-```
+```text
 ├── _drafts
 |   ├── week-4-kramdown.md
 |   └── week-5-feedparser.md
@@ -687,7 +687,7 @@ Drafts are unpublished posts without a date.
 
 ## Global Variables
 
-```
+```text
 site             -- Sitewide information plus configuration settings from  _config.yml.
 page             -- Page specific information plus the front matter.
                     Custom variables set via the front matter will be available here.
@@ -700,7 +700,7 @@ paginator        -- When the paginate configuration option is set variable becom
 
 **Built-in**
 
-```
+```text
 site.time           --  The current time (when you run the jekyll command)
 site.pages          --  A list of all Pages
 site.posts          --  A reverse chronological list of all Posts
@@ -729,15 +729,15 @@ then in your Posts and Pages it will be stored in `site.url`.
 
 If you add in your `_config.yml` site configuration, for example:
 
-```
+```yaml
 url:   'http://openfootball.github.io'
 title: 'football.db - Open Football Data'
-preview: /images/previews/jeykll.png
+preview: /images/previews/jekyll.png
 ```
 
 than you can use the variables in your posts, pages and templates:
 
-```
+```text
 site.url     -- your site's url
 site.title   -- your site's title
 ```
@@ -747,7 +747,7 @@ you must restart Jekyll to see changes to variables.
 
 ## Page Variables
 
-```
+```text
 page.content      --  The content of the Page, rendered or un-rendered depending upon what
                       Liquid is being processedand what page is.
 page.title        --  The title of the Page.
@@ -779,7 +779,7 @@ page.previous     --  The previous post relative to the position of the current 
 
 **String Filters**
 
-```
+```liquid
 {% raw %}
 {{ | capitalize }}      -- capitalize words in the input sentence
 {{ | downcase }}        -- convert an input string to lowercase
@@ -943,7 +943,7 @@ page.previous     --  The previous post relative to the position of the current 
 
 **Code Syntax Highlighting Tag**
 
-```
+```liquid
 {% raw %}
 {% highlight ruby %}
 def main
@@ -954,7 +954,7 @@ end
 
 ```
 
-```
+```liquid
 {% highlight ruby linenos %}         -- Use line numbers
 def main
   puts 'Hello World'
@@ -966,13 +966,13 @@ end
 
 The default `date` permalink is defined as:
 
-```
+```text
 /:categories/:year/:month/:day/:title.html
 ```
 
 ### Permalink Variables
 
-```
+```text
 year        -- Year from the Post’s filename
 month       -- Month from the Post’s filename
 i_month     -- Month from the Post’s filename without leading zeros.
@@ -990,7 +990,7 @@ categories  -- The specified categories for this Post.
 
 **Built-in**
 
-```
+```text
 date     /:categories/:year/:month/:day/:title.html
 pretty   /:categories/:year/:month/:day/:title/
 none     /:categories/:title.html
@@ -1000,7 +1000,7 @@ none     /:categories/:title.html
 
 Given a post named: /2015-01-15-week-3-slideshow.md
 
-```
+```text
 None specified (date)             /2015/01/15/week-3-slideshow.html
 pretty                            /2015/01/15/week-3-slideshow/index.html
 /:month-:day-:year/:title.html    /01-15-2015/week-3-slideshow.html
@@ -1009,7 +1009,7 @@ pretty                            /2015/01/15/week-3-slideshow/index.html
 
 ## CSS Preprocessor Example
 
-```
+```text
 ├── _config.yml            # site configuration (add sass settings)
 └── css
     ├── _settings.scss     # include / partial settings
@@ -1018,7 +1018,7 @@ pretty                            /2015/01/15/week-3-slideshow/index.html
 
 will result in:
 
-```
+```text
 └── _site
     └── css
         └── style.css      # all-in-one styles (converted from scss to css)
@@ -1026,14 +1026,14 @@ will result in:
 
 Example - `_config.yml`:
 
-```
+```yaml
 sass:
   sass_dir: css    # gets used for partial lookup (default is _sass)
 ```
 
 Example - `_settings.scss`:
 
-```
+```scss
 $font-family:    Helvetica, Arial, sans-serif;
 
 $color-primary:  #8b0000;    // dark red (ruby)
@@ -1170,7 +1170,7 @@ Note: You can add more than one feed, for example:
 
 ### Paginator Variables
 
-```
+```text
 paginator.per_page            --  Number of Posts per page
 paginator.posts               --  Posts available for that page
 paginator.total_posts         --  Total number of Posts

--- a/pages/_about/profile/bamr87.md
+++ b/pages/_about/profile/bamr87.md
@@ -14,28 +14,24 @@ lastmod: 2026-06-14T14:30:00.000Z
 permalink: /about/bamr87/
 ---
 
-# Navigate to your current repository
+# Amr Abdel-Motaleb
 
-```shell
+IT Wizard, Software Architect, and Tech Enthusiast based in Denver, CO. Creator
+of the [Zer0-Mistakes](https://github.com/bamr87/zer0-mistakes) Jekyll theme and
+the [IT-Journey](https://it-journey.dev) learning platform.
 
-cd ~/github/it-journey
+- **GitHub:** [@bamr87](https://github.com/bamr87)
+- **LinkedIn:** [amrabdel](https://www.linkedin.com/in/amrabdel)
+- **Website:** [it-journey.dev](https://it-journey.dev)
 
-# Add the GitHub profile repository as a remote repository
-
-git remote add bamr87 https://github.com/bamr87/bamr87.git
-
-# Add the remote repository as a subtree
-
-git subtree add --prefix=pages/_about/contributors/bamr87 bamr87 main
-
-```
+## GitHub activity
 
 <!-- GitHub contribution calendar (bundled under assets/vendor/) -->
 <script src="{{ '/assets/vendor/github-calendar/github-calendar.min.js' | relative_url }}"></script>
 <link rel="stylesheet" href="{{ '/assets/vendor/github-calendar/github-calendar-responsive.css' | relative_url }}" />
 
 <!-- Prepare a container for your calendar. -->
-<div class="calendar">
+<div class="calendar" aria-label="GitHub contribution calendar for bamr87">
     <!-- Loading stuff -->
     Loading the data just for you.
 </div>
@@ -46,3 +42,18 @@ git subtree add --prefix=pages/_about/contributors/bamr87 bamr87 main
     GitHubCalendar(".calendar", "bamr87", { responsive: true });
 
 </script>
+
+## Maintaining this profile
+
+This page is synced from the standalone [`bamr87`](https://github.com/bamr87/bamr87)
+repository as a git subtree:
+
+```shell
+cd ~/github/it-journey
+
+# Add the GitHub profile repository as a remote
+git remote add bamr87 https://github.com/bamr87/bamr87.git
+
+# Pull it in as a subtree
+git subtree add --prefix=pages/_about/contributors/bamr87 bamr87 main
+```

--- a/pages/_about/profile/bamr87.md
+++ b/pages/_about/profile/bamr87.md
@@ -1,16 +1,16 @@
 ---
-title: Amr Abdel-Motaleb
+title: "Amr Abdel-Motaleb — Software Architect & IT Journey Author"
+description: "Profile of Amr Abdel-Motaleb, software architect and creator of the Zer0-Mistakes Jekyll theme and the IT Journey learning platform."
 preview: /images/previews/amr-abdel-motaleb.png
 name: Amr Abdel-Motaleb
 avatar: /assets/images/bamr-avatar.png
 excerpt: IT Wizard, Software Architect, Tech Enthusiast.
 location: Denver, CO
-email: null
 website: https://it-journey.dev
 github: bamr87
 twitter: bamr42
 linkedin: amrabdel
-lastmod: 2024-05-25T19:07:46.394Z
+lastmod: 2026-06-14T14:30:00.000Z
 permalink: /about/bamr87/
 ---
 

--- a/pages/_docs/development/prd.md
+++ b/pages/_docs/development/prd.md
@@ -1,7 +1,8 @@
 ---
-lastmod: 2026-04-18T19:29:54.000Z
-title: Product Requirements Document
-description: Product vision, goals, and requirements for the Zer0-Mistakes Jekyll theme.
+lastmod: 2026-06-14T14:30:00.000Z
+date: 2026-04-18T19:29:54.000Z
+title: Zer0-Mistakes Product Requirements Document
+description: "The Zer0-Mistakes PRD covers the theme's vision, user personas, feature requirements, technical architecture, KPIs, and acceptance criteria."
 preview: /images/previews/product-requirements-document.png
 layout: default
 categories:
@@ -12,6 +13,11 @@ tags:
     - requirements
     - product
     - vision
+keywords:
+    - jekyll theme prd
+    - product requirements document
+    - jekyll theme roadmap
+    - zer0-mistakes requirements
 permalink: /docs/development/prd/
 difficulty: beginner
 estimated_reading_time: 10 minutes
@@ -21,8 +27,17 @@ sidebar:
 
 # Product Requirements Document
 
-The full PRD for the Zer0-Mistakes Jekyll theme — vision, user personas, feature requirements, technical architecture, KPIs, roadmap, and acceptance criteria — is maintained as a contributor reference in the technical docs:
+The full PRD for the Zer0-Mistakes Jekyll theme — vision, user personas, feature
+requirements, technical architecture, KPIs, roadmap, and acceptance criteria —
+is maintained as a contributor reference in the technical docs.
 
-**[Product Requirements Document → docs/architecture/prd-requirements.md](../../../docs/architecture/prd-requirements.md)**
+## What you will find
 
-See also: [Roadmap and Metrics → docs/architecture/prd-roadmap.md](../../../docs/architecture/prd-roadmap.md)
+The PRD documents the product vision, target personas, feature backlog,
+technical architecture constraints, KPI definitions, and release acceptance
+criteria for the `jekyll-theme-zer0` gem. It is kept under the repository's
+`docs/` tree (excluded from the Jekyll build), so the canonical copies are
+linked below on GitHub:
+
+- **[Product Requirements →](https://github.com/bamr87/zer0-mistakes/blob/main/docs/architecture/prd-requirements.md)** — vision, personas, requirements, and acceptance criteria
+- **[Roadmap and Metrics →](https://github.com/bamr87/zer0-mistakes/blob/main/docs/architecture/prd-roadmap.md)** — milestones, KPIs, and delivery tracking

--- a/pages/_docs/development/prd.md
+++ b/pages/_docs/development/prd.md
@@ -27,9 +27,9 @@ sidebar:
 
 # Product Requirements Document
 
-The full PRD for the Zer0-Mistakes Jekyll theme — vision, user personas, feature
-requirements, technical architecture, KPIs, roadmap, and acceptance criteria —
-is maintained as a contributor reference in the technical docs.
+The Zer0-Mistakes Jekyll theme keeps its full PRD — vision, user personas,
+feature requirements, technical architecture, KPIs, roadmap, and acceptance
+criteria — as a contributor reference in the repository's technical docs.
 
 ## What you will find
 


### PR DESCRIPTION
## Summary

Resolves the actionable findings the **AI content-reviewer agent** surfaced when run across the repo's low-scoring / oldest content files (3 pages, 3 collections).

### `pages/_docs/development/prd.md` (docs)
- 🔴 **Fixes broken production links** — two links pointed to `docs/architecture/*`, which `_config.yml` excludes from the Jekyll build (404 in production). Replaced with absolute GitHub URLs, per `documentation.instructions.md`.
- Expanded title (29→ in-range) and description (75→140 chars); added `keywords` and a `## What you will find` section; added `date`.

### `pages/_about/profile/bamr87.md` (about, oldest file in repo)
- Expanded the thin title; added a `description`; removed the `email: null` YAML oddity; refreshed `lastmod` (was 2024-05-25).

### `pages/_about/features/jekyll.md` (about, was lowest-scoring)
- Fixed the **`Jeykll` title typo**; added description + lead paragraph; removed four `TBD` stub sections; **deduplicated and repaired malformed nested code fences**; modernized install commands (`bundle exec` + Docker-first note); fixed bare URLs, example `alt` text, and grammar. Left `draft: true` untouched.

## Scores (deterministic tier, with the #155 fence/`{% raw %}` fixes)
| File | Before | After |
| --- | ---: | ---: |
| `prd.md` | 83 | **100** |
| `bamr87.md` | 90 | **99** |
| `jekyll.md` | 37 (0 pre-fence-fix) | **71** |

> Note: this branch carries the pre-#155 `content-review.rb`, so the in-CI deterministic comment may under-score `jekyll.md` until #155 lands and this branch is updated from `main`. The deterministic tier is advisory (`strictness.ci: warn`) and does not block.

https://claude.ai/code/session_014phQptg8y56CDCz8WA3gBG

---
_Generated by [Claude Code](https://claude.ai/code/session_014phQptg8y56CDCz8WA3gBG)_