### PR TITLE
ci: guard version.rb ↔ Gemfile.lock consistency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,6 +149,26 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v5
 
+      # Always-running guard: version.rb must equal the gem version pinned in
+      # Gemfile.lock. Lives in this job (not the path-filtered fast-checks) so it
+      # gates every PR — including release PRs that bump version.rb without
+      # re-locking, the drift that left the lock at 1.19.1 vs version.rb 1.19.0.
+      # Pure bash (no Ruby setup needed); mirrors validate_version_consistency
+      # in scripts/bin/validate.
+      - name: Version ↔ Gemfile.lock consistency
+        run: |
+          rb=$(sed -nE 's/.*VERSION = "([0-9][^"]*)".*/\1/p' lib/jekyll-theme-zer0/version.rb | head -1)
+          lock=$(sed -nE 's/^[[:space:]]*jekyll-theme-zer0 \(([^)]+)\).*/\1/p' Gemfile.lock | head -1)
+          if [ -z "$rb" ] || [ -z "$lock" ]; then
+            echo "::error::could not parse version (version.rb='$rb', Gemfile.lock='$lock')"
+            exit 1
+          fi
+          if [ "$rb" != "$lock" ]; then
+            echo "::error file=Gemfile.lock::version.rb ($rb) != Gemfile.lock ($lock) — run 'bundle lock' to re-sync"
+            exit 1
+          fi
+          echo "✓ version.rb and Gemfile.lock agree: $rb"
+
       - name: Run Quality Checks
         uses: ./.github/actions/quality-checks
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   redundant duplicates and some emitted comments were removed) — no tokens,
   selectors, or declaration values changed.
 
+### Fixed
+- **`Gemfile.lock` re-synced to `version.rb` (1.19.1 → 1.19.0)** and guarded
+  against future drift. The `validate_version_consistency` check
+  (`scripts/bin/validate`) now also compares the gem version pinned in
+  `Gemfile.lock`, and a new always-running `Version ↔ Gemfile.lock consistency`
+  step in CI's `quality-checks` job fails any PR where the two disagree — the
+  exact drift that left the lock at 1.19.1 while `version.rb` said 1.19.0.
+
 ## [1.19.0](https://github.com/bamr87/zer0-mistakes/compare/v1.18.1...v1.19.0) (2026-06-16)
 
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    jekyll-theme-zer0 (1.19.1)
+    jekyll-theme-zer0 (1.19.0)
       jekyll
 
 GEM

--- a/scripts/bin/validate
+++ b/scripts/bin/validate
@@ -35,7 +35,7 @@ DESCRIPTION:
 DEFAULT CHECKS:
     - Required repository files
     - Gemspec parse
-    - Version consistency between version.rb, package.json, and gemspec
+    - Version consistency between version.rb, package.json, gemspec, and Gemfile.lock
     - YAML parse for root config, _data, and .github/config files
     - Active configuration contract and config-file classification
     - Navigation data shape
@@ -239,6 +239,16 @@ if File.file?('package.json')
   # Explicit UTF-8: package.json contains multibyte characters and the default
   # external encoding is US-ASCII when no locale is set (containers, some CI).
   versions['package.json'] = JSON.parse(File.read('package.json', encoding: 'UTF-8')).fetch('version').to_s
+end
+
+# Gemfile.lock pins the gem's own version in its PATH specs block. It drifts
+# from version.rb when a release path bumps the version without re-locking
+# (the exact failure that left the lock at 1.19.1 while version.rb said 1.19.0).
+if File.file?('Gemfile.lock')
+  lock = File.read('Gemfile.lock')
+  if (match = lock.match(/^\s*jekyll-theme-zer0 \(([^)]+)\)\s*$/))
+    versions['Gemfile.lock'] = match[1].to_s
+  end
 end
 
 expected = versions.values.first


### PR DESCRIPTION
## Summary

Implements the version/lock guard follow-up: nothing verified that `Gemfile.lock`'s pinned `jekyll-theme-zer0 (X.Y.Z)` matched [`version.rb`](lib/jekyll-theme-zer0/version.rb), which is exactly how the lock drifted to `1.19.1` while `version.rb` said `1.19.0`.

## Changes

- **[`scripts/bin/validate`](scripts/bin/validate)** — extend the existing `validate_version_consistency` check to also read the version from `Gemfile.lock` and fold it into the same `version.rb` / `package.json` / `gemspec` assertion. Runs locally and in the path-filtered **Fast Checks** CI job.
- **[`.github/workflows/ci.yml`](.github/workflows/ci.yml)** — add an always-running **“Version ↔ Gemfile.lock consistency”** step to the `quality-checks` job (pure bash, no Ruby setup). Since `quality-checks` runs on every PR, the **Quality Control** status check now enforces the invariant — deliberately *not* the path-filtered jobs, which skip on docs-only PRs and would create a required-check-never-reports lockout.
- **[`Gemfile.lock`](Gemfile.lock)** — re-sync the existing drift (`1.19.1 → 1.19.0`) so the new guard passes on its own PR (standard "add the check, fix the existing violation").

## Validation

- `./scripts/bin/validate --quick` → `Version consistent: 1.19.0` across `version.rb`, `gemspec`, `package.json`, **and** `Gemfile.lock`.
- Bash CI step passes on the synced tree; **negative test** confirms it exits non-zero on a mismatch.
- `.claude/worktrees/**` config-contract noise in local validate is a stale-host artifact (gitignored; absent in CI).

## Coordination with PR #191

PR #191 also re-synced `Gemfile.lock`. To avoid a duplicate change in two open PRs, I'm dropping the lock change from #191 (leaving it as just the `content_statistics.yml` regen) — this PR now owns the lock fix, paired with the guard that prevents recurrence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)