### PR TITLE
fix(features): reconcile registry with the real repo + add validation gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -208,7 +208,7 @@ jobs:
           # Gate parity (T-012): run every non-Playwright theme suite that
           # `./scripts/bin/test` exposes locally, not a subset. Playwright
           # tiers run as dedicated steps below.
-          suites: core,deployment,quality,installation,installer,site_generation,obsidian
+          suites: core,deployment,quality,installation,installer,site_generation,obsidian,features
           skip-docker: true
           skip-remote: true
 

--- a/_data/features.yml
+++ b/_data/features.yml
@@ -1,7 +1,7 @@
 # zer0-mistakes Theme Features Registry
 # Comprehensive feature tracking for the zer0-mistakes Jekyll theme
-# Version: 1.6.2
-# Last Updated: 2026-06-13
+# Version: 1.23.0
+# Last Updated: 2026-06-30
 
 features:
   # ============================================================================
@@ -39,7 +39,7 @@ features:
     tags: [docker, devops, development, cross-platform]
     date: 2025-01-27
     references:
-      config: ["docker-compose.yml", "docker-compose.prod.yml", "docker-compose.test.yml"]
+      config: ["docker-compose.yml", "docker-compose.test.yml"]
       dockerfile: "docker/Dockerfile"
       scripts: ["scripts/setup.sh"]
     features:
@@ -220,7 +220,11 @@ features:
     tags: [navigation, ui, accessibility, performance, sidebar]
     date: 2025-12-01
     references:
-      javascript: "assets/js/sidebar.js"
+      javascript:
+        - "assets/js/modules/navigation/sidebar-state.js"
+        - "assets/js/modules/navigation/sidebar-visibility.js"
+        - "assets/js/modules/navigation/scroll-spy.js"
+        - "assets/js/modules/navigation/smooth-scroll.js"
       layouts: ["_layouts/default.html"]
       includes:
         - "_includes/navigation/sidebar-left.html"
@@ -228,7 +232,7 @@ features:
         - "_includes/navigation/sidebar-categories.html"
         - "_includes/navigation/sidebar-folders.html"
       styles: ["_sass/core/_docs-layout.scss", "_sass/custom.scss"]
-      docs: "docs/SIDEBAR_IMPROVEMENTS.md"
+      docs: "pages/_docs/features/sidebar-navigation.md"
     features:
       - "Intersection Observer scroll spy"
       - "Smooth scrolling with offset"
@@ -249,8 +253,12 @@ features:
     tags: [accessibility, keyboard, navigation, ux]
     date: 2025-12-01
     references:
-      javascript: "assets/js/sidebar.js"
-      docs: "docs/keyboard-navigation.md"
+      javascript:
+        - "assets/js/modules/navigation/keyboard.js"
+        - "assets/js/modules/navigation/gestures.js"
+      includes:
+        - "_includes/components/shortcuts-modal.html"
+      docs: "pages/_docs/features/keyboard-navigation.md"
     shortcuts:
       - key: "["
         action: "Previous section"
@@ -314,7 +322,7 @@ features:
       workflow: ".github/workflows/convert-notebooks.yml"
       config: "_config.yml"
       collection: "pages/_notebooks/"
-      docs: "docs/JUPYTER_NOTEBOOKS.md"
+      docs: "docs/features/jupyter-notebooks.md"
       makefile: "Makefile"
     features:
       - "Automatic .ipynb to Markdown conversion"
@@ -430,8 +438,10 @@ features:
   
   - id: ZER0-017
     title: "Automated Version Bump Workflow"
-    description: "GitHub Actions workflow for manual version bumping with test execution, changelog updates, and automated tagging"
-    implemented: true
+    description: "Removed in v1.20.0 — the manual version-bump GitHub Actions workflow was superseded by the release-please pipeline (see ZER0-015). Kept for ID stability and historical reference"
+    implemented: false
+    removed_in: "1.20.0"
+    superseded_by: "ZER0-015"
     version: "0.14.2"
     link: "/"
     docs: "/docs/development/version-bump/"
@@ -482,22 +492,29 @@ features:
       layouts:
         - "_layouts/root.html"
         - "_layouts/default.html"
-        - "_layouts/journals.html"
         - "_layouts/home.html"
         - "_layouts/landing.html"
+        - "_layouts/article.html"
+        - "_layouts/news.html"
+        - "_layouts/section.html"
+        - "_layouts/note.html"
         - "_layouts/notebook.html"
-        - "_layouts/blog.html"
-        - "_layouts/category.html"
         - "_layouts/collection.html"
         - "_layouts/index.html"
         - "_layouts/sitemap-collection.html"
         - "_layouts/stats.html"
         - "_layouts/tag.html"
