### PR TITLE
fix(ci): self-repair gate crashes before checkout (gh pr view needs -R)

### DIFF
--- a/.github/workflows/ci-self-repair.yml
+++ b/.github/workflows/ci-self-repair.yml
@@ -54,7 +54,10 @@ jobs:
           if [ -z "$pr" ] || [ "$pr" = "null" ]; then
             echo "No open PR for $HEAD_SHA — nothing to repair."; echo "go=false" >>"$GITHUB_OUTPUT"; exit 0
           fi
-          labels=$(gh pr view "$pr" --json labels --jq '[.labels[].name]|join(",")')
+          # -R is required: this gate runs BEFORE the checkout step, so there is no
+          # local git remote for `gh pr view` to infer the repo from (it would die
+          # with "not a git repository"). Pass the repo explicitly, like `gh api` above.
+          labels=$(gh pr view "$pr" -R "$GITHUB_REPOSITORY" --json labels --jq '[.labels[].name]|join(",")')
           case ",$labels," in
             *",auto-fix,"*) : ;;
             *) echo "PR #$pr is not opted in (missing the 'auto-fix' label)."; echo "go=false" >>"$GITHUB_OUTPUT"; exit 0 ;;


### PR DESCRIPTION
## Problem

The **CI self-repair** workflow failed at its first real step — [run 28406225888](https://github.com/bamr87/zer0-mistakes/actions/runs/28406225888/job/84169205668):

```
failed to run git: fatal: not a git repository (or any of the parent directories): .git
##[error]Process completed with exit code 1.
```

The `Resolve PR + opt-in gate` step runs **before** `Checkout PR branch`, so there's no local git remote. `gh pr view "$pr" --json labels` infers the repo from git remotes → dies → the whole job fails before it can even check the `auto-fix` opt-in label. (The `gh api` call right above it works because it passes the repo explicitly.)

## Fix

One line — pass the repo explicitly:

```diff
-labels=$(gh pr view "$pr" --json labels --jq '[.labels[].name]|join(",")')
+labels=$(gh pr view "$pr" -R "$GITHUB_REPOSITORY" --json labels --jq '...')
```

Now the gate reads the labels correctly and **no-ops cleanly** (`go=false`) for PRs without the `auto-fix` label — which is what should have happened on the triggering run (that PR wasn't opted in). Everything downstream of the gate already runs post-checkout, so no other call needs `-R`.

> Touches CODEOWNERS-owned `.github/workflows/` → your review/merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)