### PR TITLE
fix(skins): map dark + contrast skins to their background assets (#240)

### DIFF
--- a/_data/theme_backgrounds.yml
+++ b/_data/theme_backgrounds.yml
@@ -99,3 +99,27 @@ skins:
     gradient: "assets/backgrounds/gradients/sunrise.svg"
     pattern: "assets/backgrounds/patterns/sunrise.svg"
     noise: "assets/backgrounds/noise/sunrise.svg"
+
+  # `dark` is the DEFAULT theme_skin, and `contrast` is advertised as valid, but
+  # neither was mapped here — so the SVG-background feature had no entry for them
+  # (issue #240). The gradient/pattern/noise assets already ship; these entries
+  # wire them up. Colors are taken from each skin's gradient stops.
+  dark:
+    label: "Dark"
+    colors:
+      primary: "#1a1a2e"
+      secondary: "#16213e"
+      accent: "#0f3460"
+    gradient: "assets/backgrounds/gradients/dark.svg"
+    pattern: "assets/backgrounds/patterns/dark.svg"
+    noise: "assets/backgrounds/noise/dark.svg"
+
+  contrast:
+    label: "Contrast"
+    colors:
+      primary: "#111111"
+      secondary: "#333333"
+      accent: "#ffcc00"
+    gradient: "assets/backgrounds/gradients/contrast.svg"
+    pattern: "assets/backgrounds/patterns/contrast.svg"
+    noise: "assets/backgrounds/noise/contrast.svg"


### PR DESCRIPTION
Resolves #240 (filed by the issue autopilot's triage pass).

## What
`dark` (the **default** `theme_skin`) and `contrast` were advertised as valid skins but were **missing from `_data/theme_backgrounds.yml` `skins:`**, so the SVG-background feature had no gradient/pattern/noise mapping for them. This adds both entries.

## Why it's safe
- **Data-only.** No layout/SCSS/include/JS changes.
- **No new assets** — every referenced file already ships on `main`:
  `assets/backgrounds/{gradients,patterns,noise}/{dark,contrast}.svg` (verified).
- **Colors derived from the assets** — `colors:` values are taken from each skin's gradient stops (dark: `#1a1a2e`/`#16213e`/`#0f3460`; contrast: `#111111`/`#333333`/`#ffcc00`), so they're consistent by construction.

## Review note
This affects the **default (dark) skin's** rendered backgrounds and the theme-customizer skin list, so please give it a quick **visual confirm** before merging (per the repo's screenshot convention for rendered changes). Found by the it-journey issue autopilot; YAML validated and all asset paths confirmed present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)