### PR TITLE
docs(automation): wire the autonomous issue pipeline + schedules (Phase 5)

### DIFF
--- a/.github/instructions/README.md
+++ b/.github/instructions/README.md
@@ -29,14 +29,19 @@ This directory contains file-specific instructions for GitHub Copilot to provide
 │   ├── commit-publish.prompt.md      # Full release pipeline
 │   ├── frontmatter-maintainer.prompt.md  # Front matter audit / fix
 │   ├── content-review.prompt.md      # Content SEO/consistency/polish review
-│   ├── repo-audit.prompt.md          # Review repo → file backlog tasks
+│   ├── repo-audit.prompt.md          # Review repo + triage open issues → backlog
 │   ├── backlog-implement.prompt.md   # Implement next backlog task → PR
+│   ├── issue-implement.prompt.md     # Route one issue → loop-to-green → PR (human-dispatched)
+│   ├── issue-plan.prompt.md          # Planning committee → order-only roadmap_plan.yml
 │   └── seed.prompt.md                # Theme rebuild blueprint
 ├── skills/                          # Operational workflow checklists (SKILL.md)
 │   ├── change-workflow/SKILL.md      # Branch → commit → PR for any change
 │   ├── validate-build/SKILL.md       # Pre-commit / pre-PR validation pipeline
 │   ├── content-review/SKILL.md       # Content SEO/consistency/polish review
-│   └── visual-evidence/SKILL.md      # Regression test + before/after evidence for UI changes
+│   ├── visual-evidence/SKILL.md      # Regression test + before/after evidence for UI changes
+│   └── committee-plan/SKILL.md       # /issue-plan fan-out + order-only synthesis
+├── ../../_data/routing.yml          # area:* → executor lane (issue-implement routing)
+├── ../../.claude/agents/            # Specialized executor + plan-lens agents
 └── seed/                            # Deep architectural blueprint docs
 
 .cursor/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,8 +74,10 @@ should load them manually):
 | Front matter audit / fix across content | `.github/prompts/frontmatter-maintainer.prompt.md` |
 | Review content for SEO / consistency / polish (per-collection) | `.github/prompts/content-review.prompt.md` |
 | Rebuild the theme from scratch (deep blueprint) | `.github/prompts/seed.prompt.md` |
-| Review the repo and file tactical tasks into the backlog | `.github/prompts/repo-audit.prompt.md` |
+| Review the repo **and triage all open issues** into the backlog | `.github/prompts/repo-audit.prompt.md` |
 | Implement the next open backlog task and open a PR | `.github/prompts/backlog-implement.prompt.md` |
+| Implement ONE issue/task — route → loop-until-green → PR (human-dispatched) | `.github/prompts/issue-implement.prompt.md` |
+| Plan/sequence the open backlog (the planning committee) | `.github/prompts/issue-plan.prompt.md` |
 
 ### Workflow skills
 
@@ -88,6 +90,7 @@ skill before the action it covers.
 | Validating a change before commit/PR (Jekyll build, doctor, tests) | `.github/skills/validate-build/SKILL.md` |
 | **Any UI/behavioural change** — regression test + before/after evidence (required for fixes to auto-merge) | `.github/skills/visual-evidence/SKILL.md` |
 | Reviewing content PRs for SEO/consistency/polish | `.github/skills/content-review/SKILL.md` |
+| Planning/sequencing the backlog (the `/issue-plan` committee fan-out) | `.github/skills/committee-plan/SKILL.md` |
 
 ---
 
@@ -96,8 +99,12 @@ skill before the action it covers.
 This repo runs a self-sustaining backlog loop so AI agents can keep improving it
 between human sessions:
 
-1. **Audit** (`/repo-audit`, scheduled weekly) reviews tests, docs, and roadmap
-   delivery and files tasks into [`_data/backlog.yml`](./_data/backlog.yml).
+1. **Audit + issue intake** (`/repo-audit`, scheduled weekly) reviews tests, docs,
+   and roadmap delivery **and triages all open GitHub issues** into
+   [`_data/backlog.yml`](./_data/backlog.yml) (`source: issue`, adopted via
+   `links.issue` — no duplicates). The committee `/issue-plan` then sequences them
+   and `/issue-implement` (human-dispatched) routes each to a specialized agent.
+   See [`docs/systems/continuous-evolution.md`](./docs/systems/continuous-evolution.md).
 2. **Sync** (`.github/workflows/sync.yml`) mirrors open tasks to GitHub
    Issues (`agent-ready` label) and closes issues for tasks marked `done`.
 3. **Implement** (`/backlog-implement`, scheduled) picks the top open task, builds

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,15 +31,26 @@ files you touch:
   obsidian, sass, testing, documentation, version-control, backlog,
   content-review, ai-chat). Read the matching file before editing those paths.
 - `.github/prompts/*.prompt.md` — reusable multi-step workflows
