### PR TITLE
chore(vscode): containerize dev tasks and refresh editor tooling

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -3,55 +3,61 @@
   // UNIFIED VS CODE EXTENSIONS - Docker-First Development
   // ==================================================
   // Optimized for zer0-mistakes Jekyll theme development
-  // Last Updated: 2025-10-26
-  
+  // Last Updated: 2026-06-21
+
   "recommendations": [
     // ==========================================
     // CORE DEVELOPMENT TOOLS
     // ==========================================
     "github.copilot",
     "github.copilot-chat",
+    "github.vscode-github-actions",
     "ms-azuretools.vscode-docker",
-    
+
     // ==========================================
     // JEKYLL/WEB DEVELOPMENT
     // ==========================================
     "shopify.liquid",
-    "ms-vscode.vscode-json",
     "redhat.vscode-yaml",
     "davidanson.vscode-markdownlint",
     "yzhang.markdown-all-in-one",
-    
+    "ms-playwright.playwright",
+
     // ==========================================
     // RUBY/GEM DEVELOPMENT
     // ==========================================
     "shopify.ruby-lsp",
-    "rebornix.ruby",
-    
+
+    // ==========================================
+    // BASH / SHELL TOOLING
+    // ==========================================
+    "timonwong.shellcheck",
+
     // ==========================================
     // UTILITY EXTENSIONS
     // ==========================================
-    "ms-vscode.vscode-typescript-next",
     "ms-vscode-remote.remote-containers",
     "ms-vscode.remote-repositories",
     "streetsidesoftware.code-spell-checker",
     "eamodio.gitlens",
-    
+
     // ==========================================
     // OPTIONAL ENHANCEMENTS
     // ==========================================
     "ms-vscode.live-server",
-    "bradlc.vscode-tailwindcss",
     "formulahendry.auto-rename-tag",
     "christian-kohler.path-intellisense",
     "esbenp.prettier-vscode"
   ],
-  
+
   // ==========================================
   // WORKSPACE SPECIFIC RECOMMENDATIONS
   // ==========================================
   "unwantedRecommendations": [
     "ms-vscode.vscode-typescript",
-    "ms-vscode.nodejs-extension-pack"
+    "ms-vscode.vscode-typescript-next",
+    "ms-vscode.nodejs-extension-pack",
+    "rebornix.ruby",
+    "bradlc.vscode-tailwindcss"
   ]
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -14,7 +14,7 @@
   //
   // Gem releases: Tasks → 🚀 Release: * (scripts/release; see tasks.json).
   //
