### PR TITLE
root layout: use a semantic <main> landmark

### DIFF
--- a/_layouts/root.html
+++ b/_layouts/root.html
@@ -81,10 +81,13 @@
         <!-- ======================== -->
         <!-- MAIN CONTENT AREA        -->
         <!-- ======================== -->
-        <!-- Skip-link target: keep a single, consistent #main-content anchor site-wide -->
-        <div id="main-content">
+        <!-- Skip-link target: keep a single, consistent #main-content anchor site-wide.
+             Semantic <main> landmark (consistent with the default/section/news layouts)
+             so assistive tech, search engines, and AI content extractors can isolate the
+             primary content from the surrounding header/nav/footer chrome. -->
+        <main id="main-content">
             {{ content }}
-        </div>
+        </main>
 
         <!-- ======================== -->
         <!-- FOOTER AND SCRIPTS       -->


### PR DESCRIPTION
## Summary
`_layouts/root.html` wrapped the content area in `<div id="main-content">`, while the `default`, `section`, and `news` layouts already use a `<main>` landmark. So any page built on `root` (landing/home pages) shipped **without a `<main>`** — inconsistent and a missed accessibility/SEO signal.

This swaps it for `<main id="main-content">`.

## Why it's safe
- The `id` is unchanged, so everything that targets it keeps working: the header skip-link (`<a href="#main-content">`), the footer z-index/stacking notes, and `assets/js/obsidian-wiki-links.js` (which already queries `'#main-content, .bd-content, main, article'`).
- `<main>` is `display:block` like `<div>` — **no visual change**.
- There's only one `<main>` per page (root pages had none before).

## Why it helps
- **Accessibility:** assistive tech can jump to the main landmark; the skip-link now points at a real landmark.
- **SEO / AI extraction:** search engines and AI content extractors can isolate the primary content from header/nav/footer chrome — directly relevant to AI-engine citability.
- **Consistency:** matches the `<main>` already used by the other layouts.

## Context
Surfaced while optimizing a consumer site (bashconsultants.com) for AI-engine citability: page-level structured content scored well, but full-page audits couldn't distinguish content from chrome. A semantic `<main>` is the right primitive for that separation.

Generated with Claude Code