+        - "_layouts/author.html"
+        - "_layouts/authors.html"
+        - "_layouts/admin.html"
+        - "_layouts/search.html"
+        - "_layouts/setup.html"
+        - "_layouts/welcome.html"
       docs: ".github/instructions/layouts.instructions.md"
     layout_hierarchy:
       - "root.html (base HTML structure)"
       - "default.html (main content wrapper)"
-      - "journals.html (blog posts)"
+      - "article.html (blog posts)"
       - "notebook.html (Jupyter notebooks)"
       - "landing.html (homepage)"
   
@@ -543,7 +560,7 @@ features:
     references:
       plugin: "_plugins/theme_version.rb"
       include: "_includes/components/theme-info.html"
-      docs: "docs/THEME_VERSION_IMPLEMENTATION.md"
+      docs: "docs/features/theme-version.md"
     features:
       - "Gem specification parsing"
       - "Remote theme support"
@@ -599,7 +616,9 @@ features:
     tags: [documentation, prd, product, planning]
     date: 2025-11-25
     references:
-      doc: "docs/PRD.md"
+      doc:
+        - "docs/architecture/prd-requirements.md"
+        - "docs/architecture/prd-roadmap.md"
     features:
       - "Vision statement"
       - "Target personas"
@@ -740,21 +759,27 @@ features:
 
   - id: ZER0-031
     title: "Dark/Light Mode Toggle"
-    description: "Theme color mode switcher supporting light, dark, and auto modes with system preference detection and localStorage persistence"
+    description: "Theme color mode switcher supporting light, dark, and auto modes with system preference detection, localStorage persistence, and a server+client color_mode_default config knob with FOUC prevention"
     implemented: true
-    version: "0.1.0"
+    version: "1.23.0"
     link: "/"
     docs: "/docs/features/color-modes/"
     tags: [ui, theme, dark-mode, accessibility]
-    date: 2025-01-01
+    date: 2026-06-30
     references:
       scripts:
-        - "assets/js/color-modes.js"
+        - "assets/js/modules/theme/appearance.js"
+      includes:
+        - "_includes/core/color-mode-init.html"
+      layouts:
+        - "_layouts/root.html"
+      config: "_config.yml"
     features:
       - "Light, dark, and auto modes"
       - "System preference detection"
       - "LocalStorage persistence"
       - "Bootstrap 5.3 data-bs-theme integration"
+      - "color_mode_default config knob with FOUC prevention"
       - "Smooth theme transitions"
 
   - id: ZER0-032
@@ -827,16 +852,22 @@ features:
 
   - id: ZER0-035
     title: "Giscus Comments"
-    description: "GitHub Discussions-powered comment system with theme-aware styling and reaction support"
+    description: "GitHub Discussions-powered comment system with theme-aware styling, reaction support, and Claude-Code-driven conversation building"
     implemented: true
     version: "0.1.0"
     link: "/"
     docs: "/docs/features/giscus-comments/"
-    tags: [comments, github, discussions, engagement]
+    tags: [comments, github, discussions, engagement, claude-code]
     date: 2025-01-01
     references:
       includes:
         - "_includes/content/giscus.html"
+      layouts: ["_layouts/article.html", "_layouts/note.html", "_layouts/notebook.html"]
+      config: "_config.yml"
+      script: "scripts/bin/giscus-discussions"
+      skill: ".github/skills/giscus-conversation/SKILL.md"
+      workflow: ".github/workflows/giscus-digest.yml"
+      tests: "test/test_core.sh"
       docs:
         - "pages/_docs/features/giscus-comments.md"
     features:
@@ -845,6 +876,8 @@ features:
       - "Pathname-based mapping"
       - "Reaction support"
       - "Top-positioned input"
+      - "Consistent site.giscus.enabled gating across layouts"
+      - "Claude Code conversation building (read/draft/seed/post via gh)"
 
   - id: ZER0-036
     title: "MathJax Math Rendering"
@@ -983,9 +1016,12 @@ features:
     references:
       includes:
         - "_includes/content/sitemap.html"
+      plugin: "_plugins/search_and_sitemap_generator.rb"
+      layouts:
+        - "_layouts/sitemap-collection.html"
+        - "_layouts/search.html"
       files:
         - "search.json"
-        - "sitemap.xml"
     features:
       - "XML sitemap for search engines"
       - "JSON search index for site search"
@@ -1240,8 +1276,10 @@ features:
 
   - id: ZER0-057
     title: "Local Docker Publishing Pipeline"
