### PR TITLE
fix(config): restore zer0-mistakes.com site identity + CNAME (site was down)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- **Restore `zer0-mistakes.com` site identity (site was down).** PR #173 (the
+  federated org content hub) accidentally rewrote this repo's own `_config.yml`
+  to the `year-of-ai.github.io` identity and deleted the `CNAME` file, which
+  broke the production custom domain. Restored `github_user`/`repository_name`/
+  `local_repo`/`title`/`domain`/`domain_ext`/`url`/`email`/`description` to the
+  `bamr87/zer0-mistakes` → `https://zer0-mistakes.com` values and re-added the
+  `CNAME` (`zer0-mistakes.com`) so GitHub Pages serves the custom domain again.
+
 ## [1.19.0] - 2026-06-16
 
 ### Changed

--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+zer0-mistakes.com

--- a/_config.yml
+++ b/_config.yml
@@ -28,39 +28,35 @@
 site_configured          : true   # Tells the theme this site has been personalised
 
 founder                  : "Amr Abdel-Motaleb"
-# This repo is the year-of-ai organization root site (year-of-ai.github.io), a
-# fork of the zer0-mistakes theme. It renders via the shared theme below and
-# also serves as the remote_theme source for the org's year sites
-# (year-of-ai/<year>).
 remote_theme             : "bamr87/zer0-mistakes"
 gem                      : &gem "jekyll-theme-zer0"
 # theme                    : "jekyll-theme-zer0"
 
 ## Github Information
-github_user              : &github_user "year-of-ai"
-repository_name          : &github_repository "year-of-ai.github.io"
+github_user              : &github_user "bamr87"
+repository_name          : &github_repository "zer0-mistakes"
 repository               : [*github_user, "/", *github_repository] # GitHub username/repo-name
-local_repo               : &local_repo "year-of-ai.github.io"
+local_repo               : &local_repo "zer0-mistakes"
 branch                   : &branch "main"
 repo_map                 : "/sitemap/"
 portfolio                : &portfolio [*github_user, '.', 'github.io']
 
 ## Site Information ---------------------------------------------------------------
 
-title                    : &title "Year of AI"
+title                    : &title "zer0-mistakes"
 title_url                : "/"
 title_icon               : "robot"
 subtitle                 : ""
 subtitle_url             : "localhost"
 subtitle_icon            : "code"
 title_separator          : "|" # Appears in the web browser tab name
-domain                   : &domain "year-of-ai"
-domain_ext               : &domain_ext "github.io"
+domain                   : &domain "zer0-mistakes"
+domain_ext               : &domain_ext "com"
 baseurl                  : &baseurl "" # the subpath of your site, e.g. /blog - Use this if you want this whole repo to be a domain branch
 url_test                 : &url_test [ 'https', '://', *github_user, '.', *domain, '.', *domain_ext ] # the base hostname & protocol for your site, e.g. http://example.com
 domain_url               : &domain_url [ 'https', '://', *domain, '.', *domain_ext ]
 github_io_url            : &github_io_url [ 'https', '://', *github_user, '.', *domain, '.', *domain_ext, '/', *github_repository ]
-url                      : &url https://year-of-ai.github.io
+url                      : &url https://zer0-mistakes.com
 public_folder            : assets # path to the public folder
 port                     : 4000 # Jekyll Serve Dev port
 dg_port                  : 4001 # TODO: Doppelganger site. Use this if you want to switch between parallel deployments
@@ -69,11 +65,11 @@ og_image                 : '/assets/images/wizard-on-journey.png'
 ### Owner Information -------------------------------------------------------------
 
 name                     : &name "Amr"
-email                    : "amr.abdel@gmail.com"
+email                    : "amr@zer0-mistakes.com"
 description              : >- # this means to ignore newlines until the next variable
-  Year of AI — the organization hub for a federated network of self-growing,
-  year-by-year knowledge bases. Each year publishes its own site, all rendered
-  with the shared zer0-mistakes Jekyll theme.
+  "Jekyll and Bootstrap 5 theme for perfectionists.
+  Step-by-step instructions to build your blog, portfolio,
+  and documentation site with no mistakes, unless you're a n00b."
 level                    : 'n00b'
 
 ## Maintainer Information----------------------------------------------------------

--- a/pages/_about/settings/_config.yml
+++ b/pages/_about/settings/_config.yml
@@ -29,39 +29,35 @@
 site_configured          : true   # Tells the theme this site has been personalised
 
 founder                  : "Amr Abdel-Motaleb"
-# This repo is the year-of-ai organization root site (year-of-ai.github.io), a
-# fork of the zer0-mistakes theme. It renders via the shared theme below and
-# also serves as the remote_theme source for the org's year sites
-# (year-of-ai/<year>).
 remote_theme             : "bamr87/zer0-mistakes"
 gem                      : &gem "jekyll-theme-zer0"
 # theme                    : "jekyll-theme-zer0"
 
 ## Github Information
-github_user              : &github_user "year-of-ai"
-repository_name          : &github_repository "year-of-ai.github.io"
+github_user              : &github_user "bamr87"
+repository_name          : &github_repository "zer0-mistakes"
 repository               : [*github_user, "/", *github_repository] # GitHub username/repo-name
