### PR TITLE
feat(scripts): issue adoption in sync-backlog (Phase 1)

### DIFF
--- a/_data/backlog.yml
+++ b/_data/backlog.yml
@@ -44,8 +44,15 @@
 #     summary:    1–2 lines of context
 #     acceptance: List of checkable done-criteria the implement routine verifies
 #     links:      { issue: <#|null>, pr: <#|null>, roadmap: "<version>|null" }
+#                 When `issue:` points at an EXISTING issue, sync ADOPTS it (adds
+#                 a managed block, preserves the author's text, no duplicate)
+#                 instead of creating a new one. At most one task per issue.
 #     created:    YYYY-MM-DD
 #     updated:    YYYY-MM-DD
+#     route:      (optional) executor-lane hint for /issue-implement; resolved via
+#                 _data/routing.yml (defaults to the lane for `area`).
+#     depends_on: (optional) [T-NNN, …] tasks that must land first; consumed by the
+#                 /issue-plan committee for ordering. Advisory.
 #
 # `risk: low` + area in {docs, deps, lint} makes a task auto-merge eligible once
 # CI is green (see `.github/prompts/backlog-implement.prompt.md`). Everything

--- a/scripts/sync-backlog.rb
+++ b/scripts/sync-backlog.rb
@@ -89,6 +89,7 @@ def validate(data)
   return ['Missing or empty `tasks:` list.'] unless tasks.is_a?(Array) && !tasks.empty?
 
   seen_ids = {}
+  seen_links = {}
   tasks.each_with_index do |task, i|
     where = "tasks[#{i}]"
     unless task.is_a?(Hash)
@@ -114,6 +115,30 @@ def validate(data)
     unless task['acceptance'].is_a?(Array) && !task['acceptance'].empty?
       errors << "#{where}: `acceptance` must be a non-empty list."
     end
+
+    # Adoption guard: an existing GitHub issue may be claimed by at most one task,
+    # so two tasks can never fight over (or duplicate) the same issue.
+    lnk = task.dig('links', 'issue')
+    if lnk
+      unless lnk.is_a?(Integer) || lnk.to_s =~ /\A\d+\z/
+        errors << "#{where}: `links.issue` must be an issue number (got #{lnk.inspect})."
+      end
+      key = lnk.to_s
+      if seen_links[key]
+        errors << "#{where}: `links.issue` ##{key} already claimed by #{seen_links[key]}."
+      else
+        seen_links[key] = (id || where)
+      end
+    end
+    # Optional routing/dependency metadata (consumed by /issue-implement + /issue-plan).
+    if task.key?('route') && !task['route'].is_a?(String)
+      errors << "#{where}: `route` must be a string."
+    end
+    if task.key?('depends_on') &&
+       !(task['depends_on'].is_a?(Array) &&
+         task['depends_on'].all? { |d| d.is_a?(String) && d =~ /\AT-\d{3,}\z/ })
+      errors << "#{where}: `depends_on` must be a list of T-NNN ids."
+    end
   end
   errors
 end
@@ -131,6 +156,52 @@ end
 
 def marker(id)
   "<!-- backlog-id: #{id} -->"
