### PR TITLE
fix(ci): enable auto-merge via GraphQL (no checkout) + graceful no-op

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -67,7 +67,24 @@ jobs:
       - name: Enable native auto-merge
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NODE: ${{ github.event.pull_request.node_id }}
           PR: ${{ github.event.pull_request.number }}
-        # No --squash: let the repo's merge-method setting (squash-only) decide,
-        # so this stays correct if a merge queue is later enabled.
-        run: gh pr merge "$PR" --auto
+        # Enable via the GraphQL mutation, NOT `gh pr merge --auto`: this
+        # pull_request_target job intentionally does not check out the (untrusted)
+        # PR, and `gh pr merge` shells out to git, failing with "not a git
+        # repository". mergeMethod SQUASH matches the repo's squash-only setting.
+        run: |
+          if gh api graphql -f query='
+            mutation($id: ID!) {
+              enablePullRequestAutoMerge(input: { pullRequestId: $id, mergeMethod: SQUASH }) {
+                pullRequest { number }
+              }
+            }' -F id="$PR_NODE" 2>/tmp/am-err; then
+            echo "✓ native auto-merge enabled for #$PR — it will merge once required checks pass."
+          else
+            # Expected when branch protection / required checks aren't configured:
+            # there's nothing for auto-merge to gate on, so it can't be enabled.
+            # That's the safe no-op state — the PR simply waits for a human.
+            echo "::notice::Native auto-merge not enabled for #$PR (branch protection with required checks not configured). Leaving it for human review."
+            sed 's/^/  gh: /' /tmp/am-err || true
+          fi


### PR DESCRIPTION
## Problem
`auto-merge.yml`'s **Enable native auto-merge** step ran `gh pr merge "$PR" --auto`, which shells out to git and fails with `fatal: not a git repository` — this `pull_request_target` job **intentionally does not check out** the untrusted PR. Result: every `auto-merge`-labelled PR gets a spurious **red `enable-auto-merge` check** (surfaced by the pipeline demo PR #230).

## Fix
Enable auto-merge through the **`enablePullRequestAutoMerge` GraphQL mutation** (uses the PR's `node_id` — no git, no checkout; `mergeMethod: SQUASH` matches the repo's squash-only setting), and treat the *can't-enable* case (no branch protection / required checks) as a **logged no-op that exits 0**. So an `auto-merge`-labelled PR cleanly **waits for a human** instead of showing a failed check — the intended inert behaviour while branch protection is off.

Found via the autonomous-pipeline demo (#230). CODEOWNERS-gated (`.github/workflows/`) → your review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)