### PR TITLE
docs(deployment): cross-link safe-mode build-overlay recipe

### DIFF
--- a/_data/backlog.yml
+++ b/_data/backlog.yml
@@ -832,6 +832,6 @@ tasks:
       - "A docs page/section under `pages/_docs/` documents the build-overlay recipe (clone -> overlay -> strip _plugins -> strict build)."
       - "It is cross-linked from the remote-theme/deploy docs and passes markdownlint + the content-review deterministic tier."
       - "No code change; docs only."
-    links: { issue: 220, pr: null, roadmap: null }
+    links: { issue: 220, pr: 251, roadmap: null }
     created: 2026-06-26
     updated: 2026-06-29

--- a/_data/backlog.yml
+++ b/_data/backlog.yml
@@ -815,7 +815,7 @@ tasks:
 
   - id: T-031
     title: "Document the safe-mode build-overlay recipe for consumers building outside GitHub Pages"
-    status: open
+    status: done
     priority: P3
     area: docs
     risk: low
@@ -834,4 +834,4 @@ tasks:
       - "No code change; docs only."
     links: { issue: 220, pr: null, roadmap: null }
     created: 2026-06-26
-    updated: 2026-06-26
+    updated: 2026-06-29

--- a/_data/navigation/docs.yml
+++ b/_data/navigation/docs.yml
@@ -70,6 +70,10 @@
       url: /docs/deployment/
     - title: GitHub Pages
       url: /docs/deployment/github-pages/
+    - title: Remote-Theme Consumer Checklist
+      url: /docs/deployment/remote-theme-checklist/
+    - title: Safe-Mode Build Overlay
+      url: /docs/deployment/build-overlay/
     - title: Netlify
       url: /docs/deployment/netlify/
     - title: Custom Domain

--- a/pages/_docs/deployment/index.md
+++ b/pages/_docs/deployment/index.md
@@ -36,6 +36,7 @@ Deploy your Zer0-Mistakes Jekyll site to various hosting platforms.
 
 - **[GitHub Pages](github-pages/)** — Deploy to GitHub's free hosting
 - **[Remote-Theme Consumer Checklist](remote-theme-checklist/)** — What `remote_theme` does not deliver, and how to fill the gaps
+- **[Safe-Mode Build Overlay](build-overlay/)** — Reproduce a GitHub Pages build in your own CI (clone → overlay → strip `_plugins` → strict build)
 - **[Netlify](netlify/)** — Deploy with custom headers and redirects
 - **[Custom Domain](custom-domain/)** — Set up your own domain name
 


### PR DESCRIPTION
## What

Make the **Safe-Mode Build Overlay** recipe (`/docs/deployment/build-overlay/`) discoverable. The page already existed and was linked *from* the remote-theme checklist, but nothing linked *to* it from the deployment landing page or the docs sidebar — so a reader on the deployment overview could not find it.

This PR adds the reciprocal links:

- `pages/_docs/deployment/index.md` — adds the build-overlay entry to the **Guides in This Section** list (next to the remote-theme checklist).
- `_data/navigation/docs.yml` — adds **Safe-Mode Build Overlay** (and the previously-missing **Remote-Theme Consumer Checklist**) to the Deployment sidebar nav, so both appear in the docs sidebar.
- `_data/backlog.yml` — marks T-031 `done` and bumps `updated`.

## Why

Closes the discoverability gap triaged for #220. Acceptance for the build-overlay docs required it be "cross-linked from the remote-theme/deploy docs"; the page existed but the deploy index/nav reciprocal link was missing.

## Acceptance criteria

- [x] A docs page under `pages/_docs/` documents the build-overlay recipe (already present: `build-overlay.md`).
- [x] It is cross-linked from the remote-theme/deploy docs (now also from the deployment index + docs sidebar nav) and passes markdownlint + the content-review deterministic tier.
- [x] No code change; docs/data only.

## Validation

- `markdownlint-cli --config .github/config/.markdownlint.json` on both touched/related `.md` files → **OK**.
- `ruby scripts/content-review.rb` (deterministic tier) on the two docs → **Average 94.5/100** (index.md 89 acceptable, build-overlay.md 100 excellent); threshold 70. The index.md warnings (short title/description, no keywords) are pre-existing front matter not touched by this PR.
- YAML re-parsed via Ruby; the Deployment nav block now lists Overview, GitHub Pages, Remote-Theme Consumer Checklist, Safe-Mode Build Overlay, Netlify, Custom Domain. All nav `url`s confirmed to match real page `permalink`s.
- Jekyll build could NOT be run in this isolated worktree (container bundle not materialized for the worktree mount; host bundle lacks jekyll). The change adds only Markdown list items and nav entries pointing at an already-building page — no new template/front-matter logic — so build risk is nil. CI will run the full build.

## Compatibility

Additive only; no removed links, no front matter or layout changes. Safe for remote-theme consumers.

Closes #220