### PR TITLE
ci(release): adopt hardened-trunk release strategy

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,31 @@
+# Code owners — paths that REQUIRE @bamr87 review before merge, enforced by the
+# branch-protection rule "Require review from Code Owners" on `main`.
+#
+# Deliberately NO catch-all `*` rule. A `*` owner would force a code-owner review
+# on EVERY PR and kill the low-risk auto-merge fast path (auto-merge.yml) that the
+# bot firehose relies on. With only the paths below owned, a PR that touches none
+# of them (content under pages/**, _sass/**, assets/**, docs/**) needs no
+# code-owner review and can still auto-merge on green — while any change to the
+# release/versioning/CI surface is gated on human (your) review.
+
+# Release & versioning surface — only the release tooling (release-please) should
+# move these; a stray hand-edit is how version.rb and Gemfile.lock drift apart.
+/lib/jekyll-theme-zer0/version.rb   @bamr87
+/CHANGELOG.md                       @bamr87
+/release-please-config.json         @bamr87
+/.release-please-manifest.json      @bamr87
+
+# Gem + dependency manifests.
+*.gemspec                           @bamr87
+/Gemfile                            @bamr87
+/Gemfile.lock                       @bamr87
+/package.json                       @bamr87
+/package-lock.json                  @bamr87
+
+# High-blast-radius infrastructure: CI/CD, custom plugins, release scripts.
+/.github/workflows/                 @bamr87
+/.github/actions/                   @bamr87
+/.github/CODEOWNERS                 @bamr87
+/_plugins/                          @bamr87
+/scripts/bin/                       @bamr87
+/scripts/lib/                       @bamr87

--- a/.github/instructions/version-control.instructions.md
+++ b/.github/instructions/version-control.instructions.md
@@ -9,17 +9,50 @@ lastmod: 2026-06-21T12:00:00.000Z
 
 For the full release pipeline see [`.github/prompts/commit-publish.prompt.md`](../prompts/commit-publish.prompt.md). This file defines the rules.
 
-## Branching
+## Branching — Hardened Trunk
 
-GitHub Flow. `main` is always deployable.
+GitHub Flow on a **single trunk**. `main` is always deployable and is the only
+long-lived branch — there is **no `develop`, no `next`, no standing `release/*`**.
 
 ```
-feature/<scope>-<desc>     bugfix/<scope>-<desc>
-hotfix/<scope>-<desc>      docs/<desc>
-chore/<desc>               refactor/<scope>-<desc>
+feature/<scope>-<desc>     bugfix/<scope>-<desc>     ci/<desc>
+hotfix/<scope>-<desc>      docs/<desc>               perf/<scope>-<desc>
+chore/<scope>-<desc>       refactor/<scope>-<desc>
+claude/<slug>   copilot/<slug>   automated/<slug>    # agent work — same rules
 ```
 
