### PR TITLE
fix(analytics): only load GA/GTM in production, skip dev hostnames

### DIFF
--- a/_includes/analytics/google-analytics.html
+++ b/_includes/analytics/google-analytics.html
@@ -1,9 +1,17 @@
     <!-- Global site tag (gtag.js) - Google Analytics -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id={{ site.google_analytics }}"></script>
     <script>
-    window.dataLayer = window.dataLayer || [];
-    function gtag(){dataLayer.push(arguments);}
-    gtag('js', new Date());
-
-    gtag('config', '{{ site.google_analytics }}');
+    (function () {
+      // Skip tracking on local/dev hostnames even if a prod build is served locally (Docker/CI preview).
+      var h = location.hostname;
+      if (h === 'localhost' || h === '127.0.0.1' || h === '0.0.0.0' || h === '[::1]' ||
+          h === 'host.docker.internal' || h.endsWith('.local') || h.endsWith('.test')) return;
+      var s = document.createElement('script');
+      s.async = true;
+      s.src = 'https://www.googletagmanager.com/gtag/js?id={{ site.google_analytics }}';
+      document.head.appendChild(s);
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      gtag('config', '{{ site.google_analytics }}');
+    })();
     </script>

--- a/_includes/analytics/google-tag-manager-head.html
+++ b/_includes/analytics/google-tag-manager-head.html
@@ -2,9 +2,17 @@
   title: Google Tag Manager 
   file: 
 -->
-<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-    new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-    j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-    'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-    })(window,document,'script','dataLayer','GTM-NN8P7RZ');</script>
+<script>
+    // Skip GTM on local/dev hostnames even if a prod build is served locally (Docker/CI preview).
+    (function () {
+      var h = location.hostname;
+      if (h === 'localhost' || h === '127.0.0.1' || h === '0.0.0.0' || h === '[::1]' ||
+          h === 'host.docker.internal' || h.endsWith('.local') || h.endsWith('.test')) return;
+      (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+        new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+        j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+        'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+        })(window,document,'script','dataLayer','GTM-NN8P7RZ');
+    })();
+    </script>
     <!-- End Google Tag Manager -->

--- a/_includes/core/head.html
+++ b/_includes/core/head.html
@@ -30,7 +30,8 @@
 <!-- ANALYTICS AND TRACKING          -->
 <!-- ================================ -->
 <!-- Google Tag Manager - Must be in head section for proper tracking -->
-{% include analytics/google-tag-manager-head.html %}
+<!-- Only load in production builds (JEKYLL_ENV=production); the include also guards against dev hostnames -->
+{% if jekyll.environment == "production" %}{% include analytics/google-tag-manager-head.html %}{% endif %}
 
 <!-- ================================ -->
 <!-- JAVASCRIPT LIBRARIES            -->
@@ -118,7 +119,8 @@ window.MathJax = {
 <!-- ANALYTICS INTEGRATION     -->
 <!-- ========================== -->
 <!-- Google Analytics tracking - Configured in _config.yml -->
-{% include analytics/google-analytics.html %}
+<!-- Only load in production AND when an ID is configured; the include also guards against dev hostnames -->
+{% if jekyll.environment == "production" and site.google_analytics %}{% include analytics/google-analytics.html %}{% endif %}
 
 
 <!-- ================================ -->


### PR DESCRIPTION
## Problem

The theme loads Google Analytics (gtag) and the GTM container on **every** build — local `jekyll serve`, Docker, and CI included. On it-journey.dev this meant **~85% of recorded sessions were non-production** (`127.0.0.1`, `localhost`, `host.docker.internal`), badly skewing the analytics.

## Fix (two layers, site-agnostic)

1. **Production gate** — `_includes/core/head.html` wraps both analytics includes in `{% if jekyll.environment == "production" %}` (GA also requires `site.google_analytics`). Dev/CI builds emit no tags.
2. **Dev-hostname guard** — `google-analytics.html` and `google-tag-manager-head.html` skip `localhost`/`127.0.0.1`/`0.0.0.0`/`[::1]`/`host.docker.internal`/`*.local`/`*.test`, covering prod-env builds served locally (Docker/CI previews).

## Impact

- Production analytics stay intact on real domains.
- Local/Docker/CI traffic stops polluting GA for **every** site built on this theme.

🤖 Generated with [Claude Code](https://claude.com/claude-code)