-    description: "Publish the gem from a clean Docker container locally, mirroring the CI release path for reproducible releases without polluting the host Ruby environment"
-    implemented: true
+    description: "Removed in v1.8.1 — the dedicated docker-compose.publish.yml / docker-compose.prod.yml local-publish path was retired; gem publishing now runs through the release-please CI pipeline (see ZER0-015) and scripts/bin/release. Kept for ID stability"
+    implemented: false
+    removed_in: "1.8.1"
+    superseded_by: "ZER0-015"
     version: "0.21.1"
     link: "/"
     docs: "/docs/development/docker-publishing/"

--- a/features/README.md
+++ b/features/README.md
@@ -83,4 +83,4 @@ diff -q features/features.yml _data/features.yml   # must report no difference
 
 ## Feature Count
 
-Current count: **59 features** (as of 2026-05-05, gem v1.6.1)
+Current count: **60 features** (as of 2026-06-30, gem v1.23.0)

--- a/features/features.yml
+++ b/features/features.yml
@@ -1,7 +1,7 @@
 # zer0-mistakes Theme Features Registry
 # Comprehensive feature tracking for the zer0-mistakes Jekyll theme
-# Version: 1.6.2
-# Last Updated: 2026-06-13
+# Version: 1.23.0
+# Last Updated: 2026-06-30
 
 features:
   # ============================================================================
@@ -39,7 +39,7 @@ features:
     tags: [docker, devops, development, cross-platform]
     date: 2025-01-27
     references:
-      config: ["docker-compose.yml", "docker-compose.prod.yml", "docker-compose.test.yml"]
+      config: ["docker-compose.yml", "docker-compose.test.yml"]
       dockerfile: "docker/Dockerfile"
       scripts: ["scripts/setup.sh"]
     features:
@@ -220,7 +220,11 @@ features:
     tags: [navigation, ui, accessibility, performance, sidebar]
     date: 2025-12-01
     references:
-      javascript: "assets/js/sidebar.js"
+      javascript:
+        - "assets/js/modules/navigation/sidebar-state.js"
+        - "assets/js/modules/navigation/sidebar-visibility.js"
+        - "assets/js/modules/navigation/scroll-spy.js"
+        - "assets/js/modules/navigation/smooth-scroll.js"
       layouts: ["_layouts/default.html"]
       includes:
         - "_includes/navigation/sidebar-left.html"
@@ -228,7 +232,7 @@ features:
         - "_includes/navigation/sidebar-categories.html"
         - "_includes/navigation/sidebar-folders.html"
       styles: ["_sass/core/_docs-layout.scss", "_sass/custom.scss"]
-      docs: "docs/SIDEBAR_IMPROVEMENTS.md"
+      docs: "pages/_docs/features/sidebar-navigation.md"
     features:
       - "Intersection Observer scroll spy"
       - "Smooth scrolling with offset"
@@ -249,8 +253,12 @@ features:
     tags: [accessibility, keyboard, navigation, ux]
     date: 2025-12-01
     references:
-      javascript: "assets/js/sidebar.js"
-      docs: "docs/keyboard-navigation.md"
+      javascript:
+        - "assets/js/modules/navigation/keyboard.js"
+        - "assets/js/modules/navigation/gestures.js"
+      includes:
+        - "_includes/components/shortcuts-modal.html"
+      docs: "pages/_docs/features/keyboard-navigation.md"
     shortcuts:
       - key: "["
         action: "Previous section"
@@ -314,7 +322,7 @@ features:
       workflow: ".github/workflows/convert-notebooks.yml"
       config: "_config.yml"
       collection: "pages/_notebooks/"
-      docs: "docs/JUPYTER_NOTEBOOKS.md"
+      docs: "docs/features/jupyter-notebooks.md"
       makefile: "Makefile"
     features:
       - "Automatic .ipynb to Markdown conversion"
@@ -430,8 +438,10 @@ features:
   
   - id: ZER0-017
     title: "Automated Version Bump Workflow"
-    description: "GitHub Actions workflow for manual version bumping with test execution, changelog updates, and automated tagging"
-    implemented: true
+    description: "Removed in v1.20.0 — the manual version-bump GitHub Actions workflow was superseded by the release-please pipeline (see ZER0-015). Kept for ID stability and historical reference"
+    implemented: false
+    removed_in: "1.20.0"
+    superseded_by: "ZER0-015"
     version: "0.14.2"
     link: "/"
     docs: "/docs/development/version-bump/"
@@ -482,22 +492,29 @@ features:
       layouts:
         - "_layouts/root.html"
         - "_layouts/default.html"