+end
+
+# Delimiters around the sync-owned section of an ADOPTED human issue. Text ABOVE
+# the start delimiter (the author's original report) is never touched; only this
+# block is upserted on each sync, so adoption is non-destructive.
+MANAGED_START = '<!-- backlog-managed:start -->'
+MANAGED_END   = '<!-- backlog-managed:end -->'
+
+def render_managed_block(task)
+  accept = (task['acceptance'] || []).map { |a| "- [ ] #{a}" }.join("\n")
+  roadmap = task.dig('links', 'roadmap')
+  meta_row = [
+    "**Priority:** #{task['priority']}",
+    "**Area:** #{task['area']}",
+    "**Risk:** #{task['risk']}",
+    "**Effort:** #{task['effort']}",
+    "**Source:** #{task['source']}"
+  ].join(' · ')
+
+  <<~BLOCK.strip
+    #{MANAGED_START}
+    #{marker(task['id'])}
+    > Tracked from [`_data/backlog.yml`](../blob/main/_data/backlog.yml) by `scripts/sync-backlog.rb`.
+    > The report above is the author's; this block is auto-managed — edit the backlog, not here.
+
+    #{meta_row}#{roadmap ? " · **Roadmap:** v#{roadmap}" : ''}
+
+    ## Acceptance criteria
+
+    #{accept}
+
+    Picked up by the IMPLEMENT routine; see [`docs/systems/continuous-evolution.md`](../blob/main/docs/systems/continuous-evolution.md).
+    #{MANAGED_END}
+  BLOCK
+end
+
+# Upsert the managed block into a (human-authored) issue body, preserving the
+# author's text. Idempotent: replaces an existing block, else appends one.
+def upsert_managed_block(body, task)
+  body  = body.to_s
+  block = render_managed_block(task)
+  if body.include?(MANAGED_START) && body.include?(MANAGED_END)
+    body.sub(/#{Regexp.escape(MANAGED_START)}.*#{Regexp.escape(MANAGED_END)}/m, block)
+  else
+    "#{body.rstrip}\n\n#{block}\n"
+  end
 end
 
 def render_body(task)
@@ -202,26 +273,52 @@ def ensure_labels(gh)
   VALID_RISK.each { |r| gh.write(['label', 'create', "risk:#{r}", '--color', RISK_COLOR, '--force']) }
 end
 
-# Map of backlog id -> existing issue {number, state, labels} via the body marker.
-def existing_issues(gh)
+# Returns [index, link_state]:
+#   index      — backlog id -> {number,state,labels,body,marker_id} for every
+#                marker-bearing agent-ready issue (the already-managed ones).
+#   link_state — issue number -> same record, for each issue referenced by a task
+#                `links.issue`. A human issue may carry neither the agent-ready
+#                label nor a marker yet, so it is fetched by number for adoption +
+#                provenance checks (is it already claimed by a foreign marker?).
+def existing_issues(gh, link_numbers = [])
+  index = {}
+  link_state = {}
+  to_rec = lambda do |issue|
+    body = issue['body'].to_s
+    rec = {
+      'number'    => issue['number'],
+      'state'     => issue['state'].to_s.downcase,
+      'labels'    => (issue['labels'] || []).map { |l| l['name'] },
+      'body'      => body,
+      'marker_id' => body[/<!-- backlog-id: (T-\d+) -->/, 1]
+    }
+    index[rec['marker_id']] = rec if rec['marker_id']
+    rec
+  end
+
   raw = gh.read(
     ['issue', 'list', '--label', 'agent-ready', '--state', 'all', '--limit', '500',
      '--json', 'number,body,state,labels'],
     default: '[]'
   )
-  index = {}
-  JSON.parse(raw).each do |issue|
-    next unless issue['body'] =~ /<!-- backlog-id: (T-\d+) -->/
-
-    index[Regexp.last_match(1)] = {
-      'number' => issue['number'],
-      'state'  => issue['state'].to_s.downcase,
-      'labels' => (issue['labels'] || []).map { |l| l['name'] }
-    }
+  begin
+    JSON.parse(raw).each { |issue| to_rec.call(issue) }
+  rescue JSON::ParserError
+    # leave index empty; adoption/create still work off link_state
   end
-  index
-rescue JSON::ParserError
-  {}
+
+  link_numbers.compact.map(&:to_i).uniq.each do |n|
+    raw1 = gh.read(['issue', 'view', n.to_s, '--json', 'number,body,state,labels'], default: '')
+    next if raw1.strip.empty?
+
+    begin
+      link_state[n] = to_rec.call(JSON.parse(raw1))
+    rescue JSON::ParserError
+      next
+    end
+  end
+
+  [index, link_state]
 end
 
 # ---------------------------------------------------------------------------
@@ -241,29 +338,55 @@ end
 
 def sync(data, gh)
   ensure_labels(gh)
-  index = existing_issues(gh)
-  created = updated = closed = 0
+  tasks = data['tasks'] || []
+  link_numbers = tasks.map { |t| t.dig('links', 'issue') }.compact
+  index, link_state = existing_issues(gh, link_numbers)
+  created = adopted = updated = closed = 0
 
-  (data['tasks'] || []).each do |task|
-    id    = task['id']
-    title = task['title']
-    body  = render_body(task)
+  tasks.each do |task|
+    id        = task['id']
+    title     = task['title']
     want_open = OPEN_STATUSES.include?(task['status'])
-    issue = index[id]
+    lnk       = task.dig('links', 'issue')
+    issue     = index[id] # already marker-tracked?
+
+    # Adoption: task points at an existing issue not yet marker-tracked. Adopt it
+    # (inject the managed block) instead of creating a duplicate — unless the
+    # issue already carries a DIFFERENT marker (foreign provenance → refuse).
+    if issue.nil? && lnk
+      ls = link_state[lnk.to_i]
+      if ls.nil?
+        warn "task #{id}: links.issue ##{lnk} not found — creating a new issue instead."
+      elsif ls['marker_id'] && ls['marker_id'] != id
+        warn "task #{id}: refusing to adopt ##{lnk} — already marked #{ls['marker_id']} (foreign). Skipping."
+        next
+      else
+        issue = ls.merge('adopt' => true)
+      end
+    end
 
     if issue.nil?
       next unless want_open # never create an issue for an already-done task
 
-      args = ['issue', 'create', '--title', title, '--body', body]
+      args = ['issue', 'create', '--title', title, '--body', render_body(task)]
       managed_labels(task).each { |l| args.push('--label', l) }
       created += 1 if gh.write(args)
       next
     end
 
     number = issue['number'].to_s
-    gh.write(['issue', 'edit', number, '--title', title, '--body', body] +
-             label_args(managed_labels(task), issue['labels']))
-    updated += 1
+    if lnk
+      # Human-authored (adopted) issue: NEVER overwrite its title/body — only
+      # upsert the managed block (preserving the author's report) + labels.
+      gh.write(['issue', 'edit', number, '--body', upsert_managed_block(issue['body'], task)] +
+               label_args(managed_labels(task), issue['labels']))
+      issue['adopt'] ? (adopted += 1) : (updated += 1)
+    else
+      # Bot-created issue: fully sync-owned title + body.
+      gh.write(['issue', 'edit', number, '--title', title, '--body', render_body(task)] +
+               label_args(managed_labels(task), issue['labels']))
+      updated += 1
+    end
 
     if want_open && issue['state'] != 'open'
       gh.write(['issue', 'reopen', number])
@@ -273,7 +396,7 @@ def sync(data, gh)
     end
   end
 
-  puts "Backlog sync complete: #{created} created, #{updated} updated, #{closed} closed."
+  puts "Backlog sync complete: #{created} created, #{adopted} adopted, #{updated} updated, #{closed} closed."
   0
 end
 


### PR DESCRIPTION
**Phase 1 of the autonomous issue pipeline — the hard prerequisite.** Nothing that folds GitHub issues into the backlog may ship before this.

## Why
The pipeline keeps `_data/backlog.yml` as the single source of truth and *mirrors* tasks to issues. Human-filed issues get folded in as `source: issue` tasks carrying `links.issue: <#>`. But today `links.issue` is **dead code** and `existing_issues()` indexes only `agent-ready` issues — so a naive fold would **manufacture a duplicate** of every human issue.

## What
- **Adoption**: a task with `links.issue:<#>` adopts the existing issue instead of creating one. Adoption is **non-destructive** — it upserts a delimited `backlog-managed` block (marker + priority/area/risk + acceptance) into the author's body and **never overwrites their title or text**. The issue index is broadened to fetch linked issues by number; a **provenance guard** refuses to adopt an issue already carrying a *foreign* marker.
- **`--check` guards**: two tasks can't claim one `links.issue`; optional `route` (string) and `depends_on` (`[T-NNN]`) are type-checked.
- **Schema docs**: `backlog.yml` header documents adoption + the new fields.

## Verification (all green)
- `--check` on the real backlog — no regression (25 tasks valid).
- Unit tests — dup-links / route / depends_on rejection; upsert preserves the author's text, injects the marker, and is idempotent (exactly one block).
- Real-`gh` `--dry-run` against human issue **#204** → `gh issue edit 204` (adopt, author body preserved), **no `issue create`** (no duplicate).

Next: Phase 2 adds the issue-intake phase to `/repo-audit` (which emits these `links.issue` tasks).

🤖 Generated with [Claude Code](https://claude.com/claude-code)