### PR TITLE
fix(release): re-sync Gemfile.lock and package-lock.json to 1.20.1

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,8 +9,14 @@ Zer0-Mistakes is a Docker-first Jekyll theme published as the Ruby gem
 and automated semantic releases to RubyGems. Primary languages: Liquid/HTML
 (theme), SCSS, Bash (tooling), Ruby (gem + plugins).
 
-**Version source of truth**: `lib/jekyll-theme-zer0/version.rb`. Never bump it
-by hand outside a release — use `./scripts/bin/release`.
+**Version source of truth**: `lib/jekyll-theme-zer0/version.rb`. Don't bump it by
+hand. **release-please** is the canonical flow: it watches Conventional Commits on
+`main`, opens a "chore(main): release X.Y.Z" PR, and merging that PR tags the
+release and publishes the gem (`.github/workflows/release.yml` → reusable
+workflows in `bamr87/.github`). `./scripts/bin/release` remains a manual fallback.
+Any `version.rb` bump MUST re-lock `Gemfile.lock` *and* `package-lock.json` in the
+same change — a stale lock breaks the frozen `bundle install` in the publish job
+(CI guards version.rb ↔ Gemfile.lock).
 
 ## Layered Agent Guidance
 
@@ -150,9 +156,11 @@ support `--dry-run`. The self-healing installer is `install.sh` +
    layout/include/sass change, run the Docker Jekyll build above.
 4. **Update `CHANGELOG.md`** for user-visible changes (Keep a Changelog
    format, newest entry at the top).
-5. **Version bumps happen only via `./scripts/bin/release`** — never in
-   unrelated PRs. Keep `Gemfile.lock`'s `jekyll-theme-zer0` version in sync with
-   `version.rb`, and keep the generated `_data/content_statistics.yml` out of
+5. **Version bumps happen via release automation** — release-please's release PR
+   (canonical) or `./scripts/bin/release` (manual fallback), never in unrelated
+   PRs. A `version.rb` bump MUST re-lock `Gemfile.lock` *and* `package-lock.json`
+   in the same change — a stale lock breaks the frozen `bundle install` in the
+   publish workflow. Keep the generated `_data/content_statistics.yml` out of
    feature PRs (its own `chore` commit or CI).
 6. **Conventional commits**: types `feat|fix|docs|style|refactor|perf|test|chore`;
    scopes include `search`, `navigation`, `layouts`, `includes`, `sass`,

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    jekyll-theme-zer0 (1.20.0)
+    jekyll-theme-zer0 (1.20.1)
       jekyll
 
 GEM

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "zer0-mistakes-theme-tools",
-  "version": "1.19.0",
+  "version": "1.20.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "zer0-mistakes-theme-tools",
-      "version": "1.19.0",
+      "version": "1.20.1",
       "devDependencies": {
         "@axe-core/playwright": "^4.11.1",
         "@playwright/test": "^1.49.0",


### PR DESCRIPTION
## Why

The gem stopped auto-publishing to RubyGems (latest published is **1.19.1**; 1.20.0 and 1.20.1 are tagged but never published). Root cause: release-please bumps `version.rb` but doesn't re-lock, so `main` drifted —

| file | was | now |
|---|---|---|
| `lib/jekyll-theme-zer0/version.rb` | 1.20.1 | 1.20.1 |
| `Gemfile.lock` (path gem) | **1.20.0** | 1.20.1 |
| `package.json` | 1.20.1 | 1.20.1 |
| `package-lock.json` | **1.19.0** | 1.20.1 |

The stale `Gemfile.lock` fails the frozen `bundle install` in the publish job (exit 16: *"the gemspecs for path gems changed, but the lockfile can't be updated because frozen mode is set"*), trips the `version.rb ↔ Gemfile.lock` CI guard, and breaks `bundle install --deployment` for Docker/consumers.

## What

- Re-sync all version sources to **1.20.1** (surgical version-field edits — no dependency churn).
- Clarify in `CLAUDE.md` that **release-please is the canonical release flow** and that any `version.rb` bump must re-lock both lockfiles in the same change.

## Companion fix

The recurring drift + publish fragility is fixed at the source in [bamr87/.github#1](https://github.com/bamr87/.github/pull/1): the publish job no longer does a frozen install, and the release-please workflow re-locks `Gemfile.lock`/`package-lock.json` on the release PR. Once that merges, future releases stay self-consistent automatically and 1.20.1 can be published by re-running the failed run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)