-local_repo               : &local_repo "year-of-ai.github.io"
+local_repo               : &local_repo "zer0-mistakes"
 branch                   : &branch "main"
 repo_map                 : "/sitemap/"
 portfolio                : &portfolio [*github_user, '.', 'github.io']
 
 ## Site Information ---------------------------------------------------------------
 
-title                    : &title "Year of AI"
+title                    : &title "zer0-mistakes"
 title_url                : "/"
 title_icon               : "robot"
 subtitle                 : ""
 subtitle_url             : "localhost"
 subtitle_icon            : "code"
 title_separator          : "|" # Appears in the web browser tab name
-domain                   : &domain "year-of-ai"
-domain_ext               : &domain_ext "github.io"
+domain                   : &domain "zer0-mistakes"
+domain_ext               : &domain_ext "com"
 baseurl                  : &baseurl "" # the subpath of your site, e.g. /blog - Use this if you want this whole repo to be a domain branch
 url_test                 : &url_test [ 'https', '://', *github_user, '.', *domain, '.', *domain_ext ] # the base hostname & protocol for your site, e.g. http://example.com
 domain_url               : &domain_url [ 'https', '://', *domain, '.', *domain_ext ]
 github_io_url            : &github_io_url [ 'https', '://', *github_user, '.', *domain, '.', *domain_ext, '/', *github_repository ]
-url                      : &url https://year-of-ai.github.io
+url                      : &url https://zer0-mistakes.com
 public_folder            : assets # path to the public folder
 port                     : 4000 # Jekyll Serve Dev port
 dg_port                  : 4001 # TODO: Doppelganger site. Use this if you want to switch between parallel deployments
@@ -70,11 +66,11 @@ og_image                 : '/assets/images/wizard-on-journey.png'
 ### Owner Information -------------------------------------------------------------
 
 name                     : &name "Amr"
-email                    : "amr.abdel@gmail.com"
+email                    : "amr@zer0-mistakes.com"
 description              : >- # this means to ignore newlines until the next variable
-  Year of AI — the organization hub for a federated network of self-growing,
-  year-by-year knowledge bases. Each year publishes its own site, all rendered
-  with the shared zer0-mistakes Jekyll theme.
+  "Jekyll and Bootstrap 5 theme for perfectionists.
+  Step-by-step instructions to build your blog, portfolio,
+  and documentation site with no mistakes, unless you're a n00b."
 level                    : 'n00b'
 
 ## Maintainer Information----------------------------------------------------------


### PR DESCRIPTION
## Problem

**zer0-mistakes.com was down.** The production site for `bamr87/zer0-mistakes` is the custom domain `zer0-mistakes.com`, but `_config.yml` on `main` had been overwritten to point at `year-of-ai.github.io`, and the `CNAME` file was deleted. With no `CNAME` and a `year-of-ai.github.io` `url:`, GitHub Pages stopped serving the custom domain and all generated absolute URLs (SEO tags, sitemap, feed) were wrong.

## Root cause

Traced to **PR #173 (`a2ec16c "updates (#173)"`)**, which added the federated org content hub feature. That change accidentally edited this repo's *own* identity config — intended for the `year-of-ai` root site — and deleted `CNAME`:

- `git log --diff-filter=D -- CNAME` → `a2ec16c`
- `git log -S "zer0-mistakes.com" -- _config.yml` → last present at `a2ec16c^`

The hub feature itself is fine and untouched; only this repo's self-identity and `CNAME` were collateral damage.

## Fix

Restored the pre-#173 values in `_config.yml`:

| key | restored value |
|-----|----------------|
| `github_user` | `bamr87` |
| `repository_name` / `local_repo` | `zer0-mistakes` |
| `title` | `zer0-mistakes` |
| `domain` / `domain_ext` | `zer0-mistakes` / `com` |
| `url` | `https://zer0-mistakes.com` |
| `email` | `amr@zer0-mistakes.com` |
| `description` | original theme tagline |

Also removed the stray "year-of-ai organization root site" comment block and **re-added `CNAME` (`zer0-mistakes.com`)** so GitHub Pages picks the custom domain back up on deploy.

## Validation

- `_config.yml` parses cleanly (`ruby -ryaml` load OK).
- `CNAME` matches the original byte-for-byte (`zer0-mistakes.com`, no trailing newline).
- No residual `year-of-ai` identity references remain in `_config.yml` / `_config_dev.yml` / `CNAME`.
- Jekyll isn't installed in this environment, so a local build wasn't run — change is config strings + `CNAME` only; GitHub Pages builds on merge.

> Note: DNS records for `zer0-mistakes.com` at the registrar are external to the repo. If the domain still doesn't resolve after this merges and Pages redeploys, verify the GitHub Pages custom-domain setting and the registrar's A/CNAME records.

https://claude.ai/code/session_01Acu2dFMyzWuMc1bVwFfggU

---
_Generated by [Claude Code](https://claude.ai/code/session_01Acu2dFMyzWuMc1bVwFfggU)_