-  // Last updated: 2026-03-29
+  // Last updated: 2026-06-21
   "version": "0.2.0",
   "configurations": [
     {
@@ -26,8 +26,7 @@
       "preLaunchTask": "Docker: Compose Up (Detached)",
       "postDebugTask": "Docker: Compose Stop",
       "runtimeArgs": [
-        "--remote-debugging-port=9222",
-        "--disable-web-security"
+        "--remote-debugging-port=9222"
       ],
       "userDataDir": "${workspaceFolder}/.vscode/chrome-debug-profile",
       "killBehavior": "forceful",
@@ -42,9 +41,7 @@
       },
       "pathMapping": {
         "/": "${workspaceFolder}/_site/",
-        "/assets/": "${workspaceFolder}/assets/",
-        "/js/": "${workspaceFolder}/assets/js/",
-        "/css/": "${workspaceFolder}/assets/css/"
+        "/assets/": "${workspaceFolder}/assets/"
       },
       "presentation": {
         "group": "Docker",
@@ -60,8 +57,7 @@
       "preLaunchTask": "Docker: Compose Up (Detached)",
       "postDebugTask": "Docker: Compose Stop",
       "runtimeArgs": [
-        "--remote-debugging-port=9222",
-        "--disable-web-security"
+        "--remote-debugging-port=9222"
       ],
       "userDataDir": "${workspaceFolder}/.vscode/edge-debug-profile",
       "killBehavior": "forceful",
@@ -76,9 +72,7 @@
       },
       "pathMapping": {
         "/": "${workspaceFolder}/_site/",
-        "/assets/": "${workspaceFolder}/assets/",
-        "/js/": "${workspaceFolder}/assets/js/",
-        "/css/": "${workspaceFolder}/assets/css/"
+        "/assets/": "${workspaceFolder}/assets/"
       },
       "presentation": {
         "group": "Docker",
@@ -102,9 +96,7 @@
       },
       "pathMapping": {
         "/": "${workspaceFolder}/_site/",
-        "/assets/": "${workspaceFolder}/assets/",
-        "/js/": "${workspaceFolder}/assets/js/",
-        "/css/": "${workspaceFolder}/assets/css/"
+        "/assets/": "${workspaceFolder}/assets/"
       },
       "presentation": {
         "group": "Docker",
@@ -121,7 +113,6 @@
       "postDebugTask": "Docker: Compose Down",
       "runtimeArgs": [
         "--remote-debugging-port=9222",
-        "--disable-web-security",
         "--auto-open-devtools-for-tabs"
       ],
       "userDataDir": "${workspaceFolder}/.vscode/chrome-debug-profile",
@@ -137,9 +128,7 @@
       },
       "pathMapping": {
         "/": "${workspaceFolder}/_site/",
-        "/assets/": "${workspaceFolder}/assets/",
-        "/js/": "${workspaceFolder}/assets/js/",
-        "/css/": "${workspaceFolder}/assets/css/"
+        "/assets/": "${workspaceFolder}/assets/"
       },
       "presentation": {
         "group": "Docker",
@@ -156,7 +145,6 @@
       "postDebugTask": "Docker: Compose Stop",
       "runtimeArgs": [
         "--remote-debugging-port=9222",
-        "--disable-web-security",
         "--device-scale-factor=2",
         "--force-device-scale-factor=2",
         "--user-agent=Mozilla/5.0 (iPhone; CPU iPhone OS 15_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.0 Mobile/15E148 Safari/604.1"
@@ -170,9 +158,7 @@
       "timeout": 60000,
       "pathMapping": {
         "/": "${workspaceFolder}/_site/",
-        "/assets/": "${workspaceFolder}/assets/",
-        "/js/": "${workspaceFolder}/assets/js/",
-        "/css/": "${workspaceFolder}/assets/css/"
+        "/assets/": "${workspaceFolder}/assets/"
       },
       "presentation": {
         "group": "Docker",
@@ -206,9 +192,7 @@
       },
       "pathMapping": {
         "/": "${workspaceFolder}/_site/",
-        "/assets/": "${workspaceFolder}/assets/",
-        "/js/": "${workspaceFolder}/assets/js/",
-        "/css/": "${workspaceFolder}/assets/css/"
+        "/assets/": "${workspaceFolder}/assets/"
       },
       "presentation": {
         "group": "Docker",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,8 +3,8 @@
   // UNIFIED VS CODE SETTINGS - Docker-First Development
   // ==================================================
   // Optimized for zer0-mistakes Jekyll theme development
-  // Last Updated: 2025-10-26
-  
+  // Last Updated: 2026-06-21
+
   // ==========================================
   // GITHUB COPILOT CONFIGURATION
   // ==========================================
@@ -21,18 +21,13 @@
     "json": true,
     "jsonc": true
   },
-  "github.copilot.advanced": {
-    "enableSuggestionAutoTrigger": true,
-    "contextLength": 4096,
-    "enableAutoCompletions": true
-  },
 
   // ==========================================
   // FILE ASSOCIATIONS & LANGUAGE SUPPORT
   // ==========================================
   "files.associations": {
     "*.html": "liquid",
-    "*.md": "markdown", 
+    "*.md": "markdown",
     "*.yml": "yaml",
     "*.yaml": "yaml",
     "_config*.yml": "yaml",
@@ -80,6 +75,16 @@
   "yaml.completion": true,
   "yaml.hover": true,
   "yaml.validate": true,
+  "yaml.schemas": {
+    "https://json.schemastore.org/github-workflow.json": [
+      ".github/workflows/*.yml",
+      ".github/workflows/*.yaml"
+    ],
+    "https://json.schemastore.org/github-action.json": [
+      ".github/actions/*/action.yml",
+      ".github/actions/*/action.yaml"
+    ]
+  },
 
   // ==========================================
   // LIQUID TEMPLATE CONFIGURATION
@@ -94,22 +99,48 @@
   },
 
   // ==========================================
-  // RUBY CONFIGURATION
+  // RUBY CONFIGURATION (Shopify Ruby LSP)
   // ==========================================
   "[ruby]": {
+    "editor.defaultFormatter": "Shopify.ruby-lsp",
     "editor.formatOnSave": true,
-    "editor.codeActionsOnSave": {
-      "source.organizeImports": "explicit"
-    }
+    "editor.tabSize": 2,
+    "editor.insertSpaces": true
   },
-  "ruby.rubocop.onSave": true,
-  "ruby.format": "rubocop",
+  "rubyLsp.formatter": "auto",
 
   // ==========================================
-  // DOCKER CONFIGURATION
+  // SCSS / JSON / SHELL CONFIGURATION
   // ==========================================
-  "docker.images.label": "latest",
-  "docker.commands.compose": "docker-compose",
+  "[scss]": {
+    "editor.tabSize": 2,
+    "editor.insertSpaces": true
+  },
+  "[json]": {
+    "editor.tabSize": 2,
+    "editor.insertSpaces": true
+  },
+  "[jsonc]": {
+    "editor.tabSize": 2,
+    "editor.insertSpaces": true
+  },
+  "[shellscript]": {
+    "editor.tabSize": 4,
+    "editor.insertSpaces": true
+  },
+
+  // ==========================================
+  // DOCKER / CONTAINERS CONFIGURATION
+  // ==========================================
+  "containers.images.label": "Tag",
+  "containers.composeCommand": "docker-compose",
+
+  // ==========================================
+  // SHELLCHECK (timonwong.shellcheck)
+  // ==========================================
+  "shellcheck.enable": true,
+  "shellcheck.run": "onType",
+  "shellcheck.useWorkspaceRootAsCwd": true,
 
   // ==========================================
   // TERMINAL CONFIGURATION
@@ -119,7 +150,7 @@
     "DOCKER_BUILDKIT": "1"
   },
   "terminal.integrated.env.linux": {
-    "JEKYLL_ENV": "development", 
+    "JEKYLL_ENV": "development",
     "DOCKER_BUILDKIT": "1"
   },
 
@@ -133,7 +164,7 @@
     "**/_site/**": true,
     "**/.sass-cache/**": true,
     "**/.jekyll-cache/**": true,
-    "**/vendor/**": true,
+    "/vendor/**": true,
     "**/__pycache__/**": true,
     "**/*.pyc": true,
     "**/venv/**": true,
@@ -156,7 +187,7 @@
     "**/bower_components": true,
     "**/*.code-search": true,
     "**/_site": true,
-    "**/vendor": true,
+    "/vendor": true,
     "**/__pycache__": true,
     "**/build": true
   },
@@ -172,23 +203,30 @@
   // ==========================================
   "cSpell.words": [
     "bamr",
+    "barodybroject",
+    "buildkit",
+    "commonmarker",
     "endcapture",
     "endraw",
+    "frontmatter",
+    "gemspec",
     "Groking",
     "Inkscape",
     "Jamstack",
     "Krita",
     "lastmod",
+    "livereload",
     "markdownify",
     "MERN",
-    "Picade",
-    "sublinks",
-    "winget",
-    "barodybroject",
     "parodynews",
-    "zer0",
-    "gemspec",
-    "rubocop"
-  ],
-  "containers.images.label": "latest"
+    "Picade",
+    "posthog",
+    "rubocop",
+    "rubygems",
+    "sublinks",
+    "webrick",
+    "wikilinks",
+    "winget",
+    "zer0"
+  ]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,6 +1,26 @@
 {
+  // ==================================================================
+  // Docker-first tasks — everything runs in a container, nothing local
+  // ==================================================================
+  // Execution model:
+  //   • Container-native work (Jekyll, Ruby, Bash scripts, tests) runs
+  //     inside the running `jekyll` service via `docker-compose exec`.
+  //     These tasks `dependsOn` "Docker: Compose Up (Detached)", so they
+  //     start the container automatically.
+  //   • Tools NOT in the jekyll image (Playwright/node, markdownlint,
+  //     yamllint) run via throwaway `docker run` images (nothing installed
+  //     on the host).
+  //   • The Docker lifecycle tasks are themselves the `docker-compose`
+  //     commands, so they run on the host.
+  //   • Release PUBLISH tasks (Patch/Minor/Major, Quick Build & Test) are
+  //     the one host exception: they push to RubyGems + git and need host
+  //     credentials. Dry-run/preview release tasks run in the container.
+  // Last updated: 2026-06-21
   "version": "2.0.0",
   "tasks": [
+    // ---------------------------------------------------------------
+    // Docker lifecycle (these ARE the docker commands — run on host)
+    // ---------------------------------------------------------------
     {
       "label": "Docker: Compose Up (Detached)",
       "type": "shell",
@@ -42,320 +62,379 @@
       "problemMatcher": []
     },
     {
-      "label": "🚀 Release: Patch",
+      "label": "Docker: Shell into jekyll",
       "type": "shell",
-      "command": "${workspaceFolder}/scripts/release",
-      "args": ["patch"],
-      "group": {
-        "kind": "build",
-        "isDefault": false
-      },
+      "command": "docker-compose",
+      "args": ["exec", "jekyll", "bash"],
+      "options": { "cwd": "${workspaceFolder}" },
+      "dependsOn": "Docker: Compose Up (Detached)",
       "presentation": {
         "echo": true,
         "reveal": "always",
         "focus": true,
         "panel": "new",
         "showReuseMessage": false,
-        "clear": true
+        "clear": false
       },
       "problemMatcher": [],
-      "detail": "Publishes a patch version release (0.0.X) with full workflow: changelog generation, version bump, tests, build, and publish to RubyGems - using new modular release command"
+      "detail": "Open an interactive bash shell inside the running jekyll container."
+    },
+
+    // ---------------------------------------------------------------
+    // Build / validate (in container)
+    // ---------------------------------------------------------------
+    {
+      "label": "🧱 Jekyll: Build Validation",
+      "type": "shell",
+      "command": "docker-compose",
+      "args": ["exec", "-T", "jekyll", "bundle", "exec", "jekyll", "build", "--config", "_config.yml,_config_dev.yml"],
+      "options": { "cwd": "${workspaceFolder}" },
+      "dependsOn": "Docker: Compose Up (Detached)",
+      "group": "test",
+      "presentation": { "echo": true, "reveal": "always", "focus": false, "panel": "shared", "showReuseMessage": true, "clear": false },
+      "problemMatcher": [],
+      "detail": "Validate the Jekyll build inside the jekyll container (required before declaring theme/layout/include/sass changes done)."
+    },
+    {
+      "label": "✅ Validate: Preflight",
+      "type": "shell",
+      "command": "docker-compose",
+      "args": ["exec", "-T", "jekyll", "bash", "-lc", "cd /site && ./scripts/validate"],
+      "options": { "cwd": "${workspaceFolder}" },
+      "dependsOn": "Docker: Compose Up (Detached)",
+      "group": "test",
+      "presentation": { "echo": true, "reveal": "always", "focus": false, "panel": "shared", "showReuseMessage": true, "clear": false },
+      "problemMatcher": [],
+      "detail": "Run canonical preflight validation in the container (scripts/validate -> scripts/bin/validate)."
+    },
+    {
+      "label": "🔨 Build: Gem Only",
+      "type": "shell",
+      "command": "docker-compose",
+      "args": ["exec", "-T", "jekyll", "bash", "-lc", "cd /site && ./scripts/build"],
+      "options": { "cwd": "${workspaceFolder}" },
+      "dependsOn": "Docker: Compose Up (Detached)",
+      "group": { "kind": "build", "isDefault": true },
+      "presentation": { "echo": true, "reveal": "always", "focus": false, "panel": "shared", "showReuseMessage": true, "clear": false },
+      "problemMatcher": [],
+      "detail": "Build the gem in the container (no version bump/publish) — safe default build."
+    },
+
+    // ---------------------------------------------------------------
+    // Tests (in container)
+    // ---------------------------------------------------------------
+    {
+      "label": "🧪 Test: Run All Suites",
+      "type": "shell",
+      "command": "docker-compose",
+      "args": ["exec", "-T", "jekyll", "bash", "-lc", "cd /site && ./scripts/bin/test"],
+      "options": { "cwd": "${workspaceFolder}" },
+      "dependsOn": "Docker: Compose Up (Detached)",
+      "group": { "kind": "test", "isDefault": true },
+      "presentation": { "echo": true, "reveal": "always", "focus": false, "panel": "shared", "showReuseMessage": true, "clear": false },
+      "problemMatcher": [],
+      "detail": "Run all test tiers (lib + theme + integration) in the container via scripts/bin/test."
+    },
+    {
+      "label": "🧪 Test: lib",
+      "type": "shell",
+      "command": "docker-compose",
+      "args": ["exec", "-T", "jekyll", "bash", "-lc", "cd /site && ./scripts/bin/test lib"],
+      "options": { "cwd": "${workspaceFolder}" },
+      "dependsOn": "Docker: Compose Up (Detached)",
+      "group": "test",
+      "presentation": { "echo": true, "reveal": "always", "focus": false, "panel": "shared", "showReuseMessage": true, "clear": false },
+      "problemMatcher": [],
+      "detail": "Run library unit tests only (in container)."
+    },
+    {
+      "label": "🧪 Test: theme",
+      "type": "shell",
+      "command": "docker-compose",
+      "args": ["exec", "-T", "jekyll", "bash", "-lc", "cd /site && ./scripts/bin/test theme"],
+      "options": { "cwd": "${workspaceFolder}" },
+      "dependsOn": "Docker: Compose Up (Detached)",
+      "group": "test",
+      "presentation": { "echo": true, "reveal": "always", "focus": false, "panel": "shared", "showReuseMessage": true, "clear": false },
+      "problemMatcher": [],
+      "detail": "Run theme validation tests only (in container)."
+    },
+    {
+      "label": "🧪 Test: integration",
+      "type": "shell",
+      "command": "docker-compose",
+      "args": ["exec", "-T", "jekyll", "bash", "-lc", "cd /site && ./scripts/bin/test integration"],
+      "options": { "cwd": "${workspaceFolder}" },
+      "dependsOn": "Docker: Compose Up (Detached)",
+      "group": "test",
+      "presentation": { "echo": true, "reveal": "always", "focus": false, "panel": "shared", "showReuseMessage": true, "clear": false },
+      "problemMatcher": [],
+      "detail": "Run integration tests only (in container). Note: the mermaid sub-test probes the live server and may fail depending on build/config state."
+    },
+    {
+      "label": "🧪 Test Automated Version System",
+      "type": "shell",
+      "command": "docker-compose",
+      "args": ["exec", "-T", "jekyll", "bash", "-lc", "cd /site && ./scripts/test-auto-version.sh"],
+      "options": { "cwd": "${workspaceFolder}" },
+      "dependsOn": "Docker: Compose Up (Detached)",
+      "group": "test",
+      "presentation": { "echo": true, "reveal": "always", "focus": true, "panel": "shared", "showReuseMessage": true, "clear": true },
+      "problemMatcher": [],
+      "detail": "Run comprehensive tests on the automated version bump system (in container)."
+    },
+
+    // ---------------------------------------------------------------
+    // Lint (in container where possible; docker run images otherwise)
+    // ---------------------------------------------------------------
+    {
+      "label": "🧹 Lint: Page Frontmatter",
+      "type": "shell",
+      "command": "docker-compose",
+      "args": ["exec", "-T", "jekyll", "bash", "-lc", "cd /site && ./scripts/lint-pages"],
+      "options": { "cwd": "${workspaceFolder}" },
+      "dependsOn": "Docker: Compose Up (Detached)",
+      "group": "test",
+      "presentation": { "echo": true, "reveal": "always", "focus": false, "panel": "shared", "showReuseMessage": true, "clear": false },
+      "problemMatcher": [],
+      "detail": "Validate page front matter across all collections (in container)."
+    },
+    {
+      "label": "🧹 Lint: Markdown",
+      "type": "shell",
+      "command": "docker",
+      "args": [
+        "run", "--rm",
+        "-v", "${workspaceFolder}:/workdir",
+        "davidanson/markdownlint-cli2:latest",
+        "--config", ".github/config/.markdownlint.json",
+        "docs/**/*.md", "pages/_docs/**/*.md", "!docs/archive/**"
+      ],
+      "options": { "cwd": "${workspaceFolder}" },
+      "group": "test",
+      "presentation": { "echo": true, "reveal": "always", "focus": false, "panel": "shared", "showReuseMessage": true, "clear": false },
+      "problemMatcher": [],
+      "detail": "Lint docs/ and pages/_docs/ via the markdownlint-cli2 Docker image (mirrors CI config; nothing installed locally)."
+    },
+    {
+      "label": "🧹 Lint: YAML",
+      "type": "shell",
+      "command": "docker",
+      "args": [
+        "run", "--rm",
+        "-v", "${workspaceFolder}:/data",
+        "cytopia/yamllint:latest",
+        "-c", ".github/config/.yamllint.yml", "."
+      ],
+      "options": { "cwd": "${workspaceFolder}" },
+      "group": "test",
+      "presentation": { "echo": true, "reveal": "always", "focus": false, "panel": "shared", "showReuseMessage": true, "clear": false },
+      "problemMatcher": [],
+      "detail": "Lint YAML via the yamllint Docker image using the repo config (nothing installed locally)."
+    },
+
+    // ---------------------------------------------------------------
+    // Playwright (throwaway Microsoft Playwright image, nothing local)
+    // ---------------------------------------------------------------
+    {
+      "label": "🎭 Playwright: Smoke",
+      "type": "shell",
+      "command": "docker",
+      "args": [
+        "run", "--rm",
+        "--add-host", "host.docker.internal:host-gateway",
+        "-v", "${workspaceFolder}:/work",
+        "-v", "/work/node_modules",
+        "-w", "/work",
+        "-e", "BASE_URL=http://host.docker.internal:4000",
+        "mcr.microsoft.com/playwright:v1.58.2-noble",
+        "bash", "-lc", "npm ci && npm run test:smoke"
+      ],
+      "options": { "cwd": "${workspaceFolder}" },
+      "dependsOn": "Docker: Compose Up (Detached)",
+      "group": "test",
+      "presentation": { "echo": true, "reveal": "always", "focus": false, "panel": "shared", "showReuseMessage": true, "clear": false },
+      "problemMatcher": [],
+      "detail": "Run the Playwright smoke tier in the official Playwright image against the running dev server (host.docker.internal:4000). Runs `npm ci` in an isolated node_modules volume; requires the jekyll container up."
+    },
+    {
+      "label": "🎭 Playwright: Snapshots",
+      "type": "shell",
+      "command": "docker",
+      "args": [
+        "run", "--rm",
+        "--add-host", "host.docker.internal:host-gateway",
+        "-v", "${workspaceFolder}:/work",
+        "-v", "/work/node_modules",
+        "-w", "/work",
+        "-e", "BASE_URL=http://host.docker.internal:4000",
+        "mcr.microsoft.com/playwright:v1.58.2-noble",
+        "bash", "-lc", "npm ci && npm run test:snapshots"
+      ],
+      "options": { "cwd": "${workspaceFolder}" },
+      "dependsOn": "Docker: Compose Up (Detached)",
+      "group": "test",
+      "presentation": { "echo": true, "reveal": "always", "focus": false, "panel": "shared", "showReuseMessage": true, "clear": false },
+      "problemMatcher": [],
+      "detail": "Run the Playwright pixel-snapshot tier in the official Playwright image (Linux) against the running dev server. Baselines are Linux-generated; run on Linux for matching pixels."
+    },
+
+    // ---------------------------------------------------------------
+    // Release / versioning
+    //   PUBLISH tasks run on the HOST (need RubyGems + git credentials).
+    //   Dry-run / preview / analysis run in the container.
+    // ---------------------------------------------------------------
+    {
+      "label": "🚀 Release: Patch",
+      "type": "shell",
+      "command": "${workspaceFolder}/scripts/release",
+      "args": ["patch"],
+      "group": { "kind": "build", "isDefault": false },
+      "presentation": { "echo": true, "reveal": "always", "focus": true, "panel": "new", "showReuseMessage": false, "clear": true },
+      "problemMatcher": [],
+      "detail": "HOST: publish a patch release (changelog, version bump, tests, build, push to RubyGems + git). Needs host RubyGems/git credentials."
     },
     {
       "label": "🚀 Release: Minor",
       "type": "shell",
       "command": "${workspaceFolder}/scripts/release",
       "args": ["minor"],
-      "group": {
-        "kind": "build",
-        "isDefault": false
-      },
-      "presentation": {
-        "echo": true,
-        "reveal": "always",
-        "focus": true,
-        "panel": "new",
-        "showReuseMessage": false,
-        "clear": true
-      },
+      "group": { "kind": "build", "isDefault": false },
+      "presentation": { "echo": true, "reveal": "always", "focus": true, "panel": "new", "showReuseMessage": false, "clear": true },
       "problemMatcher": [],
-      "detail": "Publishes a minor version release (0.X.0) with full workflow: changelog generation, version bump, tests, build, and publish to RubyGems - using new modular release command"
+      "detail": "HOST: publish a minor release (full workflow). Needs host RubyGems/git credentials."
     },
     {
       "label": "🚀 Release: Major",
       "type": "shell",
       "command": "${workspaceFolder}/scripts/release",
       "args": ["major"],
-      "group": {
-        "kind": "build",
-        "isDefault": false
-      },
-      "presentation": {
-        "echo": true,
-        "reveal": "always",
-        "focus": true,
-        "panel": "new",
-        "showReuseMessage": false,
-        "clear": true
-      },
+      "group": { "kind": "build", "isDefault": false },
+      "presentation": { "echo": true, "reveal": "always", "focus": true, "panel": "new", "showReuseMessage": false, "clear": true },
       "problemMatcher": [],
-      "detail": "Publishes a major version release (X.0.0) with full workflow: changelog generation, version bump, tests, build, and publish to RubyGems - using new modular release command"
+      "detail": "HOST: publish a major release (full workflow). Needs host RubyGems/git credentials."
+    },
+    {
+      "label": "⚡ Release: Quick Build & Test (no publish)",
+      "type": "shell",
+      "command": "${workspaceFolder}/scripts/release",
+      "args": ["patch", "--skip-publish", "--no-github-release"],
+      "group": { "kind": "build", "isDefault": false },
+      "presentation": { "echo": true, "reveal": "always", "focus": true, "panel": "new", "showReuseMessage": false, "clear": true },
+      "problemMatcher": [],
+      "detail": "HOST: changelog + version bump + tests + build, skipping RubyGems publish. Still commits/tags/pushes git, so needs host git credentials."
     },
     {
       "label": "🔍 Release: Dry Run Preview",
       "type": "shell",
-      "command": "${workspaceFolder}/scripts/release",
-      "args": ["patch", "--dry-run"],
-      "group": {
-        "kind": "test",
-        "isDefault": false
-      },
-      "presentation": {
-        "echo": true,
-        "reveal": "always",
-        "focus": true,
-        "panel": "new",
-        "showReuseMessage": false,
-        "clear": true
-      },
+      "command": "docker-compose",
+      "args": ["exec", "-T", "jekyll", "bash", "-lc", "cd /site && ./scripts/release patch --dry-run"],
+      "options": { "cwd": "${workspaceFolder}" },
+      "dependsOn": "Docker: Compose Up (Detached)",
+      "group": { "kind": "test", "isDefault": false },
+      "presentation": { "echo": true, "reveal": "always", "focus": true, "panel": "new", "showReuseMessage": false, "clear": true },
       "problemMatcher": [],
-      "detail": "Preview what a patch release would do without making any changes - shows changelog generation and version updates using new modular release command"
-    },
-    {
-      "label": "⚡ Release: Quick Build & Test",
-      "type": "shell",
-      "command": "${workspaceFolder}/scripts/release",
-      "args": ["patch", "--skip-publish", "--no-github-release"],
-      "group": {
-        "kind": "build",
-        "isDefault": true
-      },
-      "presentation": {
-        "echo": true,
-        "reveal": "always",
-        "focus": true,
-        "panel": "new",
-        "showReuseMessage": false,
-        "clear": true
-      },
-      "problemMatcher": [],
-      "detail": "Quick development workflow: changelog generation, version bump, tests, and build - but skip publishing to RubyGems - using new modular release command"
+      "detail": "Preview a patch release without making changes (in container)."
     },
     {
       "label": "📝 Release: Generate Changelog Preview",
       "type": "shell",
-      "command": "${workspaceFolder}/scripts/release",
-      "args": ["patch", "--skip-tests", "--skip-publish", "--no-github-release", "--dry-run"],
-      "group": {
-        "kind": "test",
-        "isDefault": false
-      },
-      "presentation": {
-        "echo": true,
-        "reveal": "always",
-        "focus": true,
-        "panel": "new",
-        "showReuseMessage": false,
-        "clear": true
-      },
+      "command": "docker-compose",
+      "args": ["exec", "-T", "jekyll", "bash", "-lc", "cd /site && ./scripts/release patch --skip-tests --skip-publish --no-github-release --dry-run"],
+      "options": { "cwd": "${workspaceFolder}" },
+      "dependsOn": "Docker: Compose Up (Detached)",
+      "group": { "kind": "test", "isDefault": false },
+      "presentation": { "echo": true, "reveal": "always", "focus": true, "panel": "new", "showReuseMessage": false, "clear": true },
       "problemMatcher": [],
-      "detail": "Preview automatic changelog generation from commit history - useful for reviewing changes before release - using new modular release command"
-    },
-    {
-      "label": "🧪 Gem: Run Tests Only",
-      "type": "shell",
-      "command": "bundle exec rspec",
-      "group": {
-        "kind": "test",
-        "isDefault": true
-      },
-      "presentation": {
-        "echo": true,
-        "reveal": "always",
-        "focus": false,
-        "panel": "shared",
-        "showReuseMessage": true,
-        "clear": false
-      },
-      "problemMatcher": [],
-      "detail": "Run the full test suite without any release actions"
-    },
-    {
-      "label": "🔨 Build: Gem Only",
-      "type": "shell",
-      "command": "${workspaceFolder}/scripts/build",
-      "group": {
-        "kind": "build",
-        "isDefault": false
-      },
-      "presentation": {
-        "echo": true,
-        "reveal": "always",
-        "focus": false,
-        "panel": "shared",
-        "showReuseMessage": true,
-        "clear": false
-      },
-      "problemMatcher": [],
-      "detail": "Build the gem file without publishing or version changes - using new modular build command"
-    },
-    {
-      "label": "📊 Gem: Version Info",
-      "type": "shell",
-      "command": "echo \"Current Version: $(grep -o 'VERSION = \"[^\"]*\"' lib/jekyll-theme-zer0/version.rb | sed 's/VERSION = \"\\(.*\\)\"/\\1/')\" && echo \"Last Tag: $(git describe --tags --abbrev=0 2>/dev/null || echo 'No tags found')\" && echo \"Commits since last tag: $(git rev-list --count $(git describe --tags --abbrev=0 2>/dev/null || git rev-list --max-parents=0 HEAD)..HEAD 2>/dev/null || echo '0')\"",
-      "group": {
-        "kind": "test",
-        "isDefault": false
-      },
-      "presentation": {
-        "echo": true,
-        "reveal": "always",
-        "focus": false,
-        "panel": "shared",
-        "showReuseMessage": true,
-        "clear": false
-      },
-      "problemMatcher": [],
-      "detail": "Display current version information and commit status"
-    },
-    {
-      "label": "🤖 Analyze Commits for Version Bump",
-      "type": "shell",
-      "command": "./scripts/analyze-commits.sh",
-      "args": ["HEAD~5..HEAD"],
-      "options": {
-        "cwd": "${workspaceFolder}"
-      },
-      "group": "build",
-      "presentation": {
-        "echo": true,
-        "reveal": "always",
-        "focus": false,
-        "panel": "shared",
-        "showReuseMessage": true,
-        "clear": false
-      },
-      "problemMatcher": [],
-      "detail": "Analyze recent commits to determine what version bump would be appropriate"
-    },
-    {
-      "label": "🧪 Test Automated Version System",
-      "type": "shell", 
-      "command": "./scripts/test-auto-version.sh",
-      "options": {
-        "cwd": "${workspaceFolder}"
-      },
-      "group": "test",
-      "presentation": {
-        "echo": true,
-        "reveal": "always",
-        "focus": true,
-        "panel": "shared",
-        "showReuseMessage": true,
-        "clear": true
-      },
-      "problemMatcher": [],
-      "detail": "Run comprehensive tests on the automated version bump system"
+      "detail": "Preview automatic changelog generation from commit history (in container)."
     },
     {
       "label": "🔍 Preview Automated Release",
       "type": "shell",
-      "command": "./scripts/release",
-      "args": ["patch", "--dry-run", "--skip-tests", "--skip-publish", "--no-github-release"],
-      "options": {
-        "cwd": "${workspaceFolder}"
-      },
+      "command": "docker-compose",
+      "args": ["exec", "-T", "jekyll", "bash", "-lc", "cd /site && ./scripts/release patch --dry-run --skip-tests --skip-publish --no-github-release"],
+      "options": { "cwd": "${workspaceFolder}" },
+      "dependsOn": "Docker: Compose Up (Detached)",
       "group": "build",
-      "presentation": {
-        "echo": true,
-        "reveal": "always",
-        "focus": false,
-        "panel": "shared",
-        "showReuseMessage": true,
-        "clear": false
-      },
+      "presentation": { "echo": true, "reveal": "always", "focus": false, "panel": "shared", "showReuseMessage": true, "clear": false },
       "problemMatcher": [],
-      "detail": "Preview what an automated release would do without making any changes"
+      "detail": "Preview what an automated release would do without making any changes (in container)."
     },
+    {
+      "label": "📊 Gem: Version Info",
+      "type": "shell",
+      "command": "docker-compose",
+      "args": ["exec", "-T", "jekyll", "bash", "-lc", "cd /site && echo Current version: && grep VERSION lib/jekyll-theme-zer0/version.rb && echo Last tag: && (git describe --tags --abbrev=0 2>/dev/null || echo none) && echo Commits since last tag: && (git rev-list --count $(git describe --tags --abbrev=0 2>/dev/null || git rev-list --max-parents=0 HEAD)..HEAD 2>/dev/null || echo 0)"],
+      "options": { "cwd": "${workspaceFolder}" },
+      "dependsOn": "Docker: Compose Up (Detached)",
+      "group": { "kind": "test", "isDefault": false },
+      "presentation": { "echo": true, "reveal": "always", "focus": false, "panel": "shared", "showReuseMessage": true, "clear": false },
+      "problemMatcher": [],
+      "detail": "Display current version information and commit status (in container)."
+    },
+    {
+      "label": "🤖 Analyze Commits for Version Bump",
+      "type": "shell",
+      "command": "docker-compose",
+      "args": ["exec", "-T", "jekyll", "bash", "-lc", "cd /site && ./scripts/analyze-commits.sh HEAD~5..HEAD"],
+      "options": { "cwd": "${workspaceFolder}" },
+      "dependsOn": "Docker: Compose Up (Detached)",
+      "group": "build",
+      "presentation": { "echo": true, "reveal": "always", "focus": false, "panel": "shared", "showReuseMessage": true, "clear": false },
+      "problemMatcher": [],
+      "detail": "Analyze recent commits to determine the appropriate version bump (in container)."
+    },
+
+    // ---------------------------------------------------------------
+    // Preview images (in container; generation needs OPENAI_API_KEY)
+    // ---------------------------------------------------------------
     {
       "label": "🎨 Preview Images: List Missing",
       "type": "shell",
-      "command": "./scripts/generate-preview-images.sh",
-      "args": ["--list-missing"],
-      "options": {
-        "cwd": "${workspaceFolder}"
-      },
+      "command": "docker-compose",
+      "args": ["exec", "-T", "jekyll", "bash", "-lc", "cd /site && ./scripts/generate-preview-images.sh --list-missing"],
+      "options": { "cwd": "${workspaceFolder}" },
+      "dependsOn": "Docker: Compose Up (Detached)",
       "group": "build",
-      "presentation": {
-        "echo": true,
-        "reveal": "always",
-        "focus": true,
-        "panel": "new",
-        "showReuseMessage": false,
-        "clear": true
-      },
+      "presentation": { "echo": true, "reveal": "always", "focus": true, "panel": "new", "showReuseMessage": false, "clear": true },
       "problemMatcher": [],
-      "detail": "List all content files that are missing preview images"
+      "detail": "List all content files missing preview images (in container)."
     },
     {
       "label": "🎨 Preview Images: Dry Run",
       "type": "shell",
-      "command": "./scripts/generate-preview-images.sh",
-      "args": ["--dry-run", "--verbose"],
-      "options": {
-        "cwd": "${workspaceFolder}"
-      },
+      "command": "docker-compose",
+      "args": ["exec", "-T", "jekyll", "bash", "-lc", "cd /site && ./scripts/generate-preview-images.sh --dry-run --verbose"],
+      "options": { "cwd": "${workspaceFolder}" },
+      "dependsOn": "Docker: Compose Up (Detached)",
       "group": "build",
-      "presentation": {
-        "echo": true,
-        "reveal": "always",
-        "focus": true,
-        "panel": "new",
-        "showReuseMessage": false,
-        "clear": true
-      },
+      "presentation": { "echo": true, "reveal": "always", "focus": true, "panel": "new", "showReuseMessage": false, "clear": true },
       "problemMatcher": [],
-      "detail": "Preview what images would be generated without making changes"
+      "detail": "Preview what images would be generated without making changes (in container)."
     },
     {
       "label": "🎨 Preview Images: Generate for Posts",
       "type": "shell",
-      "command": "./scripts/generate-preview-images.sh",
-      "args": ["--collection", "posts"],
-      "options": {
-        "cwd": "${workspaceFolder}"
-      },
+      "command": "docker-compose",
+      "args": ["exec", "-T", "-e", "OPENAI_API_KEY=${env:OPENAI_API_KEY}", "jekyll", "bash", "-lc", "cd /site && ./scripts/generate-preview-images.sh --collection posts"],
+      "options": { "cwd": "${workspaceFolder}" },
+      "dependsOn": "Docker: Compose Up (Detached)",
       "group": "build",
-      "presentation": {
-        "echo": true,
-        "reveal": "always",
-        "focus": true,
-        "panel": "new",
-        "showReuseMessage": false,
-        "clear": true
-      },
+      "presentation": { "echo": true, "reveal": "always", "focus": true, "panel": "new", "showReuseMessage": false, "clear": true },
       "problemMatcher": [],
-      "detail": "Generate AI preview images for all posts missing previews (requires OPENAI_API_KEY)"
+      "detail": "Generate AI preview images for posts missing previews (in container; needs OPENAI_API_KEY in your environment)."
     },
     {
       "label": "🎨 Preview Images: Generate All",
       "type": "shell",
-      "command": "./scripts/generate-preview-images.sh",
-      "args": ["--collection", "all"],
-      "options": {
-        "cwd": "${workspaceFolder}"
-      },
+      "command": "docker-compose",
+      "args": ["exec", "-T", "-e", "OPENAI_API_KEY=${env:OPENAI_API_KEY}", "jekyll", "bash", "-lc", "cd /site && ./scripts/generate-preview-images.sh --collection all"],
+      "options": { "cwd": "${workspaceFolder}" },
+      "dependsOn": "Docker: Compose Up (Detached)",
       "group": "build",
-      "presentation": {
-        "echo": true,
-        "reveal": "always",
-        "focus": true,
-        "panel": "new",
-        "showReuseMessage": false,
-        "clear": true
-      },
+      "presentation": { "echo": true, "reveal": "always", "focus": true, "panel": "new", "showReuseMessage": false, "clear": true },
       "problemMatcher": [],
-      "detail": "Generate AI preview images for all content missing previews (requires OPENAI_API_KEY)"
+      "detail": "Generate AI preview images for all content missing previews (in container; needs OPENAI_API_KEY in your environment)."
     }
   ]
 }