-Branch off `main`, open PR early, squash-merge.
+Branch off `main`, open a PR early, **squash-merge** (the squash title is the
+Conventional Commit the release tooling reads). One concern per PR. Agent
+branches (`claude/*`, `copilot/*`, `automated/*`) obey the same rules as human
+ones. Parallel efforts each get their own short-lived branch / `git worktree` —
+never a shared accumulator branch.
+
+### The release PR *is* your accumulator
+
+You do **not** stage a version on a branch. release-please keeps one open
+`chore(main): release X.Y.Z` PR that recomputes the pending version from `main`'s
+commit history on every push — a conflict-free, server-side accumulator that
+collapses N merged PRs into exactly one pending version:
+
+| Concept | Where | Meaning |
+|---|---|---|
+| **Intent** | a GitHub **Milestone** (`1.21`, `2.0`) | what you *plan* to ship (human view; auto-assigned by `milestone-assign.yml` when exactly one milestone is open) |
+| **Pending version** | the open **release PR** | what *will* ship if you cut now (`feat`→minor; `fix/perf/refactor/docs/chore/test/ci`→patch; `!`/`BREAKING CHANGE:`→major) |
+| **Truth** | `version.rb` on `main` | the last released version |
+| **Fact** | git **tags** `vX.Y.Z` | immutable release points (linear tree) |
+
+**Cutting a set** = deliberately merging the release PR when its contents are
+coherent — *you* control the timing. That tags `vX.Y.Z`, publishes the gem, and
+(via continuous Pages deploy) ships the site. To **aim** the accumulator at a
+chosen version class, add a `Release-As: 1.21.0` footer to a held commit, and
+audit incoming agent PR titles for a rogue `!` / `BREAKING CHANGE:` that would
+silently flip the pending major.
+
+For a multi-week breaking **2.0** that must stabilize alongside 1.x, create a
+*temporary* `prerelease/2.0` branch with a one-off `Release-As: 2.0.0-rc.1`
+(first verify `gem build` accepts the resulting `2.0.0.pre.rc.1`) — delete it the
+day 2.0.0 ships. That is the only sanctioned long-lived-ish branch, and only when
+a real major is in flight.
 
 ## Working-Tree & Branch Discipline
 
@@ -129,22 +162,33 @@ Rules:
 
 ## Release Process
 
+**Canonical: release-please.** Conventional-Commit PRs merged to `main` are
+accumulated into one open `chore(main): release X.Y.Z` PR
+(`.github/workflows/release.yml` → reusable workflows in `bamr87/.github`).
+**Cut a release by merging that PR** — it tags `vX.Y.Z`, creates the GitHub
+Release, and `publish.yml` builds the gem and pushes it to RubyGems. The reusable
+`relock` job re-locks `Gemfile.lock`/`package-lock.json` on the release PR, so the
+version↔lock invariant holds automatically. Do **not** hand-bump the version or
+run a second release flow for the same version.
+
+**Manual fallback** (local, only if the automated pipeline is unavailable):
+
 ```bash
 ./scripts/bin/release patch --dry-run    # preview
 ./scripts/bin/release [patch|minor|major]
 ```
 
-The script runs: analyze commits → validate (Jekyll build, doctor, YAML) → bump version → update CHANGELOG → commit → tag → push → `gem build` → `gem push` → verify on RubyGems.
+The script analyzes commits → validates → bumps `version.rb` → updates CHANGELOG →
+re-locks `Gemfile.lock` → commits/tags/pushes → `gem build`/`gem push`. Never mix
+it with a release-please cut for the same version.
 
-Manual fallback: see `commit-publish.prompt.md`.
+## Pre-Release Checklist (before merging the release PR)
 
-## Pre-Release Checklist
-
-- [ ] `main` clean, CI green
-- [ ] All `[Unreleased]` entries belong in this release
-- [ ] No `WIP`, `TODO`, or commented-out code in diff
-- [ ] Bumped `version.rb` matches new tag
-- [ ] Tested locally: `docker-compose exec -T jekyll bundle exec jekyll build`
+- [ ] CI green on the release PR's **final HEAD** — the relock commit, not the bump commit
+- [ ] The pending version + CHANGELOG match the set you intend to ship
+- [ ] No stray `feat!` / `BREAKING CHANGE:` in the set unless you mean to cut a major
+- [ ] `version.rb`, `Gemfile.lock`, `package*.json` all agree on the new version
+- [ ] Site builds: `docker-compose exec -T jekyll bundle exec jekyll build`
 
 ## Gem Publication
 
@@ -158,19 +202,24 @@ s.add_runtime_dependency "jekyll"
 
 First-time setup: `gem signin` (stores API key in `~/.gem/credentials`, perms `0600`).
 
-CI publication via `.github/workflows/gem-release.yml` triggered on `v*` tag, using `RUBYGEMS_API_KEY` secret.
+CI publication: `.github/workflows/release.yml` chains release-please → `publish.yml`
+(in `bamr87/.github`), which runs on the **release-PR merge** (not a `v*` tag
+trigger) and `gem push`es using the `RUBYGEMS_API_KEY` secret.
 
 ## Hotfix Process
 
