### PR TITLE
fix(layouts): render hero image for breaking posts, not just featured

### DIFF
--- a/_layouts/article.html
+++ b/_layouts/article.html
@@ -183,9 +183,23 @@ layout: default
   </header>
   
   {% comment %} ================================ {% endcomment %}
-  {% comment %} FEATURED HERO IMAGE             {% endcomment %}
+  {% comment %} FEATURED / BREAKING HERO IMAGE  {% endcomment %}
   {% comment %} ================================ {% endcomment %}
-  {% if post_type == "featured" and page.preview %}
+  {% comment %}
+    Render the hero image for prominent post types (featured + breaking) when a
+    preview image is set. Breaking stories were previously skipped because the
+    condition checked only post_type == "featured"; since breaking is mapped
+    before featured (see top of file), breaking+featured posts showed no hero.
+    Nested ifs keep the "only when page.preview exists" guard intact (Liquid has
+    no parentheses, so a flat `a or b and c` would misgroup).
+  {% endcomment %}
+  {% assign show_hero = false %}
+  {% if page.preview %}
+    {% if post_type == "featured" or post_type == "breaking" %}
+      {% assign show_hero = true %}
+    {% endif %}
+  {% endif %}
+  {% if show_hero %}
   <figure class="featured-hero mb-5">
     {% include components/preview-image.html 
        src=page.preview 


### PR DESCRIPTION
## Summary

Breaking-news posts with a `preview` image were not showing a featured hero image. The article layout maps `breaking: true` front matter to `post_type == "breaking"` (with precedence over `featured`), but the hero block guarded only on `post_type == "featured"` — so breaking posts fell through and rendered no hero.

## Change

[`_layouts/article.html`](_layouts/article.html): replace the single `post_type == "featured"` check with a `show_hero` flag that renders the hero for **both** `featured` and `breaking` post types, but only when `page.preview` is set. Nested `if`s keep the "only when preview exists" guard intact (Liquid has no parentheses to safely group `or`/`and` in one expression).

## Validation

- `docker-compose exec -T jekyll bundle exec jekyll build --config '_config.yml,_config_dev.yml'` — build succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)