### PR DESCRIPTION
## Summary

Aligns the VS Code workspace with the repo's Docker-first workflow and current toolchain. Editor-config only — no theme, layout, or runtime code changes.

## Changes

- **[`.vscode/tasks.json`](.vscode/tasks.json)** — route container-native work (Jekyll build/validate, test tiers, gem build, frontmatter lint, release dry-runs/preview, preview-image generation, commit analysis) through `docker-compose exec` on the running `jekyll` service, with `dependsOn` auto-starting the container. Lint (markdownlint, yamllint) and Playwright (smoke + snapshots) tiers run via throwaway `docker run` images so nothing is installed on the host. Release **publish** tasks remain on the host since they need RubyGems + git credentials. Adds a documented execution-model header.
- **[`.vscode/settings.json`](.vscode/settings.json)** — switch Ruby formatting to Shopify Ruby LSP (drop removed rubocop/rebornix settings), add GitHub Actions YAML schema mapping, per-language tab settings, shellcheck config, renamed `containers.*` Docker settings, and expanded cSpell dictionary.
- **[`.vscode/extensions.json`](.vscode/extensions.json)** — recommend GitHub Actions, Playwright, and shellcheck; move stale TypeScript/Tailwind/`rebornix.ruby` entries to `unwantedRecommendations`.
- **[`.vscode/launch.json`](.vscode/launch.json)** — drop `--disable-web-security` from Chrome/Edge debug profiles and trim redundant `/js/` and `/css/` path mappings (already covered by `/assets/`).

## Validation

Editor configuration only; no build impact. JSONC files parse cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)