### PR TITLE
chore(backlog): mark T-010 done (v1.9 quickstart docs shipped)

### DIFF
--- a/_data/backlog.yml
+++ b/_data/backlog.yml
@@ -270,7 +270,7 @@ tasks:
 
   - id: T-010
     title: "Complete v1.9 quickstart docs rewrite with getting-started guide and screenshots"
-    status: open
+    status: done
     priority: P2
     area: docs
     risk: low
@@ -286,9 +286,9 @@ tasks:
       - "At least one guide beyond `bare-minimum.md` covers the standard fork/remote-theme workflow."
       - "Each guide includes at least one screenshot stored under `assets/images/docs/quickstart/`."
       - "All new pages pass `docs-validate.yml` front-matter and link checks."
-    links: { issue: null, pr: null, roadmap: "1.9" }
+    links: { issue: 126, pr: null, roadmap: "1.9" }
     created: 2026-06-01
-    updated: 2026-06-01
+    updated: 2026-06-29
 
   - id: T-011
     title: "Add Ruby unit tests for uncovered _plugins/ generators"


### PR DESCRIPTION
Closes #126

Verified all four acceptance criteria of T-010/#126 are met on `main`:
- [x] `pages/_docs/quickstart/index.md` — nav overview + guide table linking the quickstart guides
- [x] A guide beyond `bare-minimum.md` — `fork-and-deploy.md` (standard fork / remote-theme GitHub Pages workflow)
- [x] Each guide has a screenshot under `assets/images/docs/quickstart/` — real PNGs `theme-home.png` (2560×660) + `docs-deployment.png` (2560×1400)
- [x] Passes docs-validate — markdownlint clean (CI config), front matter + permalinks valid

The deliverables already landed on `main`; this marks **T-010** done so `sync.yml` closes #126. Data-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)