### PR TITLE
docs: fix broken internal docs/ links in pages/_docs

### DIFF
--- a/pages/_docs/customization/includes.md
+++ b/pages/_docs/customization/includes.md
@@ -1,5 +1,5 @@
 ---
-lastmod: 2026-06-14T00:00:00.000Z
+lastmod: 2026-06-16T00:00:00.000Z
 title: Include Components
 description: Guide to the 70+ reusable include components organized by category for maximum flexibility.
 preview: /images/previews/include-components.png
@@ -311,7 +311,7 @@ bundle show jekyll-theme-zer0
 
 For contributor-level details (component API reference, include parameters, extending the component library):
 
-- [Components → docs/ui/components.md](../../../docs/ui/components.md)
+- [Components → docs/ui/components.md](https://github.com/bamr87/zer0-mistakes/blob/main/docs/ui/components.md)
 
 ## See also
 

--- a/pages/_docs/customization/index.md
+++ b/pages/_docs/customization/index.md
@@ -1,5 +1,5 @@
 ---
-lastmod: 2026-04-18T19:29:53.000Z
+lastmod: 2026-06-16T00:00:00.000Z
 title: Customization
 description: Customize the Zer0-Mistakes Jekyll theme - layouts, styles, navigation, and more.
 preview: /images/previews/customization.png
@@ -115,8 +115,8 @@ Example: Override the footer by creating `_includes/core/footer.html`.
 
 For contributor-level details (SCSS architecture, design token catalog, fork-safe extension patterns):
 
-- [Extending the Theme → docs/ui/extending.md](../../../docs/ui/extending.md)
-- [UI Customization → docs/ui/customization.md](../../../docs/ui/customization.md)
+- [Extending the Theme → docs/ui/extending.md](https://github.com/bamr87/zer0-mistakes/blob/main/docs/ui/extending.md)
+- [UI Customization → docs/ui/customization.md](https://github.com/bamr87/zer0-mistakes/blob/main/docs/ui/customization.md)
 
 ## See also
 

--- a/pages/_docs/customization/layouts.md
+++ b/pages/_docs/customization/layouts.md
@@ -1,5 +1,5 @@
 ---
-lastmod: 2026-04-18T19:29:53.000Z
+lastmod: 2026-06-16T00:00:00.000Z
 title: Layouts
 description: Create and customize page layouts in the Zer0-Mistakes Jekyll theme.
 preview: /images/previews/layouts.png
@@ -167,7 +167,7 @@ Use includes for reusable parts:
 
 For contributor-level details (layout hierarchy, Liquid template inheritance, sidebar wiring):
 
-- [Layouts and Navigation → docs/ui/layouts-and-navigation.md](../../../docs/ui/layouts-and-navigation.md)
+- [Layouts and Navigation → docs/ui/layouts-and-navigation.md](https://github.com/bamr87/zer0-mistakes/blob/main/docs/ui/layouts-and-navigation.md)
 
 ## See also
 

--- a/pages/_docs/customization/styles.md
+++ b/pages/_docs/customization/styles.md
@@ -1,5 +1,5 @@
 ---
-lastmod: 2026-04-18T19:29:52.000Z
+lastmod: 2026-06-16T00:00:00.000Z
 title: Styles
 description: Customize CSS and SCSS styles in the Zer0-Mistakes Jekyll theme.
 preview: /images/previews/styles.png
@@ -286,9 +286,9 @@ Use Bootstrap's breakpoints:
 
 For contributor-level details (SCSS pipeline, design token catalog, Bootstrap integration internals, extending the design system):
 
-- [Design System → docs/ui/design-system.md](../../../docs/ui/design-system.md)
-- [Theming → docs/ui/theming.md](../../../docs/ui/theming.md)
-- [Design Tokens → docs/ui/design-tokens.md](../../../docs/ui/design-tokens.md)
+- [Design System → docs/ui/design-system.md](https://github.com/bamr87/zer0-mistakes/blob/main/docs/ui/design-system.md)
+- [Theming → docs/ui/theming.md](https://github.com/bamr87/zer0-mistakes/blob/main/docs/ui/theming.md)
+- [Design Tokens → docs/ui/design-tokens.md](https://github.com/bamr87/zer0-mistakes/blob/main/docs/ui/design-tokens.md)
 
 ## See also
 

--- a/pages/_docs/deployment/github-pages.md
+++ b/pages/_docs/deployment/github-pages.md
@@ -1,5 +1,5 @@
 ---
-lastmod: 2026-04-18T19:30:01.000Z
+lastmod: 2026-06-16T00:00:00.000Z
 title: Deploy to GitHub Pages
 description: Deploy your Zer0-Mistakes Jekyll site to GitHub Pages with automatic builds.
 preview: /images/previews/deploy-to-github-pages.png
@@ -186,7 +186,7 @@ This allows custom plugins and more build control.
 
 For contributor-level details (deploy target module architecture, profile system, CI/CD integration):
 
-- [Deploy Targets → docs/installation/deploy-targets.md](../../../docs/installation/deploy-targets.md)
+- [Deploy Targets → docs/installation/deploy-targets.md](https://github.com/bamr87/zer0-mistakes/blob/main/docs/installation/deploy-targets.md)
 
 ## See also
 

--- a/pages/_docs/development/dependency-updates.md
+++ b/pages/_docs/development/dependency-updates.md
@@ -1,5 +1,5 @@
 ---
-lastmod: 2026-04-18T19:29:54.000Z
+lastmod: 2026-06-16T00:00:00.000Z
 title: Dependency Updates
 description: Guide to automated dependency management and Ruby gem updates for the Zer0-Mistakes theme.
 preview: /images/previews/dependency-updates.png
@@ -42,4 +42,4 @@ bundle exec jekyll build
 
 The complete dependency management guide — Zero-Pin strategy rationale, Dependabot configuration, update policy, lockfile management:
 
-**[Dependency Management → docs/systems/dependency-management.md](../../../docs/systems/dependency-management.md)**
+**[Dependency Management → docs/systems/dependency-management.md](https://github.com/bamr87/zer0-mistakes/blob/main/docs/systems/dependency-management.md)**

--- a/pages/_docs/development/release-management.md
+++ b/pages/_docs/development/release-management.md
@@ -1,5 +1,5 @@
 ---
-lastmod: 2026-05-31T00:00:00.000Z
+lastmod: 2026-06-16T00:00:00.000Z
 title: Release Management
 description: Overview of the release process for the Zer0-Mistakes theme. See docs/ for the full release automation reference.
 preview: /images/previews/release-management.png
@@ -35,6 +35,6 @@ The command handles version bumping, CHANGELOG generation, gem build, RubyGems p
 
 The complete release automation guide — 10-step workflow, flags, troubleshooting, library architecture — is in the contributor docs:
 
-**[Release Automation → docs/systems/release-automation.md](../../../docs/systems/release-automation.md)**
+**[Release Automation → docs/systems/release-automation.md](https://github.com/bamr87/zer0-mistakes/blob/main/docs/systems/release-automation.md)**
 
-See also: [Automated Version System → docs/systems/automated-version-system.md](../../../docs/systems/automated-version-system.md)
+See also: [Automated Version System → docs/systems/automated-version-system.md](https://github.com/bamr87/zer0-mistakes/blob/main/docs/systems/automated-version-system.md)

--- a/pages/_docs/development/testing.md
+++ b/pages/_docs/development/testing.md
@@ -1,5 +1,5 @@
 ---
-lastmod: 2026-05-31T00:00:00.000Z
+lastmod: 2026-06-16T00:00:00.000Z
 title: Testing
 description: Overview of the test suite for the Zer0-Mistakes theme. See the contributor reference in docs/ for the full testing guide.
 preview: /images/previews/testing.png
@@ -41,4 +41,4 @@ Tests run automatically via GitHub Actions on every push and pull request. The s
 
 The complete testing guide — test structure, writing new tests, coverage expectations, CI/CD integration, and Playwright setup — lives in the contributor docs:
 
-**[Testing Guide → docs/development/testing.md](../../../docs/development/testing.md)**
+**[Testing Guide → docs/development/testing.md](https://github.com/bamr87/zer0-mistakes/blob/main/docs/development/testing.md)**

--- a/pages/_docs/development/version-bump.md
+++ b/pages/_docs/development/version-bump.md
@@ -1,5 +1,5 @@
 ---
-lastmod: 2026-05-31T00:00:00.000Z
+lastmod: 2026-06-16T00:00:00.000Z
 title: Version Bump Workflow
 description: How semantic versioning and version bumping work in zer0-mistakes. Full reference in docs/systems/.
 preview: /images/previews/version-bump-workflow.png
@@ -37,6 +37,6 @@ Version is stored in `lib/jekyll-theme-zer0/version.rb` and `package.json`. The 
 
 The complete automated version system docs — conventional commit analysis, calculation algorithm, GitHub Actions integration — are in the contributor docs:
 
-**[Automated Version System → docs/systems/automated-version-system.md](../../../docs/systems/automated-version-system.md)**
+**[Automated Version System → docs/systems/automated-version-system.md](https://github.com/bamr87/zer0-mistakes/blob/main/docs/systems/automated-version-system.md)**
 
 See also: [Release Management](release-management/) for the end-to-end release workflow.

--- a/pages/_docs/features/jupyter-notebooks.md
+++ b/pages/_docs/features/jupyter-notebooks.md
@@ -1,5 +1,5 @@
 ---
-lastmod: 2026-04-18T19:30:00.000Z
+lastmod: 2026-06-16T00:00:00.000Z
 title: Jupyter Notebook Integration
 description: Full Jupyter notebook support with GitHub Pages compatibility, automated conversion, and responsive design.
 preview: /images/previews/jupyter-notebook-integration.png
@@ -296,7 +296,7 @@ Add responsive wrapper:
 
 For implementation details (Docker conversion pipeline, nbconvert config, SCSS styling, GitHub Actions workflow):
 
-- [Jupyter Notebooks → docs/features/jupyter-notebooks.md](../../../docs/features/jupyter-notebooks.md)
+- [Jupyter Notebooks → docs/features/jupyter-notebooks.md](https://github.com/bamr87/zer0-mistakes/blob/main/docs/features/jupyter-notebooks.md)
 
 ## See also
 

--- a/pages/_docs/features/keyboard-navigation.md
+++ b/pages/_docs/features/keyboard-navigation.md
@@ -1,5 +1,5 @@
 ---
-lastmod: 2026-04-18T19:29:57.000Z
+lastmod: 2026-06-16T00:00:00.000Z
 title: Keyboard Navigation
 description: Complete guide to keyboard shortcuts and navigation accessibility features in the Zer0-Mistakes theme.
 preview: /images/previews/keyboard-navigation.png
@@ -183,7 +183,7 @@ Have suggestions for improving keyboard navigation? [Open an issue](https://gith
 
 For implementation details (WCAG 2.1 AA compliance, ARIA attributes, keyboard event handling, focus management):
 
-- [Navigation Redesign → docs/implementation/navigation-redesign.md](../../../docs/implementation/navigation-redesign.md)
+- [Navigation Redesign → docs/implementation/navigation-redesign.md](https://github.com/bamr87/zer0-mistakes/blob/main/docs/implementation/navigation-redesign.md)
 
 ## See also
 

--- a/pages/_docs/features/mermaid-diagrams.md
+++ b/pages/_docs/features/mermaid-diagrams.md
@@ -1,5 +1,5 @@
 ---
-lastmod: 2026-04-18T19:29:57.000Z
+lastmod: 2026-06-16T00:00:00.000Z
 title: Mermaid Diagrams
 description: Complete guide to integrating Mermaid diagrams in Jekyll sites - flowcharts, sequence diagrams, class diagrams and more with GitHub Pages compatibility.
 preview: /images/previews/mermaid-diagrams.png
@@ -381,7 +381,7 @@ docker-compose up
 
 For implementation details (how Mermaid v2 was integrated, file changes, test suite):
 
-- [Mermaid Integration → docs/implementation/feature-change-log.md](../../../docs/implementation/feature-change-log.md#mermaid-integration-v20)
+- [Mermaid Integration → docs/implementation/feature-change-log.md](https://github.com/bamr87/zer0-mistakes/blob/main/docs/implementation/feature-change-log.md#mermaid-integration-v20)
 
 ## See also
 

--- a/pages/_docs/features/posthog-analytics.md
+++ b/pages/_docs/features/posthog-analytics.md
@@ -1,5 +1,5 @@
 ---
-lastmod: 2026-04-18T19:29:56.000Z
+lastmod: 2026-06-16T00:00:00.000Z
 title: PostHog Analytics
 description: Implement privacy-first web analytics in Jekyll using PostHog with GDPR/CCPA compliance, custom event tracking, and Do Not Track support.
 preview: /images/previews/posthog-analytics.png
@@ -228,7 +228,7 @@ If exceeding free tier limits:
 
 For implementation details (GDPR/CCPA configuration, event tracking architecture, integration notes):
 
-- [PostHog Integration → docs/implementation/posthog-analytics-integration.md](../../../docs/implementation/posthog-analytics-integration.md)
+- [PostHog Integration → docs/implementation/posthog-analytics-integration.md](https://github.com/bamr87/zer0-mistakes/blob/main/docs/implementation/posthog-analytics-integration.md)
 
 ## See also
 

--- a/pages/_docs/features/preview-image-generator.md
+++ b/pages/_docs/features/preview-image-generator.md
@@ -1,5 +1,5 @@
 ---
-lastmod: 2026-06-14T00:00:00.000Z
+lastmod: 2026-06-16T00:00:00.000Z
 title: AI Preview Image Generator for Jekyll Posts
 description: Generate social preview images automatically for Jekyll posts using OpenAI DALL-E, Stability AI, or local placeholders, wired into the theme build pipeline.
 keywords: [preview image, dall-e, stability ai, open graph image, jekyll social images]
@@ -339,7 +339,7 @@ export OPENAI_API_KEY="sk-..."
 
 For implementation details (multi-provider architecture, xAI Grok integration, generation workflow):
 
-- [Preview Image Generator → docs/implementation/preview-image-generator.md](../../../docs/implementation/preview-image-generator.md)
+- [Preview Image Generator → docs/implementation/preview-image-generator.md](https://github.com/bamr87/zer0-mistakes/blob/main/docs/implementation/preview-image-generator.md)
 
 ## See also
 

--- a/pages/_docs/features/sidebar-navigation.md
+++ b/pages/_docs/features/sidebar-navigation.md
@@ -1,5 +1,5 @@
 ---
-lastmod: 2026-04-18T19:30:00.000Z
+lastmod: 2026-06-16T00:00:00.000Z
 title: Sidebar Navigation System
 description: Modern sidebar with Intersection Observer scroll spy, smooth scrolling, keyboard shortcuts, and swipe gestures.
 preview: /images/previews/sidebar-navigation-system.png
@@ -288,16 +288,16 @@ Using Bootstrap Icons throughout:
 
 ## Related
 
-- [Keyboard Navigation](../../../docs/features/keyboard-navigation/)
-- [Mobile TOC Button](../../../docs/features/mobile-toc/)
-- [Table of Contents](../../../docs/features/toc/)
+- [Keyboard Navigation](/docs/features/keyboard-navigation/)
+- [Mobile TOC Button](/docs/features/mobile-toc/)
+- [Table of Contents](/docs/features/toc/)
 
 ## Technical Reference
 
 For implementation details (scroll spy, swipe gestures, keyboard shortcuts, ARIA improvements):
 
-- [Navigation Redesign → docs/implementation/navigation-redesign.md](../../../docs/implementation/navigation-redesign.md)
-- [Sidebar improvements → docs/implementation/feature-change-log.md](../../../docs/implementation/feature-change-log.md#sidebar-uiux-improvements-december-2025)
+- [Navigation Redesign → docs/implementation/navigation-redesign.md](https://github.com/bamr87/zer0-mistakes/blob/main/docs/implementation/navigation-redesign.md)
+- [Sidebar improvements → docs/implementation/feature-change-log.md](https://github.com/bamr87/zer0-mistakes/blob/main/docs/implementation/feature-change-log.md#sidebar-uiux-improvements-december-2025)
 
 ## See also
 

--- a/pages/_docs/features/theme-version.md
+++ b/pages/_docs/features/theme-version.md
@@ -1,5 +1,5 @@
 ---
-lastmod: 2026-04-18T19:29:59.000Z
+lastmod: 2026-06-16T00:00:00.000Z
 title: Theme Version Display Plugin
 description: Automatic theme version extraction from gem specification with modal display and footer integration.
 preview: /images/previews/theme-version-display-plugin.png
@@ -232,15 +232,15 @@ Plugin automatically extracts from gemspec.
 
 ## Related
 
-- [Release Management](../../../docs/development/release-management/)
-- [Version Bump](../../../docs/development/version-bump/)
-- [Gem Publishing](../../../docs/development/release-management/#rubygems-publishing)
+- [Release Management](/docs/development/release-management/)
+- [Version Bump](/docs/development/version-bump/)
+- [Gem Publishing](/docs/development/release-management/#rubygems-publishing)
 
 ## Technical Reference
 
 For implementation details (Jekyll plugin architecture, version extraction, modal integration):
 
-- [Theme Version Feature → docs/features/theme-version.md](../../../docs/features/theme-version.md)
+- [Theme Version Feature → docs/features/theme-version.md](https://github.com/bamr87/zer0-mistakes/blob/main/docs/features/theme-version.md)
 
 ## See also
 

--- a/pages/_docs/getting-started/quick-start.md
+++ b/pages/_docs/getting-started/quick-start.md
@@ -1,5 +1,5 @@
 ---
-lastmod: 2026-04-18T19:30:00.000Z
+lastmod: 2026-06-16T00:00:00.000Z
 title: Quick Start Guide
 description: Multiple installation methods for the Zer0-Mistakes Jekyll theme - from AI wizard to manual setup.
 preview: /images/previews/quick-start-guide.png
@@ -320,7 +320,7 @@ docker-compose up
 
 For contributor-level details (installer architecture, profile system, deploy target modules):
 
-- [Installation Guide → docs/installation/index.md](../../../docs/installation/index.md)
+- [Installation Guide → docs/installation/index.md](https://github.com/bamr87/zer0-mistakes/blob/main/docs/installation/index.md)
 
 ## See also
 

--- a/pages/_docs/installation.md
+++ b/pages/_docs/installation.md
@@ -14,8 +14,7 @@ permalink: /docs/installation/
 difficulty: beginner
 estimated_reading_time: 10 minutes
 prerequisites: []
-lastmod: 2026-06-14T00:00:00.000Z
-lastmod: 2026-06-14T00:00:00.000Z
+lastmod: 2026-06-16T00:00:00.000Z
 sidebar:
     nav: docs
 ---
@@ -111,8 +110,8 @@ docker-compose exec jekyll jekyll doctor
 
 For contributor-level details (installer architecture, profile system, AI-powered setup):
 
-- [Installation Guide → docs/installation/index.md](../../docs/installation/index.md)
-- [Forking Guide → docs/installation/forking.md](../../docs/installation/forking.md)
+- [Installation Guide → docs/installation/index.md](https://github.com/bamr87/zer0-mistakes/blob/main/docs/installation/index.md)
+- [Forking Guide → docs/installation/forking.md](https://github.com/bamr87/zer0-mistakes/blob/main/docs/installation/forking.md)
 
 ## See also
 


### PR DESCRIPTION
## Summary

Several `pages/_docs/**` pages linked into the **internal** `docs/` tree using relative `../docs/...` paths. `docs/` is excluded from the Jekyll build (it's the MDX maintainer tier), so those links **404 on the published site** — a violation of the `documentation.instructions.md` hard rule:

> ⚠️ Never link from `pages/_docs/` to `../../docs/...` — `docs/` is not served. Use a full GitHub URL.

This PR rewrites all 30 such links across 18 files using per-link judgment.

## What changed

**Rule 1 — internal, non-served docs → full GitHub blob URL** (24 links; anchors preserved):
- `docs/ui/*` (components, design-system, theming, design-tokens, extending, customization, layouts-and-navigation)
- `docs/systems/*` (dependency-management, automated-version-system, release-automation)
- `docs/implementation/*` (navigation-redesign, feature-change-log + anchors, posthog-analytics-integration, preview-image-generator)
- `docs/features/*` (jupyter-notebooks, theme-version)
- `docs/installation/*` (index, deploy-targets, forking)
- `docs/development/testing.md`

  Example: `](../../../docs/ui/components.md)` → `](https://github.com/bamr87/zer0-mistakes/blob/main/docs/ui/components.md)`

**Rule 2 — trailing-slash permalinks that map to real served pages → clean absolute `/docs/...` path** (6 links). Verified each target exists with a matching `permalink` in `pages/_docs/**`:
- `/docs/features/keyboard-navigation/`, `/docs/features/mobile-toc/`, `/docs/features/toc/`
- `/docs/development/release-management/` (incl. `#rubygems-publishing` anchor), `/docs/development/version-bump/`

**Also:**
- Caught two additional same-class links in `pages/_docs/installation.md` using the two-level `../../docs/` form (the audit's grep only matched three levels) and fixed them.
- Collapsed a duplicate `lastmod` key in `installation.md`.
- Bumped `lastmod` to `2026-06-16` on every edited file.

## Verification

- `grep -rnE '\]\((\.\./)+docs/' pages/_docs/` → no matches (markdown). Same for HTML `href=`.
- `ruby scripts/content-review.rb --changed --base origin/main` → **exit 0**, no 🔴 files, average **89.2/100** (threshold 70). Remaining warnings are pre-existing SEO/length/keyword nits, unrelated to links.

Content-only; no scripts or templates touched.

https://claude.ai/code/session_011QZK8LJW34wUBbkfFx1E6u

---
_Generated by [Claude Code](https://claude.ai/code/session_011QZK8LJW34wUBbkfFx1E6u)_