+Same trunk flow — a hotfix is just a high-priority `fix:` PR:
+
 ```bash
 git switch -c hotfix/<issue> main
-# fix + test
+# fix + test, then open PR → review → squash-merge
 git commit -m "fix(<scope>): <subject>
 
 Closes #999"
-# open PR → review → merge → release patch
-./scripts/bin/release patch
 ```
+
+Merging it updates the open release PR to a patch bump; **cut it** by merging the
+release PR. Don't run a parallel release flow for the same version.
 
 ## Yanking a Bad Release
 

--- a/.github/skills/change-workflow/SKILL.md
+++ b/.github/skills/change-workflow/SKILL.md
@@ -112,9 +112,17 @@ changelog.
 
 ### 7. Merge
 
-**Squash-merge** into `main`. Delete the branch. Releases are cut separately
-from an up-to-date `main` — see [`commit-publish.prompt.md`](../../prompts/commit-publish.prompt.md);
-do **not** run a release from a feature branch.
+**Squash-merge** into `main`; the branch auto-deletes. Low-risk PRs may carry the
+`auto-merge` label to land on green. PRs touching **protected paths** (anything in
+`.github/CODEOWNERS`: `version.rb`, gemspec, `Gemfile*`, `package*.json`,
+`CHANGELOG.md`, release config, `.github/workflows/`, `_plugins/`, `scripts/bin`)
+require **@bamr87 code-owner review** — agents cannot self-merge these.
+
+**You never bump the version or cut a release from a feature branch.** Every merge
+to `main` feeds release-please's open `chore(main): release X.Y.Z` PR (the
+version accumulator). A release is cut by **merging that release PR** when its set
+is coherent — see [`version-control.instructions.md`](../../instructions/version-control.instructions.md)
+(Branching — Hardened Trunk) and [`commit-publish.prompt.md`](../../prompts/commit-publish.prompt.md).
 
 ## Splitting a messy working tree
 

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -24,7 +24,7 @@ This directory contains the CI/CD workflows for the zer0-mistakes Jekyll theme.
 
 ### 1. `ci.yml` - Continuous Integration Pipeline
 
-**Triggers:** Push to `main`/`develop`, Pull Requests, Manual dispatch
+**Triggers:** Push to `main`, Pull Requests, Manual dispatch
 
 The CI pipeline validates code quality, runs tests, builds the gem, and performs Docker integration testing. Uses `dorny/paths-filter` to detect changed files and skip heavy jobs on docs-only changes.
 
@@ -121,7 +121,7 @@ Unified release workflow that publishes to RubyGems and creates GitHub releases.
 
 ### 4. `test-latest.yml` - Latest Dependency Canary
 
-**Triggers:** Push/PR to `main`/`develop`, Daily schedule, Manual dispatch
+**Triggers:** Push/PR to `main`, Daily schedule, Manual dispatch
 
 Builds with the latest resolved dependencies (no pins), runs a Docker-based validation + test suite, and publishes an immutable Docker tag on success.
 

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -41,16 +41,21 @@ jobs:
         run: |
           changed=$(gh api "repos/$GITHUB_REPOSITORY/pulls/$PR/files" --jq '.[].filename')
           echo "Changed files:"; echo "$changed"
-          # Files that must never auto-merge, even if mislabelled.
+          # Files that must never auto-merge, even if mislabelled. The primary
+          # gate is CODEOWNERS + "Require Code Owner review" on main; this is a
+          # belt-and-suspenders denylist so a self-labelling agent can't slip a
+          # release/dependency-manifest change through the auto-merge fast path.
           if echo "$changed" | grep -E -q \
