### PR TITLE
feat(home): opt-out flags for RSS link and visible title

### DIFF
--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -28,6 +28,13 @@ layout: root
   - Set layout: home in page frontmatter
   - Optionally include title: "Page Title" for display
   - Content can include hero sections, feature highlights, etc.
+
+  Front matter options:
+  - title:           displayed as <h1> (and used for SEO) when present
+  - hide_title:true  keep `title` for SEO but suppress the visible <h1>
+                     (useful when a custom hero provides its own heading)
+  - rss_subscribe:false  hide the RSS subscribe link on landing/showcase homepages
+  Both default to the original behavior, so existing homepages are unaffected.
   
   Design Philosophy:
   - Minimal structure allows for maximum content flexibility
@@ -43,9 +50,12 @@ layout: root
     <!-- ========================== -->
     <!-- OPTIONAL PAGE TITLE        -->
     <!-- ========================== -->
-    <!-- Display title only if specified in page frontmatter -->
-    <!-- Usage: Add 'title: "Homepage Title"' to page frontmatter -->
-    {%- if page.title -%}
+    <!-- Display title only if specified in page frontmatter. -->
+    <!-- Usage: Add 'title: "Homepage Title"' to page frontmatter. -->
+    <!-- Landing/showcase pages can keep `title` for SEO but suppress the -->
+    <!-- visible heading (e.g. when a custom hero supplies its own <h1>) -->
+    <!-- with `hide_title: true`. -->
+    {%- if page.title and page.hide_title != true -%}
         <h1 class="page-heading">{{ page.title }}</h1>
     {%- endif -%}
     
@@ -59,8 +69,11 @@ layout: root
     <!-- ========================== -->
     <!-- RSS SUBSCRIPTION LINK      -->
     <!-- ========================== -->
-    <!-- Provides easy access to RSS feed for blog updates -->
+    <!-- Provides easy access to RSS feed for blog updates. -->
+    <!-- Opt out on landing/showcase homepages with `rss_subscribe: false`. -->
+    {%- unless page.rss_subscribe == false -%}
     <p class="rss-subscribe">
         subscribe <a href="{{ "/feed.xml" | relative_url }}">via RSS</a>
     </p>
+    {%- endunless -%}
 </div>


### PR DESCRIPTION
## What

Adds two **backward-compatible** front-matter flags to the `home` layout so it can be used for landing / showcase homepages, not just blog-style homepages:

| Flag | Effect |
|---|---|
| `hide_title: true` | Keep `title` (for SEO / `{% seo %}`) but **suppress the visible `<h1 class="page-heading">`** — useful when a custom hero supplies its own heading, avoiding a duplicate `<h1>`. |
| `rss_subscribe: false` | Hide the `subscribe via RSS` link that the layout otherwise always renders. |

Both default to the **existing behavior**, so every current homepage is unaffected.

## Why

The `home` layout unconditionally renders an RSS subscribe link and an `<h1>` whenever a page sets `title`. On a landing/showcase homepage that wants a SEO title plus a custom animated hero, this forces a duplicate `<h1>` and an out-of-place blog RSS link, which today can only be removed with CSS hacks (`display:none`).

This came up building an epic showcase homepage for `bamr87.github.io` (which consumes this theme via `remote_theme`). The page uses `layout: home` with a full-bleed hero; these two flags let it drop the theme chrome cleanly instead of hiding it with CSS.

## Changes

- `_layouts/home.html`:
  - `{% if page.title and page.hide_title != true %}` around the page heading
  - `{% unless page.rss_subscribe == false %}` around the RSS link
  - Documented both flags in the layout's header comment.

## Compatibility

Fully backward compatible — absent flags preserve current output exactly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)