-        - "_layouts/journals.html"
         - "_layouts/home.html"
         - "_layouts/landing.html"
+        - "_layouts/article.html"
+        - "_layouts/news.html"
+        - "_layouts/section.html"
+        - "_layouts/note.html"
         - "_layouts/notebook.html"
-        - "_layouts/blog.html"
-        - "_layouts/category.html"
         - "_layouts/collection.html"
         - "_layouts/index.html"
         - "_layouts/sitemap-collection.html"
         - "_layouts/stats.html"
         - "_layouts/tag.html"
+        - "_layouts/author.html"
+        - "_layouts/authors.html"
+        - "_layouts/admin.html"
+        - "_layouts/search.html"
+        - "_layouts/setup.html"
+        - "_layouts/welcome.html"
       docs: ".github/instructions/layouts.instructions.md"
     layout_hierarchy:
       - "root.html (base HTML structure)"
       - "default.html (main content wrapper)"
-      - "journals.html (blog posts)"
+      - "article.html (blog posts)"
       - "notebook.html (Jupyter notebooks)"
       - "landing.html (homepage)"
   
@@ -543,7 +560,7 @@ features:
     references:
       plugin: "_plugins/theme_version.rb"
       include: "_includes/components/theme-info.html"
-      docs: "docs/THEME_VERSION_IMPLEMENTATION.md"
+      docs: "docs/features/theme-version.md"
     features:
       - "Gem specification parsing"
       - "Remote theme support"
@@ -599,7 +616,9 @@ features:
     tags: [documentation, prd, product, planning]
     date: 2025-11-25
     references:
-      doc: "docs/PRD.md"
+      doc:
+        - "docs/architecture/prd-requirements.md"
+        - "docs/architecture/prd-roadmap.md"
     features:
       - "Vision statement"
       - "Target personas"
@@ -740,21 +759,27 @@ features:
 
   - id: ZER0-031
     title: "Dark/Light Mode Toggle"
-    description: "Theme color mode switcher supporting light, dark, and auto modes with system preference detection and localStorage persistence"
+    description: "Theme color mode switcher supporting light, dark, and auto modes with system preference detection, localStorage persistence, and a server+client color_mode_default config knob with FOUC prevention"
     implemented: true
-    version: "0.1.0"
+    version: "1.23.0"
     link: "/"
     docs: "/docs/features/color-modes/"
     tags: [ui, theme, dark-mode, accessibility]
-    date: 2025-01-01
+    date: 2026-06-30
     references:
       scripts:
-        - "assets/js/color-modes.js"
+        - "assets/js/modules/theme/appearance.js"
+      includes:
+        - "_includes/core/color-mode-init.html"
+      layouts:
+        - "_layouts/root.html"
+      config: "_config.yml"
     features:
       - "Light, dark, and auto modes"
       - "System preference detection"
       - "LocalStorage persistence"
       - "Bootstrap 5.3 data-bs-theme integration"
+      - "color_mode_default config knob with FOUC prevention"
       - "Smooth theme transitions"
 
   - id: ZER0-032
@@ -991,9 +1016,12 @@ features:
     references:
       includes:
         - "_includes/content/sitemap.html"
+      plugin: "_plugins/search_and_sitemap_generator.rb"
+      layouts:
+        - "_layouts/sitemap-collection.html"
+        - "_layouts/search.html"
       files:
         - "search.json"
-        - "sitemap.xml"
     features:
       - "XML sitemap for search engines"
       - "JSON search index for site search"
@@ -1248,8 +1276,10 @@ features:
 
   - id: ZER0-057
     title: "Local Docker Publishing Pipeline"
-    description: "Publish the gem from a clean Docker container locally, mirroring the CI release path for reproducible releases without polluting the host Ruby environment"
-    implemented: true
+    description: "Removed in v1.8.1 — the dedicated docker-compose.publish.yml / docker-compose.prod.yml local-publish path was retired; gem publishing now runs through the release-please CI pipeline (see ZER0-015) and scripts/bin/release. Kept for ID stability"
+    implemented: false
+    removed_in: "1.8.1"
+    superseded_by: "ZER0-015"
     version: "0.21.1"
     link: "/"
     docs: "/docs/development/docker-publishing/"

--- a/scripts/bin/validate
+++ b/scripts/bin/validate
@@ -500,6 +500,19 @@ RUBY
     success "Navigation data is valid"
 }
 