-            '(^lib/jekyll-theme-zer0/version\.rb$|\.gemspec$|^Gemfile$|^Gemfile\.lock$|^package\.json$)'; then
+            '(^lib/jekyll-theme-zer0/version\.rb$|\.gemspec$|^Gemfile$|^Gemfile\.lock$|^package\.json$|^package-lock\.json$)'; then
             echo "::error::PR labelled auto-merge but touches version/release/dependency files — removing label."
             gh pr edit "$PR" --remove-label auto-merge
             exit 1
           fi
 
-      - name: Enable native auto-merge (squash)
+      - name: Enable native auto-merge
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR: ${{ github.event.pull_request.number }}
-        run: gh pr merge "$PR" --auto --squash
+        # No --squash: let the repo's merge-method setting (squash-only) decide,
+        # so this stays correct if a merge queue is later enabled.
+        run: gh pr merge "$PR" --auto

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,9 +9,9 @@ concurrency:
 
 on:
   push:
-    branches: [ main, develop ]
+    branches: [ main ]
   pull_request:
-    branches: [ main, develop ]
+    branches: [ main ]
   workflow_dispatch:
     inputs:
       test_scope:

--- a/.github/workflows/convert-notebooks.yml
+++ b/.github/workflows/convert-notebooks.yml
@@ -11,13 +11,13 @@ concurrency:
 # when .ipynb files are added or modified in the pages/_notebooks directory
 on:
   push:
-    branches: [ main, develop ]
+    branches: [ main ]
     paths:
       - 'pages/_notebooks/**.ipynb'
       - 'scripts/convert-notebooks.sh'
       - '.github/workflows/convert-notebooks.yml'
   pull_request:
-    branches: [ main, develop ]
+    branches: [ main ]
     paths:
       - 'pages/_notebooks/**.ipynb'
       - 'scripts/convert-notebooks.sh'

--- a/.github/workflows/lint-workflows.yml
+++ b/.github/workflows/lint-workflows.yml
@@ -46,3 +46,30 @@ jobs:
           # bad workflow expressions, and deprecated/too-old action runners.
           "${RUNNER_TEMP}/actionlint" -color \
             -ignore 'SC2086' -ignore 'SC2129' -ignore 'SC2035'
+
+      - name: Guard — "Quality Control" must always run
+        run: |
+          # Quality Control is the SINGLE required status check on `main` and holds
+          # the version.rb<->Gemfile.lock consistency guard. It must run even when
+          # fast-checks is skipped (docs-only PRs) — a required-but-skipped check
+          # would deadlock the repo's highest-volume PR type. This pins that
+          # invariant so a future edit can't silently re-introduce the deadlock.
+          # See .github/instructions/version-control.instructions.md (Release model).
+          python3 - <<'PY'
+          import sys, yaml
+          job = (yaml.safe_load(open('.github/workflows/ci.yml')) or {}) \
+                  .get('jobs', {}).get('quality-checks', {})
+          cond = str(job.get('if', ''))
+          problems = []
+          if not cond:
+              problems.append("quality-checks job or its `if:` is missing")
+          if 'always()' not in cond:
+              problems.append("`if:` must contain always() so it runs when fast-checks is skipped")
+          if 'fast-checks' in cond:
+              problems.append("`if:` must NOT gate on fast-checks result")
+          if problems:
+              print("::error file=.github/workflows/ci.yml::Quality Control always-runs "
+                    "invariant broken: " + "; ".join(problems))
+              sys.exit(1)
+          print("OK — Quality Control always-runs invariant holds:", cond)
+          PY

