### PR TITLE
chore(config): preload Jekyll gems in devcontainer for fast Codespaces launch

### DIFF
--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -1,0 +1,62 @@
+# Dev Container
+
+One-click Jekyll dev environment for **GitHub Codespaces** and **VS Code Dev
+Containers**. The site builds and serves automatically — no local Ruby,
+Bundler, or Node required.
+
+## How it launches the site
+
+`devcontainer.json` builds from the repo's own multi-stage
+[`docker/Dockerfile`](../docker/Dockerfile), targeting the **`dev-test`** stage.
+That stage runs `bundle install` at **image-build time**, so every gem is
+**preloaded into the image** — there is no slow `bundle install` on first boot,
+and the bundled gems always match the checked-out branch's `Gemfile.lock`.
+
+On start, the container auto-serves at **port 4000** with live reload:
+
+```bash
+bundle exec jekyll serve --config '_config.yml,_config_dev.yml' \
+  --host 0.0.0.0 --port 4000 --livereload --force_polling
+```
+
+`nohup` keeps the server alive after the start hook returns, and
+`--force_polling` makes file watching reliable over the Codespaces bind mount
+(logs in `/tmp/jekyll-serve.log`). Port 4000 auto-forwards and opens a preview;
+`35729` (LiveReload) is forwarded silently.
+
+## Make Codespaces launch near-instant (prebuilds)
+
+Building the image the first time still costs a couple of minutes. **Prebuilds**
+do that work ahead of time so new Codespaces restore from a ready image in
+seconds:
+
+1. Repo **Settings → Codespaces → Set up prebuild**.
+2. Target branch `main`, region(s) as needed.
+3. Trigger: *On configuration change* (rebuilds when `.devcontainer/**`,
+   `docker/Dockerfile`, or `Gemfile.lock` change).
+
+After the first prebuild completes, **Code → Codespaces → Create codespace on
+main** launches with gems preloaded and Jekyll already serving.
+
+## Local use (VS Code + Docker Desktop)
+
+1. Install the **Dev Containers** extension.
+2. Open the repo → *Reopen in Container* (first build ~2–3 min; cached after).
+3. Visit <http://localhost:4000>.
+
+## Design notes
+
+| Choice | Why |
+|---|---|
+| Build from `docker/Dockerfile` `dev-test` | Gems preloaded at build time; stays in sync with `Gemfile.lock`. |
+| No `workspaceMount` override | Codespaces always mounts the repo at `/workspaces/<repo>`; gems live at the global `/usr/local/bundle`, so `bundle exec` works from the default folder. Maximizes Codespaces + local compatibility. |
+| Only the `github-cli` feature | Docker-in-Docker / Node aren't needed to render the site; dropping them keeps create + prebuild fast. |
+| `postCreateCommand` is `bundle check \|\| bundle install` | A fast no-op when gems are already baked in; self-heals only on lock drift. |
+| Runs as `root` | The `ruby:3.3-slim` base has no `vscode` user; matches `docker-compose`'s root container and avoids gem/bind-mount permission friction. |
+
+## Relationship to `docker-compose.yml`
+
+Both serve the same site from the same `dev-test` image. The devcontainer adds
+IDE integration (extensions, settings, port forwarding, auto-serve) for
+Codespaces/VS Code; `docker-compose up` is the terminal-driven equivalent for
+local/team use. See [`docker/README.md`](../docker/README.md).

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,23 +1,48 @@
+// zer0-mistakes — Jekyll theme dev container
+//
+// Builds from the repo's own multi-stage docker/Dockerfile (the `dev-test`
+// stage), which runs `bundle install` at BUILD time. Every gem is therefore
+// PRELOADED into the image — a Codespace launches ready to serve with no
+// `bundle install` on first boot. Enable Codespaces *prebuilds* (Settings →
+// Codespaces → Set up prebuild) to make creation near-instant. See README.md
+// in this folder.
 {
   "name": "zer0-mistakes Jekyll Theme",
-  "image": "mcr.microsoft.com/devcontainers/jekyll:2-bullseye",
-  
-  "features": {
-    "ghcr.io/devcontainers/features/docker-in-docker:2": {},
-    "ghcr.io/devcontainers/features/github-cli:1": {},
-    "ghcr.io/devcontainers/features/node:1": {
-      "version": "lts"
-    }
+
+  "build": {
+    "dockerfile": "../docker/Dockerfile",
+    "context": "..",
+    // `dev-test` already ran `bundle install` and bundles the full Jekyll
+    // toolchain. The leaner `base`/`production` stages can't serve the site.
+    "target": "dev-test"
   },
 
-  "postCreateCommand": "bundle install --jobs 4 --retry 3",
-  "postStartCommand": "bundle exec jekyll serve --config '_config.yml,_config_dev.yml' --host 0.0.0.0 --port 4000 --livereload &",
+  // No workspaceMount/workspaceFolder override: Codespaces always mounts the
+  // repo at /workspaces/<repo>, and the gems live at the global /usr/local/bundle
+  // (independent of cwd), so `bundle exec` works from the default folder. Keeping
+  // the default maximizes Codespaces + local VS Code compatibility.
+
+  // Lightweight extras only. Docker-in-Docker and a separate Node install are
+  // NOT needed to render the site (Playwright/Sass run on the host), so they're
+  // dropped to keep create/prebuild fast.
+  "features": {
+    "ghcr.io/devcontainers/features/github-cli:1": {}
+  },
+
+  // Gems are already in the image, so `bundle check` is a fast no-op that only
+  // falls back to install if the lockfile drifted from what was baked in.
+  "postCreateCommand": "git config --global --add safe.directory ${containerWorkspaceFolder} && (bundle check || bundle install --jobs 4 --retry 3)",
+
+  // Auto-serve with live reload on each container start. nohup keeps the server
+  // alive after the hook returns; --force_polling makes file watching reliable
+  // over the Codespaces bind mount. Logs land in /tmp/jekyll-serve.log.
+  "postStartCommand": "nohup bundle exec jekyll serve --config '_config.yml,_config_dev.yml' --host 0.0.0.0 --port 4000 --livereload --force_polling > /tmp/jekyll-serve.log 2>&1 &",
 
   "forwardPorts": [4000, 35729],
   "portsAttributes": {
     "4000": {
       "label": "Jekyll Site",
-      "onAutoForward": "openBrowser"
+      "onAutoForward": "openPreview"
     },
     "35729": {
       "label": "LiveReload",
@@ -48,5 +73,7 @@
     }
   },
 
-  "remoteUser": "vscode"
+  // The Dockerfile (ruby:3.3-slim base) runs as root, matching docker-compose's
+  // `.:/site` mount. Staying root avoids gem/bind-mount permission friction.
+  "remoteUser": "root"
 }

--- a/pages/_docs/development/devcontainer.md
+++ b/pages/_docs/development/devcontainer.md
@@ -1,7 +1,8 @@
 ---
 lastmod: 2026-06-26T00:00:00.000Z
-title: DevContainer Configuration
+title: DevContainer Configuration for Codespaces
 description: VS Code Dev Container config for one-click cloud and local dev — GitHub Codespaces, JetBrains Gateway, and VS Code, with the Jekyll toolchain pre-installed.
+keywords: [jekyll devcontainer, github codespaces, codespaces prebuilds, vs code dev containers, jekyll dev environment, docker jekyll]
 preview: /images/previews/devcontainer-configuration.png
 layout: default
 categories:

--- a/pages/_docs/development/devcontainer.md
+++ b/pages/_docs/development/devcontainer.md
@@ -1,5 +1,5 @@
 ---
-lastmod: 2026-06-14T00:00:00.000Z
+lastmod: 2026-06-26T00:00:00.000Z
 title: DevContainer Configuration
 description: VS Code Dev Container config for one-click cloud and local dev — GitHub Codespaces, JetBrains Gateway, and VS Code, with the Jekyll toolchain pre-installed.
 preview: /images/previews/devcontainer-configuration.png
@@ -39,32 +39,38 @@ zer0-mistakes ships a `.devcontainer/devcontainer.json` that lets you open a ful
 
 ### What's Pre-Installed
 
-The container is based on `mcr.microsoft.com/devcontainers/jekyll:2-bullseye` and adds:
+Instead of pulling a generic base image and installing gems on every launch, the devcontainer **builds from the repo's own [`docker/Dockerfile`](https://github.com/bamr87/zer0-mistakes/blob/main/docker/Dockerfile)** (the `dev-test` stage). That stage runs `bundle install` at **image-build time**, so the whole Jekyll toolchain is **preloaded into the image** — the gems always match the checked-out branch's `Gemfile.lock`, and there's no slow `bundle install` on first boot.
 
 | Tool | Source |
 |---|---|
-| Jekyll + Bundler | Base image |
-| Docker-in-Docker | `devcontainers/features/docker-in-docker:2` |
+| Ruby 3.3 + Bundler + Jekyll toolchain | `docker/Dockerfile` `dev-test` stage (gems baked in) |
 | GitHub CLI (`gh`) | `devcontainers/features/github-cli:1` |
-| Node.js LTS | `devcontainers/features/node:1` |
+
+> Docker-in-Docker and a standalone Node install are intentionally **not**
+> included — they aren't needed to render the site (Playwright/Sass run on the
+> host), and dropping them keeps Codespace creation and prebuilds fast.
+
+### Near-instant launch with prebuilds
+
+Because the image is self-contained, [GitHub Codespaces prebuilds](https://docs.github.com/en/codespaces/prebuilding-your-codespaces) can build it ahead of time so new Codespaces restore from a ready image in seconds. Enable it under **Settings → Codespaces → Set up prebuild** (target `main`, trigger *On configuration change*). See [`.devcontainer/README.md`](https://github.com/bamr87/zer0-mistakes/blob/main/.devcontainer/README.md).
 
 ### Post-Create Hook
 
 ```bash
-bundle install --jobs 4 --retry 3
+git config --global --add safe.directory ${containerWorkspaceFolder} && (bundle check || bundle install --jobs 4 --retry 3)
 ```
 
-Runs automatically after the container is created to install all gem dependencies.
+`bundle check` is a fast no-op when the gems are already baked into the image; it only falls back to a full install if the lockfile drifted.
 
 ### Post-Start Hook
 
 ```bash
 bundle exec jekyll serve \
   --config '_config.yml,_config_dev.yml' \
-  --host 0.0.0.0 --port 4000 --livereload
+  --host 0.0.0.0 --port 4000 --livereload --force_polling
 ```
 
-The Jekyll dev server starts automatically every time the container starts. The site is available at `http://localhost:4000` and forwarded automatically in VS Code and Codespaces.
+The Jekyll dev server starts automatically every time the container starts (`nohup` keeps it alive after the hook returns; `--force_polling` makes file watching reliable over the Codespaces bind mount; logs land in `/tmp/jekyll-serve.log`). The site is available at `http://localhost:4000` and forwarded automatically in VS Code and Codespaces.
 
 ## Forwarded Ports
 


### PR DESCRIPTION
## Description

Makes the dev container launch the site in **GitHub Codespaces** efficiently by using a **preloaded image** instead of installing gems on every create.

The devcontainer now **builds from the repo's own [`docker/Dockerfile`](https://github.com/bamr87/zer0-mistakes/blob/main/docker/Dockerfile) `dev-test` stage** — that stage already runs `bundle install` at image-build time, so every gem is baked into the image. Result: no full `bundle install` on each Codespace create, and the gems always match the checked-out branch's `Gemfile.lock` (unlike pulling a mutable `:latest` from Docker Hub). With **Codespaces prebuilds** enabled, launch becomes near-instant.

### What changed
- **`.devcontainer/devcontainer.json`**
  - `image: mcr.microsoft.com/devcontainers/jekyll` → `build:` from `../docker/Dockerfile`, `target: dev-test` (gems preloaded).
  - Dropped the `docker-in-docker` and `node` features — not needed to render the site (Playwright/Sass run on the host); keeps create + prebuild fast. Kept lightweight `github-cli`.
  - `postCreateCommand` is now `bundle check || bundle install` — a fast no-op when gems are baked in; self-heals only on lock drift.
  - Auto-serve uses `nohup` + `--force_polling` (reliable file watching over the Codespaces bind mount) and logs to `/tmp/jekyll-serve.log`.
  - **No `workspaceMount`/`workspaceFolder` override** — Codespaces always mounts at `/workspaces/<repo>` and gems live at the global `/usr/local/bundle`, so `bundle exec` works from the default folder. This deliberately avoids the `/site` override, which Codespaces doesn't reliably honor.
  - Runs as `root` to match the `ruby:3.3-slim` base + `docker-compose`, avoiding gem/bind-mount permission friction.
- **`.devcontainer/README.md`** (new) — documents the design and **how to enable Codespaces prebuilds** (the one repo setting that turns "preloaded image" into instant launch).
- **`pages/_docs/development/devcontainer.md`** — updated to reflect the new image source, dropped features, and prebuild guidance.

## Type

- [x] `chore` / `ci`

## Reviewer notes
- The setup mirrors the repo's already-proven `docker-compose.yml` path exactly (same Dockerfile, same `dev-test` target, same serve command), and CI's `test-latest.yml` already builds this stage — so the image itself is known-good. No Dockerfile changes in this PR.
- `CHANGELOG.md` intentionally left untouched: it's release-please–managed (auto-generated from Conventional Commits), so a manual `[Unreleased]` entry would conflict. The `chore(config):` title flows into it automatically.
- No runtime theme/layout/include/sass changes, so no Jekyll-build/visual evidence required; `version.rb` untouched.
- Biggest end-to-end win requires a one-time repo setting: **Settings → Codespaces → Set up prebuild** (target `main`, *On configuration change*).

🤖 Generated with [Claude Code](https://claude.com/claude-code)