+validate_features_registry() {
+    step "Validating feature registry (features.yml)..."
+
+    # Delegates to the shared canonical checker so this gate and the `features`
+    # test suite never drift. Hard-fails on master/_data drift, schema
+    # violations, and stale references; warns (until FEATURES_STRICT=1) on
+    # missing provenance/tests. See
+    # .github/instructions/features.instructions.md.
+    FEATURES_STRICT="${FEATURES_STRICT:-0}" ruby "$REPO_ROOT/scripts/validate-features.rb"
+
+    success "Feature registry is valid"
+}
+
 run_jekyll_build() {
     if [[ "$SKIP_JEKYLL" == "true" ]]; then
         warn "Skipping Jekyll build"
@@ -612,6 +625,9 @@ main() {
     validate_navigation_data
     echo ""
 
+    validate_features_registry
+    echo ""
+
     run_jekyll_build
     echo ""
 
@@ -628,7 +644,7 @@ main() {
     print_summary "Validation Complete" \
         "Repository files: pass" \
         "Version consistency: pass" \
-        "YAML, config contract, and navigation data: pass" \
+        "YAML, config contract, navigation data, and feature registry: pass" \
         "Jekyll build: $([[ "$SKIP_JEKYLL" == "true" ]] && echo skipped || echo pass)" \
         "Jekyll doctor: $([[ "$SKIP_DOCTOR" == "true" ]] && echo skipped || echo pass)" \
         "Compiled assets: $([[ "$SKIP_ASSETS" == "true" ]] && echo skipped || echo pass)" \

--- a/scripts/validate-features.rb
+++ b/scripts/validate-features.rb
@@ -1,0 +1,126 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# ---------------------------------------------------------------------------
+# validate-features.rb — canonical integrity checker for the feature registry.
+#
+# Single source of truth shared by `scripts/bin/validate` (preflight) and
+# `test/test_features.sh` (the `features` test suite). Governance:
+# .github/instructions/features.instructions.md.
+#
+# HARD failures (exit 1):
+#   - features/features.yml and _data/features.yml are not byte-identical
+#   - the header is missing a `# Last Updated:` line
+#   - schema violations (missing required field, bad id/version, duplicate id)
+#   - implemented:false without `removed_in:`
+#   - a reference path on an ACTIVE feature does not exist in the repo
+#
+# WARNINGS (non-fatal unless FEATURES_STRICT=1):
+#   - missing `provenance:` block          (backfilled in PR B)
+#   - missing `tests:` linkage             (backfilled in PR C)
+#   - header `# Version:` not tracking the gem version
+#   - id gaps (IDs are never reused, but gaps are worth a human glance)
+#
+# Portable across Ruby 2.6 (macOS system) and 3.x (CI/Docker).
+# ---------------------------------------------------------------------------
+
+require 'date'
+require 'yaml'
+
+MASTER = 'features/features.yml'
+MIRROR = '_data/features.yml'
+REQUIRED = %w[id title description implemented version link docs tags date].freeze
+STRICT = ENV['FEATURES_STRICT'] == '1'
+
+def die(msg)
+  warn "  \e[31m✗\e[0m #{msg}"
+  exit 1
+end
+
+# Ruby 3.1+ defaults YAML.load_file to safe loading (rejects Date); 2.6 does
+# not accept the keywords. Try the strict form, fall back for old Ruby.
+def load_yaml(path)
+  YAML.load_file(path, permitted_classes: [Date, Time], aliases: true)
+rescue ArgumentError
+  YAML.load_file(path)
+end
+
+def ref_paths(refs)
+  return [] unless refs.is_a?(Hash)
+
+  refs.values.flat_map { |v| v.is_a?(Array) ? v : [v] }.select { |v| v.is_a?(String) }
+end
+
+[MASTER, MIRROR].each { |f| die "#{f} is missing" unless File.file?(f) }
+
+# 1. Sync contract — the two registries must be byte-identical.
+if File.binread(MASTER) != File.binread(MIRROR)
+  die "#{MASTER} and #{MIRROR} differ — run `cp #{MASTER} #{MIRROR}` (must be byte-identical)"
+end
+
+data = load_yaml(MIRROR)
+feats = data && data['features']
+die 'top-level `features:` list missing' unless feats.is_a?(Array)
+
+warnings = []
+
+# Header sanity.
+header = File.foreach(MIRROR).first(8).join
+gem_version = File.read('lib/jekyll-theme-zer0/version.rb')[/VERSION\s*=\s*"([^"]+)"/, 1]
+warnings << "header `# Version:` should match gem version #{gem_version}" unless header.include?("# Version: #{gem_version}")
+die 'header missing `# Last Updated: YYYY-MM-DD` line' unless header =~ /# Last Updated: \d{4}-\d{2}-\d{2}/
+
+seen = {}
+feats.each_with_index do |f, i|
+  die "entry ##{i} is not a mapping" unless f.is_a?(Hash)
+  id = f['id'] || "(index #{i})"
+
+  REQUIRED.each do |key|
+    val = f[key]
+    die "#{id}: required field `#{key}` is missing/empty" if val.nil? || (val.respond_to?(:empty?) && val.empty?)
+  end
+
+  die "#{id}: id must match ZER0-NNN" unless f['id'] =~ /\AZER0-\d{3}\z/
+  die "#{id}: duplicate id" if seen[f['id']]
+  seen[f['id']] = true
+  die "#{id}: version must be X.Y.Z" unless f['version'].to_s =~ /\A\d+\.\d+\.\d+/
+  die "#{id}: tags must be a non-empty list" unless f['tags'].is_a?(Array) && !f['tags'].empty?
+
+  if f['implemented'] == false
+    # Removed features keep their (now-absent) references for history but must
+    # record when they went away.
+    die "#{id}: implemented:false requires `removed_in:`" unless f['removed_in']
+    next
+  end
+
+  # 2. Every reference path on an active feature must exist.
+  ref_paths(f['references']).each do |p|
+    ok = p.end_with?('/') ? File.directory?(p) : File.exist?(p)
+    die "#{id}: reference path does not exist: #{p}" unless ok
+  end
+
+  # 3. Provenance + test linkage (warn now, fatal under FEATURES_STRICT / later PRs).
+  warnings << "#{id}: missing `provenance:` block" unless f['provenance'].is_a?(Hash)
+  tests = f['tests']
+  has_test = tests.is_a?(Array) && tests.any? { |t| t.is_a?(String) ? File.exist?(t) : (t.is_a?(Hash) && t['na']) }
+  warnings << "#{id}: no `tests:` entry (real path or `na:` + reason)" unless has_test
+end
+
+# Sequential-id sanity (gaps allowed — never reuse an ID — but flagged).
+nums = seen.keys.map { |k| k.split('-').last.to_i }.sort
+gaps = (1..nums.last).to_a - nums
+warnings << "id gaps (verify intentional): #{gaps.map { |n| format('ZER0-%03d', n) }.join(', ')}" unless gaps.empty?
+
+unless warnings.empty?
+  verbose = STRICT || ENV['FEATURES_VERBOSE'] == '1'
+  prov  = warnings.count { |w| w.include?('provenance') }
+  tests = warnings.count { |w| w.include?('`tests:`') }
+  other = warnings.length - prov - tests
+  warn "  \e[33m⚠\e[0m feature registry: #{warnings.length} warning(s) — " \
+       "provenance:#{prov} tests:#{tests} other:#{other} (FEATURES_VERBOSE=1 for the full list)"
+  warnings.each { |w| warn "    - #{w}" } if verbose
+  die "#{warnings.length} warning(s) treated as errors (FEATURES_STRICT=1)" if STRICT
+end
+
+active = feats.count { |f| f['implemented'] != false }
+puts "Feature registry valid: #{feats.length} entries (#{active} active), refs resolved, master/_data in sync"

--- a/test/test_features.sh
+++ b/test/test_features.sh
@@ -1,0 +1,102 @@
+#!/bin/bash
+#
+# test_features.sh — Feature registry integrity suite.
+#
+# Guards the single-source-of-truth feature registry that powers /features/:
+#   1. Registry integrity — delegates to scripts/validate-features.rb
+#      (master/_data byte-sync, schema, every active reference path exists,
+#      removed features carry removed_in, provenance/tests warnings).
+#   2. README count sync — features/README.md "Current count" must match the
+#      number of ZER0-NNN entries in the registry.
+#   3. Backlog visibility — reports how many entries still lack provenance/tests
+#      (non-fatal) so progress on PR B / PR C is observable in CI logs.
+#
+# Exit codes:
+#   0 — registry integrity holds (warnings allowed unless FEATURES_STRICT=1)
+#   1 — a hard invariant was violated
+#
+# Governance: .github/instructions/features.instructions.md
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+GREEN='\033[0;32m'
+RED='\033[0;31m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+OVERALL_STATUS=0
+
+section() { echo ""; echo "==> $1"; }
+ok()      { echo -e "  ${GREEN}✓${NC} $1"; }
+bad()     { echo -e "  ${RED}✗${NC} $1"; OVERALL_STATUS=1; }
+note()    { echo -e "  ${YELLOW}…${NC} $1"; }
+
+cd "$PROJECT_ROOT"
+
+# The registry checker needs only the Ruby stdlib (yaml, date) — no project
+# gems — so we call `ruby` directly. It is written to tolerate both the macOS
+# system Ruby (2.6) and CI/Docker (3.x). Using `bundle exec` here would only
+# add a needless dependency on an installed bundle.
+RUBY=(ruby)
+
+# ---------------------------------------------------------------------------
+# Layer 1 — Registry integrity (canonical checker)
+# ---------------------------------------------------------------------------
+section "Registry integrity (scripts/validate-features.rb)"
+if "${RUBY[@]}" scripts/validate-features.rb; then
+    ok "Registry integrity checks passed"
+else
+    bad "Registry integrity checks failed"
+fi
+
+# ---------------------------------------------------------------------------
+# Layer 2 — README feature-count sync
+# ---------------------------------------------------------------------------
+section "features/README.md count sync"
+actual_count="$(grep -c '^  - id: ZER0-' _data/features.yml)"
+readme_count="$(grep -oE 'Current count: \*\*[0-9]+ features\*\*' features/README.md | grep -oE '[0-9]+' | head -1)"
+if [[ -z "$readme_count" ]]; then
+    bad "Could not find 'Current count: **N features**' line in features/README.md"
+elif [[ "$actual_count" == "$readme_count" ]]; then
+    ok "README count ($readme_count) matches registry ($actual_count)"
+else
+    bad "README count ($readme_count) != registry entry count ($actual_count) — update features/README.md"
+fi
+
+# ---------------------------------------------------------------------------
+# Layer 3 — Backlog visibility (non-fatal)
+# ---------------------------------------------------------------------------
+section "Provenance / test backfill progress (informational)"
+"${RUBY[@]}" - <<'RUBY' || true
+require 'date'; require 'yaml'
+data = begin
+  YAML.load_file('_data/features.yml', permitted_classes: [Date, Time], aliases: true)
+rescue ArgumentError
+  YAML.load_file('_data/features.yml')
+end
+feats = data['features']
+active = feats.reject { |f| f['implemented'] == false }
+prov = active.count { |f| f['provenance'].is_a?(Hash) }
+tested = active.count do |f|
+  t = f['tests']
+  t.is_a?(Array) && t.any? { |x| x.is_a?(String) ? File.exist?(x) : (x.is_a?(Hash) && x['na']) }
+end
+puts "  provenance: #{prov}/#{active.length} active features  (target PR B: all)"
+puts "  tests:      #{tested}/#{active.length} active features  (target PR C: all)"
+RUBY
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+echo ""
+echo "============================================================"
+if [[ $OVERALL_STATUS -eq 0 ]]; then
+    echo -e "${GREEN}Feature registry tests: PASSED${NC}"
+else
+    echo -e "${RED}Feature registry tests: FAILURES DETECTED${NC}"
+fi
+echo "============================================================"
+exit $OVERALL_STATUS

--- a/test/test_runner.sh
+++ b/test/test_runner.sh
@@ -178,10 +178,10 @@ done
 # `playwright` runs the smoke tier; `playwright_snapshots` runs the pixel
 # regression tier. The legacy `visual` (ImageMagick + bash screenshots) and
 # `styling` (alias for the same Playwright tier) suites have been retired.
-TEST_SUITE_KEYS=("core" "deployment" "quality" "installation" "installer" "site_generation" "obsidian" "playwright" "playwright_snapshots" "audit")
-TEST_SUITE_SCRIPTS=("test_core.sh" "test_deployment.sh" "test_quality.sh" "test_installation.sh" "test_installer.sh" "test_site_generation.sh" "test_obsidian.sh" "test_playwright.sh" "test_playwright.sh" "test_audit.sh")
-TEST_SUITE_NAMES=("Core Tests (Unit, Integration, Validation)" "Deployment Tests (Installation, Docker, E2E)" "Quality Tests (Security, Accessibility, Compatibility, Performance)" "Installation Tests (CLI, Modes, Errors, Edge Cases)" "Modular Installer Tests (Profiles, Deploy Plugins, Agents, AI Wizard)" "Site Generation Tests (Config Matrix, Jekyll Build)" "Obsidian Tests (Wiki Links, Graph, Backlinks)" "Playwright Smoke Tests (CSS, layout, behavioral DOM)" "Playwright Snapshot Tests (homepage skin pixel regression)" "Audit Tests (Manifest generation, consumer classification, fix mode)")
-TEST_SUITE_ENV=("" "" "" "" "" "" "" "PLAYWRIGHT_PROJECT=smoke" "PLAYWRIGHT_PROJECT=snapshots" "")
+TEST_SUITE_KEYS=("core" "deployment" "quality" "installation" "installer" "site_generation" "obsidian" "features" "playwright" "playwright_snapshots" "audit")
+TEST_SUITE_SCRIPTS=("test_core.sh" "test_deployment.sh" "test_quality.sh" "test_installation.sh" "test_installer.sh" "test_site_generation.sh" "test_obsidian.sh" "test_features.sh" "test_playwright.sh" "test_playwright.sh" "test_audit.sh")
+TEST_SUITE_NAMES=("Core Tests (Unit, Integration, Validation)" "Deployment Tests (Installation, Docker, E2E)" "Quality Tests (Security, Accessibility, Compatibility, Performance)" "Installation Tests (CLI, Modes, Errors, Edge Cases)" "Modular Installer Tests (Profiles, Deploy Plugins, Agents, AI Wizard)" "Site Generation Tests (Config Matrix, Jekyll Build)" "Obsidian Tests (Wiki Links, Graph, Backlinks)" "Feature Registry Tests (Sync, Schema, References, Coverage Backlog)" "Playwright Smoke Tests (CSS, layout, behavioral DOM)" "Playwright Snapshot Tests (homepage skin pixel regression)" "Audit Tests (Manifest generation, consumer classification, fix mode)")
+TEST_SUITE_ENV=("" "" "" "" "" "" "" "" "PLAYWRIGHT_PROJECT=smoke" "PLAYWRIGHT_PROJECT=snapshots" "")
 
 # Helper function to get suite script by name
 get_suite_script() {
@@ -266,10 +266,10 @@ parse_test_suites() {
     
     if [[ "$suites_input" == "all" ]]; then
         # Run core test suites by default (Playwright tiers are optional and slow)
-        suites_to_run=("core" "deployment" "quality" "installation" "installer" "site_generation")
+        suites_to_run=("core" "deployment" "quality" "installation" "installer" "site_generation" "features")
     elif [[ "$suites_input" == "full" ]]; then
         # Run everything including Obsidian and both Playwright tiers
-        suites_to_run=("core" "deployment" "quality" "installation" "installer" "site_generation" "obsidian" "playwright" "playwright_snapshots")
+        suites_to_run=("core" "deployment" "quality" "installation" "installer" "site_generation" "obsidian" "features" "playwright" "playwright_snapshots")
     else
         IFS=',' read -ra suites_to_run <<< "$suites_input"
         # Backwards-compat aliases for the retired suite names


### PR DESCRIPTION
## What & why

**PR A of 4** in the feature-registry reconciliation (reconcile drift + gate → provenance → tests/screenshots → new entries + governance). See the [audit summary](#) in the PR thread.

The registry that powers https://zer0-mistakes.com/features/ had silently drifted from the code, and nothing guarded it. This PR makes the data truthful again and adds a gate so it can't drift unnoticed.

### Reconciliation (commit 1 — `fix`)
- **Re-synced** `_data/features.yml` to the `features/features.yml` master (the ZER0-035 Giscus entry was stale on the live site) — now byte-identical, header at gem `v1.23.0`.
- **Corrected 11 stale reference blocks** (verified via `git log --diff-filter=D/--follow`): `sidebar.js` → `assets/js/modules/navigation/*`, `color-modes.js` → `color-mode-init.html` + `appearance.js`, removed `docker-compose.prod/publish.yml`, the removed `journals/blog/category` layouts → the current set, and the relocated internal docs (PRD split, Jupyter/theme-version/sidebar/keyboard).
- **Marked 2 superseded features removed** (`implemented:false` + `removed_in`): ZER0-017 version-bump workflow (→ release-please, v1.20.0) and ZER0-057 local Docker publishing (v1.8.1).
- Bumped `features/README.md` count 59 → 60.

### Validation gate (commit 2 — `test`)
- New canonical checker **`scripts/validate-features.rb`**, shared by `scripts/bin/validate` (preflight, runs in `--quick`) and a new **`features` test suite** (`test/test_features.sh`, registered in the runner + CI).
- **Hard-fails** on: master/`_data` drift, schema violations, stale reference paths, removed-without-`removed_in`.
- **Warns** (until `FEATURES_STRICT=1`) on missing `provenance:`/`tests:` — these flip to hard failures as PR B and PR C land.

## Test
```
./test/test_runner.sh --suites features      # PASSED (1/1)
FEATURES_STRICT=1 ruby scripts/validate-features.rb   # exits 1 (flip proven)
diff -q features/features.yml _data/features.yml       # identical
```

## Scope notes
- No template/SCSS/JS changes (renderer updates come in PR B) — this is registry **data** + tooling, so no visual evidence applies. Add `skip-evidence` if the gate asks.
- No version bump / lockfile churn — release-please owns versioning.