--- a/.github/workflows/milestone-assign.yml
+++ b/.github/workflows/milestone-assign.yml
@@ -1,0 +1,43 @@
+name: Assign merged PRs to milestone
+
+# Keeps the "what's accumulating toward the next version" Milestone honest under
+# bot PR volume. When a PR merges to main and EXACTLY ONE open milestone exists,
+# assign the PR to it (unless it already has one). No-op when zero or many open
+# milestones exist — it never guesses. Optional convenience: the open
+# release-please PR remains the source of truth for the pending version; the
+# milestone is the human-readable intent overlay.
+#
+# Safe pattern (mirrors auto-merge.yml): pull_request_target with NO checkout of
+# untrusted PR head — it only calls the REST API with the repo token.
+
+permissions:
+  issues: write
+  pull-requests: write
+
+on:
+  pull_request_target:
+    types: [closed]
+
+concurrency:
+  group: milestone-assign-${{ github.event.pull_request.number }}
+  cancel-in-progress: false
+
+jobs:
+  assign:
+    if: >-
+      github.event.pull_request.merged == true &&
+      github.event.pull_request.milestone == null
+    runs-on: ubuntu-latest
+    steps:
+      - name: Assign to the sole open milestone (if exactly one)
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR: ${{ github.event.pull_request.number }}
+        run: |
+          mapfile -t titles < <(gh api "repos/$GITHUB_REPOSITORY/milestones?state=open" --jq '.[].title')
+          if [[ ${#titles[@]} -eq 1 ]]; then
+            echo "Assigning PR #$PR to milestone '${titles[0]}'"
+            gh pr edit "$PR" --milestone "${titles[0]}"
+          else
+            echo "Found ${#titles[@]} open milestone(s) — need exactly 1; skipping."
+          fi

--- a/.github/workflows/test-latest.yml
+++ b/.github/workflows/test-latest.yml
@@ -26,7 +26,7 @@ concurrency:
 
 on:
   push:
-    branches: [main, develop]
+    branches: [main]
     paths:
       - '_layouts/**'
       - '_includes/**'
@@ -44,7 +44,7 @@ on:
       - 'docker-compose*.yml'
       - 'Dockerfile'
   pull_request:
-    branches: [main, develop]
+    branches: [main]
     paths:
       - '_layouts/**'
       - '_includes/**'


### PR DESCRIPTION
Implements the agreed branching/release model from the strategy brainstorm: **a single trunk where release-please's open release PR is the version accumulator** — no `develop`/`next`/`release` branches. Decisions locked in: GitHub App token, require only `Quality Control`, gating via code-owner review, continuous site deploy.

## Changes

| File | Change |
|---|---|
| `.github/CODEOWNERS` *(new)* | Gate the release/versioning/CI/`_plugins`/`scripts/bin` surface on @bamr87 review. **No catch-all `*`** — so low-risk content PRs (`pages/**`, `_sass/**`, …) still hit the `auto-merge` fast path. |
| `ci.yml`, `convert-notebooks.yml`, `test-latest.yml`, `workflows/README.md` | Drop the dead `develop` branch wiring (it never existed as a branch). |
| `auto-merge.yml` | Add `package-lock.json` to the never-auto-merge denylist; drop `--squash` so the repo's squash-only setting (or a future merge queue) decides the method. |
| `lint-workflows.yml` | Pin the **"Quality Control always runs"** invariant — a guard so a future edit can't make the single required check skip on docs PRs and deadlock merges. |
| `milestone-assign.yml` *(new)* | Assign merged PRs to the sole open milestone (no-op unless exactly one is open) to keep the "what's in 1.21" view honest under bot volume. Safe `pull_request_target`, no checkout of untrusted code. |
| `version-control.instructions.md`, `change-workflow/SKILL.md` | Document the model (Branching — Hardened Trunk; release PR = accumulator; `Release-As:`; `prerelease/2.0` only for a real major; protected paths need code-owner review) and de-stale the old `scripts/bin/release`-only release section. |

## Not in this PR (require your GitHub action)

- **A fine-grained PAT** as `RELEASE_PLEASE_TOKEN` (Contents + Pull requests: write). The reusable workflow already reads it — merged in [bamr87/.github#1](https://github.com/bamr87/.github/pull/1). (GitHub App token is also supported but unused.)
- **Branch protection** on `main` (require `Quality Control` + code-owner review) — must be enabled **last**, after the App is live and a release PR is shown to trigger CI, or release PRs become unmergeable.

See the handoff comment for the exact steps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
