### PR TITLE
fix(ci): make claude-run truly OAuth-first (drop API key when OAuth token set)

### DIFF
--- a/.github/actions/claude-run/action.yml
+++ b/.github/actions/claude-run/action.yml
@@ -51,10 +51,13 @@ runs:
           echo "::warning::no Claude auth (CLAUDE_CODE_OAUTH_TOKEN or ANTHROPIC_API_KEY) — AI step is a no-op."
           exit 0
         fi
-        # The claude CLI reads either token from env. Prefer OAuth: drop an empty
-        # ANTHROPIC_API_KEY (an unset GitHub secret renders as "") so the CLI
-        # never attempts empty-key auth.
-        if [ -n "${CLAUDE_CODE_OAUTH_TOKEN:-}" ] && [ -z "${ANTHROPIC_API_KEY:-}" ]; then
+        # The claude CLI reads either token from env, but when BOTH are present it
+        # authenticates with ANTHROPIC_API_KEY. To make the OAuth token (Claude
+        # subscription billing) the real default, drop ANTHROPIC_API_KEY entirely
+        # whenever an OAuth token is set — so OAuth wins over a present API key, and
+        # an empty-string key (an unset GitHub secret renders as "") never triggers
+        # empty-key auth either.
+        if [ -n "${CLAUDE_CODE_OAUTH_TOKEN:-}" ]; then
           unset ANTHROPIC_API_KEY
         fi
         npm install -g @anthropic-ai/claude-code >/dev/null 2>&1 \


### PR DESCRIPTION
## Problem

The autopilot's agent steps fail with **`Credit balance is too low`** (e.g. [run 28398635548](https://github.com/bamr87/zer0-mistakes/actions/runs/28398635548/job/84143890982)). Two causes:

1. **No `CLAUDE_CODE_OAUTH_TOKEN` secret is configured** — only `ANTHROPIC_API_KEY`, whose account is out of credit. *(Fix: add the secret — see below. Not code.)*
2. **`claude-run` isn't actually OAuth-first.** Its guard only dropped `ANTHROPIC_API_KEY` when the key was *already empty* — a no-op. So once an OAuth token **is** added, the still-present API key would keep winning and the OAuth token (subscription billing) would never be used.

## Fix

Drop `ANTHROPIC_API_KEY` whenever a `CLAUDE_CODE_OAUTH_TOKEN` is present, so OAuth genuinely becomes the default and a credit-less API key can't shadow it.

```diff
-if [ -n "$CLAUDE_CODE_OAUTH_TOKEN" ] && [ -z "$ANTHROPIC_API_KEY" ]; then
+if [ -n "$CLAUDE_CODE_OAUTH_TOKEN" ]; then
   unset ANTHROPIC_API_KEY
 fi
```

Verified with a 4-case simulation:

| OAuth | API key | Result |
|---|---|---|
| set | set | **uses OAuth** (API key dropped) ✅ *(was: API key)* |
| — | set | uses API key (fallback unchanged) |
| set | — | uses OAuth |
| — | — | clean no-op (unchanged) |

## Still required to unblock the autopilot (account-side, only you can do)

```bash
claude setup-token                                   # mint a token from your Claude subscription
gh secret set CLAUDE_CODE_OAUTH_TOKEN -R bamr87/zer0-mistakes   # paste it
```

> Touches CODEOWNERS-owned `.github/actions/` → your review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)