### PR TITLE
fix(navigation): existence-gate the section-sidebar /tags/ links

### DIFF
--- a/_includes/navigation/section-sidebar.html
+++ b/_includes/navigation/section-sidebar.html
@@ -64,9 +64,14 @@
           {% endfor %}
         </nav>
       </div>
-      {% if sub_categories.size > 15 %}
+      {% comment %} Existence-gate the tags index: a remote-theme consumer without
+         the (plugin-generated) /tags/ page must not get a 404 link. Mirrors the
+         footer Quick-Links guard and honours the documented site.tags_page. {% endcomment %}
+      {% assign _tags_url = site.tags_page | default: "/tags/" %}
+      {% assign _tags_page = site.html_pages | where: "url", _tags_url | first %}
+      {% if sub_categories.size > 15 and _tags_page %}
       <div class="card-footer bg-transparent">
-        <a href="{{ site.baseurl }}/tags/" class="btn btn-sm btn-outline-secondary w-100">
+        <a href="{{ _tags_url | relative_url }}" class="btn btn-sm btn-outline-secondary w-100">
           View All Tags <i class="bi bi-arrow-right ms-1"></i>
         </a>
       </div>
@@ -123,11 +128,13 @@
         {% endif %}
       {% endfor %}
     </nav>
+    {% if _tags_page %}
     <div class="p-3">
-      <a href="{{ site.baseurl }}/tags/" class="btn btn-outline-primary w-100">
+      <a href="{{ _tags_url | relative_url }}" class="btn btn-outline-primary w-100">
         <i class="bi bi-tags me-2"></i>Browse All Tags
       </a>
     </div>
+    {% endif %}
   </div>
 </div>
 


### PR DESCRIPTION
**`/issue-implement` end-to-end demo #2 — the theme-ui lane (human-review path).**

Implements **T-029** (issue #218): the section-sidebar's two tag buttons hardcoded `/tags/`, which 404s for remote-theme Pages consumers (the index is plugin-generated, skipped by Pages safe mode).

| Step | What |
|---|---|
| **Route** | area `feat` + `_includes/` path → **theme-ui lane** (`_data/routing.yml`) |
| **Implement** | existence-gate both buttons (lines 69 & 127) — mirror `core/footer.html`'s `site.html_pages | where: url` guard, honour the documented `site.tags_page`, use `relative_url` |
| **Loop-to-green** | Liquid balanced (if 4/4, for 2/2); the full Jekyll build runs in CI (the gate) |
| **Evidence** | **no visual change on a normal build** (the theme's own site has `/tags/`, so both links render identically) → `skip-evidence` justified |
| **Autonomy** | a `feat`/UI change with no test+evidence is **not** auto-merge-eligible → **left for human review** (no `auto-merge` label) |

Surgical: only `_includes/navigation/section-sidebar.html`; no CODEOWNERS path. Closes #218.