-  (`commit-publish`, `repo-audit`, `backlog-implement`, `obsidian-add-syntax`,
-  `frontmatter-maintainer`, `content-review`, `seed`). Mirrored as Cursor
-  commands in `.cursor/commands/`.
+  (`commit-publish`, `repo-audit` (repo audit **+ issue intake**),
+  `backlog-implement`, `issue-implement` (route one issue → loop-until-green →
+  PR; human-dispatched), `issue-plan` (the planning **committee**),
+  `obsidian-add-syntax`, `frontmatter-maintainer`, `content-review`, `seed`).
+  Mirrored as Cursor commands in `.cursor/commands/`.
 - `.github/skills/*/SKILL.md` — operational checklists: `change-workflow`
   (branch → commit → PR for **any** change; read it before starting one),
   `validate-build` (pre-commit/PR validation), `content-review`,
   `visual-evidence` (regression test + before/after evidence for **any
   UI/behavioural change**; required for fixes to auto-merge — enforced by the
-  `evidence-gate` check and `visual-evidence.instructions.md`).
+  `evidence-gate` check and `visual-evidence.instructions.md`),
+  `committee-plan` (the `/issue-plan` fan-out + order-only synthesis).
+- **Autonomous issue pipeline** — extends the continuous-evolution loop to ingest
+  GitHub issues. `/repo-audit` triages all open issues into `_data/backlog.yml`
+  (`source: issue`, adopted via `links.issue` by `scripts/sync-backlog.rb`, no
+  duplicates); `/issue-plan` plans them (order-only `_data/roadmap_plan.yml` +
+  `scripts/sync-plan.rb`); `/issue-implement` routes via `_data/routing.yml` to a
+  specialized `.claude/agents/*` lane. Issue text is **untrusted** (injection
+  fence); agents never touch CODEOWNERS paths. See
+  [`docs/systems/continuous-evolution.md`](./docs/systems/continuous-evolution.md).
 - **AI content reviewer** — reviews content PRs (Markdown under `pages/**`) for
   SEO, consistency, polish, accessibility, and accuracy. Two tiers:
   `scripts/content-review.rb` (deterministic, per-collection thresholds from

--- a/docs/systems/continuous-evolution.md
+++ b/docs/systems/continuous-evolution.md
@@ -60,10 +60,58 @@ not the issues.
 | Visual-evidence skill | `.github/skills/visual-evidence/SKILL.md` | Standard: regression test + before/after evidence for UI/behavioural changes |
 | Evidence kit | `test/visual/evidence-kit.mjs` | Reusable generator for the before/after montages + metrics |
 | Evidence gate | `.github/workflows/evidence-gate.yml` | Required check: fails a UI PR lacking test+evidence (opt-out `skip-evidence`) |
+| Secret scan | `.github/workflows/secret-scan.yml` | Required gate: fails a PR whose diff/body leaks a credential shape |
+| Forbidden-path guards | `.github/CODEOWNERS` + the `auto-merge.yml` denylist | Block release/CI/plugin/script/version PRs from the auto-merge fast path |
+| Issue intake | `/repo-audit` Phase 1.D | Triages all open issues → `source: issue` tasks (adopted via `links.issue`, no duplicates) |
+| Routing table | `_data/routing.yml` | `area:*` (+ path globs) → executor lane (agent + instructions + skills) |
+| Issue-implement prompt | `.github/prompts/issue-implement.prompt.md` | `/issue-implement <#>` — routed, loop-until-green, one PR (human-dispatched) |
+| Executor agents | `.claude/agents/{code-fixer,theme-ui,infra-scripts,test-author,a11y-fixer,deps-bumper}.md` | The routed lanes (docs reuse `content-reviewer`) |
+| Committee prompt | `.github/prompts/issue-plan.prompt.md` + `committee-plan` skill | `/issue-plan` — 4 read-only lenses → order-only plan |
+| Plan lenses | `.claude/agents/plan-lens-{priority,dependency,risk,test}.md` | Read-only committee perspectives |
+| Plan artifact + sync | `_data/roadmap_plan.yml` · `scripts/sync-plan.rb` (+ `.sh`) | Order-only sequencing + validator + pinned tracking issue |
 
 It deliberately reuses the existing **roadmap-sync** pattern
 (`scripts/generate-roadmap.rb` + `.github/workflows/sync.yml`): a Ruby
 generator/validator with `--check`, driven by a path-filtered workflow.
+
+## Issue-first pipeline (the extension)
+
+The loop also ingests **GitHub issues** (human-filed and bot), keeping
+`_data/backlog.yml` the single source of truth — issues are a *mirror*.
+
+1. **Intake (auto).** `/repo-audit` Phase 1.D triages every open issue into a
+   `source: issue` backlog task carrying `links.issue:<#>`, with enriched
+   `area`/`risk`/`priority`/`route`. `sync-backlog.rb` then **adopts** that issue
+   (appends a managed block, preserving the author's text — no duplicate). Issue
+   text is treated as **untrusted data**; external-author issues land `agent-hold`.
+2. **Committee (auto).** `/issue-plan` fans out four read-only lenses (priority,
+   dependency, risk, test-framework) and writes an **order-only** plan to
+   `_data/roadmap_plan.yml` + one pinned tracking issue. It never re-encodes the
+   autonomy policy (below) — eligibility is derived from each task.
+3. **Implement (human-dispatched).** `/issue-implement <#|T-id>` routes the task
+   via `_data/routing.yml` to a specialized executor, **loops build+test+evidence
+   until green and compatible**, documents fully, and opens ONE PR — applying the
+   autonomy label by the same policy. It **STOPs** on any CODEOWNERS path.
+
+The **autonomy policy** below is the single canonical statement; the prompts and
+`plan-lens-risk` point at it rather than restating it.
+
+### Model tiers (per phase)
+
+| Phase | Model | Why |
+|---|---|---|
+| Intake / triage (`/repo-audit` 1.D) | haiku | classification + structured writes |
+| Committee (`/issue-plan` + 4 lenses) | sonnet | DAG / risk / merge reasoning |
+| Implement (`/issue-implement` executors) | opus | real code where quality matters |
+
+Set each via the `/schedule` routine's `--model` and the prompt front matter; no
+phase silently inherits a heavier default.
+
+### Substrate note
+
+The committee prefers Task-subagent fan-out but falls back to **inline sequential
+lenses**, and routing loads lane instructions **inline**, so the pipeline works
+whether or not the cloud-routine runtime can delegate to named subagents.
 
 ## Task lifecycle
 
@@ -149,13 +197,22 @@ click merge.
 The loop is driven by two scheduled Claude Code routines. Create them with the
 `/schedule` skill (they invoke the committed prompts, so the logic stays in-repo):
 
-- **Routine A — Weekly audit** (e.g. Mondays):
-  *"In the zer0-mistakes repo, run `/repo-audit` and open the backlog PR."*
-- **Routine B — Implementation cadence** (e.g. 2–3×/week):
+- **Routine A — Weekly audit + issue intake** (e.g. Mondays):
+  *"In the zer0-mistakes repo, run `/repo-audit` (includes issue intake) and open
+  the backlog PR."* — model `haiku`; token scope `issues:write` + PR-create.
+- **Routine B — Implementation cadence** (e.g. 2–3×/week, unchanged):
   *"In the zer0-mistakes repo, run `/backlog-implement` for the next open task."*
+- **Routine C — Committee planning** (e.g. Tuesdays, a day behind A):
+  *"In the zer0-mistakes repo, run `/issue-plan` and refresh the plan + pinned
+  issue."* — model `sonnet`.
 
-Both can also be run on demand from an interactive session, and the workflows can
-be triggered manually via `workflow_dispatch`.
+**`/issue-implement` is deliberately NOT scheduled** — per-issue implementation is
+**human-dispatched** (a person runs `/issue-implement <#>`), so nothing
+auto-dispatches code changes. Auto-merge stays a no-op until branch protection is
+enabled.
+
+All routines can also be run on demand from an interactive session, and the
+workflows can be triggered manually via `workflow_dispatch`.
 
 > **Portability:** because all logic lives in the prompt + script files, the same
 > loop can later be driven by a GitHub Actions cron + the Claude Code GitHub


### PR DESCRIPTION
**Phase 5 (final) of the autonomous issue pipeline.** Documents the new flow and registers the prompts/agents/routing across the guidance layers. Docs only.

- **`docs/systems/continuous-evolution.md`**: a new **"Issue-first pipeline"** section (intake + adoption → committee → human-dispatched implement), a **per-phase model-tier table** (haiku triage / sonnet committee / opus implement), the substrate-fallback note (inline lenses if the runtime can't delegate), an expanded Components table, and the **`/schedule` routines**: Routine A → `audit+intake`, new Routine C → `/issue-plan` committee; **`/issue-implement` stays human-dispatched (not scheduled)**. The existing **Autonomy policy** section is the single canonical statement the prompts + `plan-lens-risk` point at.
- **`AGENTS.md`, `CLAUDE.md`, `.github/instructions/README.md`**: register `/issue-implement`, `/issue-plan`, the `committee-plan` skill, `_data/routing.yml`, and the `.claude/agents` roster.

## Going live (after the PRs merge)
The cloud `/schedule` routines are **documented but not created** — flipping on standing autonomous schedules is your go-live call, and it needs Phases 0-4 merged first. When ready: create Routine A (`/repo-audit`, weekly, haiku) and Routine C (`/issue-plan`, sonnet) via the `/schedule` skill. `/issue-implement` you run by hand per issue.

This completes the 6-phase build (PRs #223–#226 + this).

🤖 Generated with [Claude Code](https://claude.com/claude-code)