### PR TITLE
test(features): regression coverage for every feature + enforce tests gate

### DIFF
--- a/_data/features.yml
+++ b/_data/features.yml
@@ -22,6 +22,9 @@ features:
       pr: null
       commit: "a8426a5"
       issue: null
+    tests:
+      - "test/visual/component-showcase.spec.js"
+      - "test/visual/styling.spec.js"
     references:
       layouts: ["_layouts/root.html", "_layouts/default.html"]
       includes: ["_includes/core/head.html"]
@@ -48,6 +51,8 @@ features:
       pr: null
       commit: "4ff71bc"
       issue: null
+    tests:
+      - "test/test_deployment.sh"
     references:
       config: ["docker-compose.yml", "docker-compose.test.yml"]
       dockerfile: "docker/Dockerfile"
@@ -73,6 +78,9 @@ features:
       pr: 76
       commit: "36cd015"
       issue: null
+    tests:
+      - "test/test_installer.sh"
+      - "test/test_installation.sh"
     references:
       script: "install.sh"
       cli: "scripts/bin/install"
@@ -110,6 +118,8 @@ features:
       pr: 83
       commit: "ffdc1eb"
       issue: null
+    tests:
+      - "test/test_core.sh"
     references:
       plugin: "_plugins/preview_image_generator.rb"
       script: "scripts/generate-preview-images.sh"
@@ -156,6 +166,8 @@ features:
       pr: 70
       commit: "bc41b0d"
       issue: null
+    tests:
+      - na: "Process/docs feature (AGENTS.md + .github/instructions/*); no runtime test"
     references:
       entry_point: "AGENTS.md"
       main: ".github/copilot-instructions.md"
@@ -202,6 +214,9 @@ features:
       pr: null
       commit: "76f4508"
       issue: null
+    tests:
+      - "test/test_quality.sh"
+      - "test/visual/security.spec.js"
     references:
       include: "_includes/analytics/posthog.html"
       config: "_config.yml"
@@ -230,6 +245,8 @@ features:
       pr: null
       commit: "76f4508"
       issue: null
+    tests:
+      - "test/test_quality.sh"
     references:
       include: "_includes/components/cookie-consent.html"
       config: "_config.yml"
@@ -259,6 +276,8 @@ features:
       pr: null
       commit: "0ea51c6"
       issue: null
+    tests:
+      - "test/visual/interactions.spec.js"
     references:
       javascript:
         - "assets/js/modules/navigation/sidebar-state.js"
@@ -297,6 +316,9 @@ features:
       pr: null
       commit: "0ea51c6"
       issue: null
+    tests:
+      - "test/visual/feature-coverage.spec.js"
+      - "test/visual/accessibility.spec.js"
     references:
       javascript:
         - "assets/js/modules/navigation/keyboard.js"
@@ -328,6 +350,9 @@ features:
       pr: null
       commit: "0ea51c6"
       issue: null
+    tests:
+      - "test/visual/feature-coverage.spec.js"
+      - "test/visual/ui-refresh.spec.js"
     references:
       include: "_includes/navigation/sidebar-right.html"
       styles: "_sass/custom.scss"
@@ -353,6 +378,8 @@ features:
       pr: null
       commit: "0ea51c6"
       issue: null
+    tests:
+      - "test/visual/accessibility.spec.js"
     references:
       include: "_includes/core/header.html"
       styles: "_sass/custom.scss"
@@ -375,6 +402,8 @@ features:
       pr: null
       commit: "8bf80ad"
       issue: null
+    tests:
+      - "test/test_core.sh"
     references:
       script: "scripts/convert-notebooks.sh"
       layout: "_layouts/notebook.html"
@@ -409,6 +438,8 @@ features:
       pr: null
       commit: "1a6184b"
       issue: null
+    tests:
+      - "test/test_core.sh"
     references:
       include: "_includes/components/mermaid.html"
       config: "_config.yml"
@@ -438,6 +469,8 @@ features:
       pr: null
       commit: "a8426a5"
       issue: null
+    tests:
+      - "test/test_site_generation.sh"
     references:
       config: "_config.yml"
       collections:
@@ -470,6 +503,8 @@ features:
       pr: null
       commit: "81ef2d7"
       issue: null
+    tests:
+      - na: "Release tooling — exercised by scripts/bin/test integration (auto-version) + .github/workflows/release.yml"
     references:
       scripts:
         - "scripts/release"
@@ -500,12 +535,12 @@ features:
       pr: null
       commit: "e527464"
       issue: null
+    tests:
+      - "test/test_runner.sh"
+      - "test/test_core.sh"
+      - "test/test_deployment.sh"
+      - "test/test_quality.sh"
     references:
-      tests:
-        - "test/test_runner.sh"
-        - "test/test_core.sh"
-        - "test/test_deployment.sh"
-        - "test/test_quality.sh"
       workflow: ".github/workflows/ci.yml"
     features:
       - "Core functionality tests"
@@ -557,6 +592,8 @@ features:
       pr: null
       commit: "5053589"
       issue: null
+    tests:
+      - na: "Security scanning — .github/workflows/codeql.yml; no unit test applicable"
     references:
       workflow: ".github/workflows/codeql.yml"
     features:
@@ -583,6 +620,8 @@ features:
       pr: null
       commit: "a8426a5"
       issue: null
+    tests:
+      - "test/visual/layouts.spec.js"
     references:
       layouts:
         - "_layouts/root.html"
@@ -627,6 +666,8 @@ features:
       pr: null
       commit: "a8426a5"
       issue: null
+    tests:
+      - "test/visual/component-showcase.spec.js"
     references:
       includes:
         - "_includes/core/"
@@ -662,6 +703,8 @@ features:
       pr: null
       commit: "fbc767b"
       issue: null
+    tests:
+      - "test/test_plugins.rb"
     references:
       plugin: "_plugins/theme_version.rb"
       include: "_includes/components/theme-info.html"
@@ -691,6 +734,8 @@ features:
       pr: null
       commit: "1bd9a2c"
       issue: null
+    tests:
+      - "test/test_quality.sh"
     references:
       page: "pages/privacy-policy.md"
     features:
@@ -714,6 +759,8 @@ features:
       pr: null
       commit: "1bd9a2c"
       issue: null
+    tests:
+      - "test/test_quality.sh"
     references:
       page: "pages/terms-of-service.md"
   
@@ -735,6 +782,8 @@ features:
       pr: null
       commit: "b7ad237"
       issue: null
+    tests:
+      - na: "Documentation artifact (docs/architecture/prd-*.md); no runtime test"
     references:
       doc:
         - "docs/architecture/prd-requirements.md"
@@ -760,6 +809,8 @@ features:
       pr: null
       commit: "ceb4962"
       issue: null
+    tests:
+      - na: "Documentation architecture; no runtime test"
     references:
       technical: "docs/"
       public: "pages/_docs/"
@@ -789,6 +840,8 @@ features:
       pr: null
       commit: "3b55b60"
       issue: null
+    tests:
+      - na: "Automation — .github/workflows/update-dependencies.yml; no unit test"
     references:
       workflow: ".github/workflows/update-dependencies.yml"
     features:
@@ -811,6 +864,8 @@ features:
       pr: null
       commit: "1ba6994"
       issue: null
+    tests:
+      - na: "CI pipeline — .github/workflows/ci.yml; self-validating"
     references:
       workflow: ".github/workflows/ci.yml"
     features:
@@ -838,6 +893,8 @@ features:
       pr: null
       commit: "32755cd"
       issue: null
+    tests:
+      - na: "Shell tooling — exercised by scripts/bin/test (lib + theme + integration)"
     references:
       scripts:
         - "scripts/build"
@@ -874,6 +931,8 @@ features:
       pr: null
       commit: "a8426a5"
       issue: null
+    tests:
+      - "test/visual/feature-coverage.spec.js"
     references:
       scripts:
         - "assets/js/back-to-top.js"
@@ -897,6 +956,8 @@ features:
       pr: null
       commit: "a8426a5"
       issue: null
+    tests:
+      - "test/visual/feature-coverage.spec.js"
     references:
       scripts:
         - "assets/js/code-copy.js"
@@ -921,6 +982,8 @@ features:
       pr: 253
       commit: "55bee97"
       issue: null
+    tests:
+      - "test/visual/color-mode-default.spec.js"
     references:
       scripts:
         - "assets/js/modules/theme/appearance.js"
@@ -951,6 +1014,9 @@ features:
       pr: 86
       commit: "21eb458"
       issue: null
+    tests:
+      - "test/visual/search.spec.js"
+      - "test/visual/search-degradation.spec.js"
     references:
       scripts:
         - "assets/js/search-modal.js"
@@ -981,6 +1047,8 @@ features:
       pr: null
       commit: "a8426a5"
       issue: null
+    tests:
+      - "test/visual/feature-coverage.spec.js"
     references:
       scripts:
         - "assets/js/auto-hide-nav.js"
@@ -1004,6 +1072,8 @@ features:
       pr: null
       commit: "a8426a5"
       issue: null
+    tests:
+      - "test/visual/backgrounds.spec.js"
     references:
       scripts:
         - "assets/js/particles.js"
@@ -1034,6 +1104,8 @@ features:
       pr: null
       commit: "a8426a5"
       issue: null
+    tests:
+      - "test/visual/giscus-comments.spec.js"
     references:
       includes:
         - "_includes/content/giscus.html"
@@ -1042,7 +1114,6 @@ features:
       script: "scripts/bin/giscus-discussions"
       skill: ".github/skills/giscus-conversation/SKILL.md"
       workflow: ".github/workflows/giscus-digest.yml"
-      tests: "test/test_core.sh"
       docs:
         - "pages/_docs/features/giscus-comments.md"
     features:
@@ -1068,6 +1139,8 @@ features:
       pr: null
       commit: "31f827e"
       issue: null
+    tests:
+      - "test/visual/feature-coverage.spec.js"
     references:
       docs:
         - "pages/_docs/features/mathjax-math.md"
@@ -1091,6 +1164,9 @@ features:
       pr: null
       commit: "a8426a5"
       issue: null
+    tests:
+      - "test/visual/feature-coverage.spec.js"
+      - "test/visual/ui-refresh.spec.js"
     references:
       includes:
         - "_includes/content/toc.html"
@@ -1119,6 +1195,8 @@ features:
       pr: null
       commit: "a8426a5"
       issue: null
+    tests:
+      - "test/test_quality.sh"
     references:
       includes:
         - "_includes/analytics/google-analytics.html"
@@ -1142,6 +1220,8 @@ features:
       pr: null
       commit: "a8426a5"
       issue: null
+    tests:
+      - "test/test_quality.sh"
     references:
       includes:
         - "_includes/analytics/google-tag-manager-head.html"
@@ -1170,6 +1250,9 @@ features:
       pr: null
       commit: "a8426a5"
       issue: null
+    tests:
+      - "test/visual/layouts.spec.js"
+      - "test/visual/authors-breadcrumb-degradation.spec.js"
     references:
       includes:
         - "_includes/navigation/breadcrumbs.html"
@@ -1198,6 +1281,8 @@ features:
       pr: null
       commit: "a8426a5"
       issue: null
+    tests:
+      - "test/test_quality.sh"
     references:
       includes:
         - "_includes/content/seo.html"
@@ -1223,6 +1308,9 @@ features:
       pr: null
       commit: "a8426a5"
       issue: null
+    tests:
+      - "test/test_core.sh"
+      - "test/test_deployment.sh"
     references:
       includes:
         - "_includes/content/sitemap.html"
@@ -1256,6 +1344,9 @@ features:
       pr: null
       commit: "8986a02"
       issue: null
+    tests:
+      - "test/test_plugins.rb"
+      - "test/test_core.sh"
     references:
       layouts:
         - "_layouts/stats.html"
@@ -1290,6 +1381,10 @@ features:
       pr: 73
       commit: "31e042c"
       issue: null
+    tests:
+      - "test/test_obsidian.sh"
+      - "test/test_ruby_converter.rb"
+      - "test/test_resolver.js"
     references:
       plugin: "_plugins/obsidian_links.rb"
       scripts:
@@ -1300,10 +1395,6 @@ features:
         - "_includes/content/backlinks.html"
         - "_includes/obsidian/full-graph.html"
       docs: "pages/_docs/obsidian/"
-      tests:
-        - "test/test_obsidian.sh"
-        - "test/test_ruby_converter.rb"
-        - "test/test_resolver.js"
       instructions: ".github/instructions/obsidian.instructions.md"
     features:
       - "[[Wiki-links]] resolution"
@@ -1328,6 +1419,9 @@ features:
       pr: 77
       commit: "d39dfa9"
       issue: null
+    tests:
+      - "test/test_obsidian.sh"
+      - "test/visual/obsidian-callouts.spec.js"
     references:
       includes:
         - "_includes/obsidian/full-graph.html"
@@ -1353,6 +1447,8 @@ features:
       pr: null
       commit: "4bd3e36"
       issue: null
+    tests:
+      - "test/test_site_generation.sh"
     references:
       includes:
         - "_includes/components/info-section.html"
@@ -1373,6 +1469,9 @@ features:
       pr: 58
       commit: "02d0295"
       issue: null
+    tests:
+      - "test/test_core.sh"
+      - "test/visual/layouts.spec.js"
     references:
       page: "404.html"
       docs: "pages/_docs/features/smart-404.md"
@@ -1391,6 +1490,8 @@ features:
       pr: 34
       commit: "10ba722"
       issue: null
+    tests:
+      - na: "Build-time validation — scripts/bin/validate; CI fast-checks job"
     references:
       script: "scripts/bin/validate"
       config: ".github/config/frontmatter_schema.yml"
@@ -1410,6 +1511,9 @@ features:
       pr: null
       commit: "a8426a5"
       issue: null
+    tests:
+      - "test/visual/ui-refresh.spec.js"
+      - "test/visual/navbar-responsive.spec.js"
     references:
       includes:
         - "_includes/navigation/navbar.html"
@@ -1428,6 +1532,9 @@ features:
       pr: 57
       commit: "27550da"
       issue: null
+    tests:
+      - "test/visual/admin-layout.spec.js"
+      - "test/visual/admin-nav.spec.js"
     references:
       layout: "_layouts/admin.html"
       includes:
@@ -1448,6 +1555,8 @@ features:
       pr: 70
       commit: "bc41b0d"
       issue: null
+    tests:
+      - na: "Documentation entry point (AGENTS.md); no runtime test"
     references:
       file: "AGENTS.md"
       instructions_index: ".github/instructions/README.md"
@@ -1466,6 +1575,8 @@ features:
       pr: 71
       commit: "7f00e4d"
       issue: null
+    tests:
+      - "test/test_core.sh"
     references:
       data: "_data/roadmap.yml"
       page: "pages/roadmap.md"
@@ -1485,6 +1596,8 @@ features:
       pr: 39
       commit: "3c96620"
       issue: null
+    tests:
+      - "test/test_core.sh"
     references:
       script: "scripts/vendor-install.sh"
       manifest: "vendor-manifest.json"
@@ -1506,6 +1619,8 @@ features:
       pr: 38
       commit: "9a27ad7"
       issue: null
+    tests:
+      - "test/test_quality.sh"
     references:
       includes:
         - "_includes/content/seo.html"
@@ -1529,6 +1644,9 @@ features:
       pr: null
       commit: "5533f34"
       issue: null
+    tests:
+      - "test/visual/navbar-responsive.spec.js"
+      - "test/visual/ui-refresh.spec.js"
     references:
       scripts:
         - "assets/js/modules/"
@@ -1550,6 +1668,8 @@ features:
       pr: null
       commit: "0ef86c2"
       issue: null
+    tests:
+      - na: "DevContainer config (.devcontainer/devcontainer.json); validated by Codespaces, no unit test"
     references:
       config:
         - ".devcontainer/devcontainer.json"
@@ -1590,6 +1710,8 @@ features:
       pr: null
       commit: "06691f9"
       issue: null
+    tests:
+      - "test/test_site_generation.sh"
     references:
       collection: "pages/_notes/"
       layouts:
@@ -1610,6 +1732,8 @@ features:
       pr: 73
       commit: "31e042c"
       issue: null
+    tests:
+      - "test/test_obsidian.sh"
     references:
       plugin: "_plugins/obsidian_links.rb"
       includes:
@@ -1628,6 +1752,8 @@ features:
       pr: 33
       commit: "341cc67"
       issue: null
+    tests:
+      - "test/visual/ai-chat.spec.js"
     references:
       includes: ["_includes/components/ai-chat.html"]
       layouts: ["_layouts/root.html"]

--- a/features/features.yml
+++ b/features/features.yml
@@ -22,6 +22,9 @@ features:
       pr: null
       commit: "a8426a5"
       issue: null
+    tests:
+      - "test/visual/component-showcase.spec.js"
+      - "test/visual/styling.spec.js"
     references:
       layouts: ["_layouts/root.html", "_layouts/default.html"]
       includes: ["_includes/core/head.html"]
@@ -48,6 +51,8 @@ features:
       pr: null
       commit: "4ff71bc"
       issue: null
+    tests:
+      - "test/test_deployment.sh"
     references:
       config: ["docker-compose.yml", "docker-compose.test.yml"]
       dockerfile: "docker/Dockerfile"
@@ -73,6 +78,9 @@ features:
       pr: 76
       commit: "36cd015"
       issue: null
+    tests:
+      - "test/test_installer.sh"
+      - "test/test_installation.sh"
     references:
       script: "install.sh"
       cli: "scripts/bin/install"
@@ -110,6 +118,8 @@ features:
       pr: 83
       commit: "ffdc1eb"
       issue: null
+    tests:
+      - "test/test_core.sh"
     references:
       plugin: "_plugins/preview_image_generator.rb"
       script: "scripts/generate-preview-images.sh"
@@ -156,6 +166,8 @@ features:
       pr: 70
       commit: "bc41b0d"
       issue: null
+    tests:
+      - na: "Process/docs feature (AGENTS.md + .github/instructions/*); no runtime test"
     references:
       entry_point: "AGENTS.md"
       main: ".github/copilot-instructions.md"
@@ -202,6 +214,9 @@ features:
       pr: null
       commit: "76f4508"
       issue: null
+    tests:
+      - "test/test_quality.sh"
+      - "test/visual/security.spec.js"
     references:
       include: "_includes/analytics/posthog.html"
       config: "_config.yml"
@@ -230,6 +245,8 @@ features:
       pr: null
       commit: "76f4508"
       issue: null
+    tests:
+      - "test/test_quality.sh"
     references:
       include: "_includes/components/cookie-consent.html"
       config: "_config.yml"
@@ -259,6 +276,8 @@ features:
       pr: null
       commit: "0ea51c6"
       issue: null
+    tests:
+      - "test/visual/interactions.spec.js"
     references:
       javascript:
         - "assets/js/modules/navigation/sidebar-state.js"
@@ -297,6 +316,9 @@ features:
       pr: null
       commit: "0ea51c6"
       issue: null
+    tests:
+      - "test/visual/feature-coverage.spec.js"
+      - "test/visual/accessibility.spec.js"
     references:
       javascript:
         - "assets/js/modules/navigation/keyboard.js"
@@ -328,6 +350,9 @@ features:
       pr: null
       commit: "0ea51c6"
       issue: null
+    tests:
+      - "test/visual/feature-coverage.spec.js"
+      - "test/visual/ui-refresh.spec.js"
     references:
       include: "_includes/navigation/sidebar-right.html"
       styles: "_sass/custom.scss"
@@ -353,6 +378,8 @@ features:
       pr: null
       commit: "0ea51c6"
       issue: null
+    tests:
+      - "test/visual/accessibility.spec.js"
     references:
       include: "_includes/core/header.html"
       styles: "_sass/custom.scss"
@@ -375,6 +402,8 @@ features:
       pr: null
       commit: "8bf80ad"
       issue: null
+    tests:
+      - "test/test_core.sh"
     references:
       script: "scripts/convert-notebooks.sh"
       layout: "_layouts/notebook.html"
@@ -409,6 +438,8 @@ features:
       pr: null
       commit: "1a6184b"
       issue: null
+    tests:
+      - "test/test_core.sh"
     references:
       include: "_includes/components/mermaid.html"
       config: "_config.yml"
@@ -438,6 +469,8 @@ features:
       pr: null
       commit: "a8426a5"
       issue: null
+    tests:
+      - "test/test_site_generation.sh"
     references:
       config: "_config.yml"
       collections:
@@ -470,6 +503,8 @@ features:
       pr: null
       commit: "81ef2d7"
       issue: null
+    tests:
+      - na: "Release tooling — exercised by scripts/bin/test integration (auto-version) + .github/workflows/release.yml"
     references:
       scripts:
         - "scripts/release"
@@ -500,12 +535,12 @@ features:
       pr: null
       commit: "e527464"
       issue: null
+    tests:
+      - "test/test_runner.sh"
+      - "test/test_core.sh"
+      - "test/test_deployment.sh"
+      - "test/test_quality.sh"
     references:
-      tests:
-        - "test/test_runner.sh"
-        - "test/test_core.sh"
-        - "test/test_deployment.sh"
-        - "test/test_quality.sh"
       workflow: ".github/workflows/ci.yml"
     features:
       - "Core functionality tests"
@@ -557,6 +592,8 @@ features:
       pr: null
       commit: "5053589"
       issue: null
+    tests:
+      - na: "Security scanning — .github/workflows/codeql.yml; no unit test applicable"
     references:
       workflow: ".github/workflows/codeql.yml"
     features:
@@ -583,6 +620,8 @@ features:
       pr: null
       commit: "a8426a5"
       issue: null
+    tests:
+      - "test/visual/layouts.spec.js"
     references:
       layouts:
         - "_layouts/root.html"
@@ -627,6 +666,8 @@ features:
       pr: null
       commit: "a8426a5"
       issue: null
+    tests:
+      - "test/visual/component-showcase.spec.js"
     references:
       includes:
         - "_includes/core/"
@@ -662,6 +703,8 @@ features:
       pr: null
       commit: "fbc767b"
       issue: null
+    tests:
+      - "test/test_plugins.rb"
     references:
       plugin: "_plugins/theme_version.rb"
       include: "_includes/components/theme-info.html"
@@ -691,6 +734,8 @@ features:
       pr: null
       commit: "1bd9a2c"
       issue: null
+    tests:
+      - "test/test_quality.sh"
     references:
       page: "pages/privacy-policy.md"
     features:
@@ -714,6 +759,8 @@ features:
       pr: null
       commit: "1bd9a2c"
       issue: null
+    tests:
+      - "test/test_quality.sh"
     references:
       page: "pages/terms-of-service.md"
   
@@ -735,6 +782,8 @@ features:
       pr: null
       commit: "b7ad237"
       issue: null
+    tests:
+      - na: "Documentation artifact (docs/architecture/prd-*.md); no runtime test"
     references:
       doc:
         - "docs/architecture/prd-requirements.md"
@@ -760,6 +809,8 @@ features:
       pr: null
       commit: "ceb4962"
       issue: null
+    tests:
+      - na: "Documentation architecture; no runtime test"
     references:
       technical: "docs/"
       public: "pages/_docs/"
@@ -789,6 +840,8 @@ features:
       pr: null
       commit: "3b55b60"
       issue: null
+    tests:
+      - na: "Automation — .github/workflows/update-dependencies.yml; no unit test"
     references:
       workflow: ".github/workflows/update-dependencies.yml"
     features:
@@ -811,6 +864,8 @@ features:
       pr: null
       commit: "1ba6994"
       issue: null
+    tests:
+      - na: "CI pipeline — .github/workflows/ci.yml; self-validating"
     references:
       workflow: ".github/workflows/ci.yml"
     features:
@@ -838,6 +893,8 @@ features:
       pr: null
       commit: "32755cd"
       issue: null
+    tests:
+      - na: "Shell tooling — exercised by scripts/bin/test (lib + theme + integration)"
     references:
       scripts:
         - "scripts/build"
@@ -874,6 +931,8 @@ features:
       pr: null
       commit: "a8426a5"
       issue: null
+    tests:
+      - "test/visual/feature-coverage.spec.js"
     references:
       scripts:
         - "assets/js/back-to-top.js"
@@ -897,6 +956,8 @@ features:
       pr: null
       commit: "a8426a5"
       issue: null
+    tests:
+      - "test/visual/feature-coverage.spec.js"
     references:
       scripts:
         - "assets/js/code-copy.js"
@@ -921,6 +982,8 @@ features:
       pr: 253
       commit: "55bee97"
       issue: null
+    tests:
+      - "test/visual/color-mode-default.spec.js"
     references:
       scripts:
         - "assets/js/modules/theme/appearance.js"
@@ -951,6 +1014,9 @@ features:
       pr: 86
       commit: "21eb458"
       issue: null
+    tests:
+      - "test/visual/search.spec.js"
+      - "test/visual/search-degradation.spec.js"
     references:
       scripts:
         - "assets/js/search-modal.js"
@@ -981,6 +1047,8 @@ features:
       pr: null
       commit: "a8426a5"
       issue: null
+    tests:
+      - "test/visual/feature-coverage.spec.js"
     references:
       scripts:
         - "assets/js/auto-hide-nav.js"
@@ -1004,6 +1072,8 @@ features:
       pr: null
       commit: "a8426a5"
       issue: null
+    tests:
+      - "test/visual/backgrounds.spec.js"
     references:
       scripts:
         - "assets/js/particles.js"
@@ -1034,6 +1104,8 @@ features:
       pr: null
       commit: "a8426a5"
       issue: null
+    tests:
+      - "test/visual/giscus-comments.spec.js"
     references:
       includes:
         - "_includes/content/giscus.html"
@@ -1042,7 +1114,6 @@ features:
       script: "scripts/bin/giscus-discussions"
       skill: ".github/skills/giscus-conversation/SKILL.md"
       workflow: ".github/workflows/giscus-digest.yml"
-      tests: "test/test_core.sh"
       docs:
         - "pages/_docs/features/giscus-comments.md"
     features:
@@ -1068,6 +1139,8 @@ features:
       pr: null
       commit: "31f827e"
       issue: null
+    tests:
+      - "test/visual/feature-coverage.spec.js"
     references:
       docs:
         - "pages/_docs/features/mathjax-math.md"
@@ -1091,6 +1164,9 @@ features:
       pr: null
       commit: "a8426a5"
       issue: null
+    tests:
+      - "test/visual/feature-coverage.spec.js"
+      - "test/visual/ui-refresh.spec.js"
     references:
       includes:
         - "_includes/content/toc.html"
@@ -1119,6 +1195,8 @@ features:
       pr: null
       commit: "a8426a5"
       issue: null
+    tests:
+      - "test/test_quality.sh"
     references:
       includes:
         - "_includes/analytics/google-analytics.html"
@@ -1142,6 +1220,8 @@ features:
       pr: null
       commit: "a8426a5"
       issue: null
+    tests:
+      - "test/test_quality.sh"
     references:
       includes:
         - "_includes/analytics/google-tag-manager-head.html"
@@ -1170,6 +1250,9 @@ features:
       pr: null
       commit: "a8426a5"
       issue: null
+    tests:
+      - "test/visual/layouts.spec.js"
+      - "test/visual/authors-breadcrumb-degradation.spec.js"
     references:
       includes:
         - "_includes/navigation/breadcrumbs.html"
@@ -1198,6 +1281,8 @@ features:
       pr: null
       commit: "a8426a5"
       issue: null
+    tests:
+      - "test/test_quality.sh"
     references:
       includes:
         - "_includes/content/seo.html"
@@ -1223,6 +1308,9 @@ features:
       pr: null
       commit: "a8426a5"
       issue: null
+    tests:
+      - "test/test_core.sh"
+      - "test/test_deployment.sh"
     references:
       includes:
         - "_includes/content/sitemap.html"
@@ -1256,6 +1344,9 @@ features:
       pr: null
       commit: "8986a02"
       issue: null
+    tests:
+      - "test/test_plugins.rb"
+      - "test/test_core.sh"
     references:
       layouts:
         - "_layouts/stats.html"
@@ -1290,6 +1381,10 @@ features:
       pr: 73
       commit: "31e042c"
       issue: null
+    tests:
+      - "test/test_obsidian.sh"
+      - "test/test_ruby_converter.rb"
+      - "test/test_resolver.js"
     references:
       plugin: "_plugins/obsidian_links.rb"
       scripts:
@@ -1300,10 +1395,6 @@ features:
         - "_includes/content/backlinks.html"
         - "_includes/obsidian/full-graph.html"
       docs: "pages/_docs/obsidian/"
-      tests:
-        - "test/test_obsidian.sh"
-        - "test/test_ruby_converter.rb"
-        - "test/test_resolver.js"
       instructions: ".github/instructions/obsidian.instructions.md"
     features:
       - "[[Wiki-links]] resolution"
@@ -1328,6 +1419,9 @@ features:
       pr: 77
       commit: "d39dfa9"
       issue: null
+    tests:
+      - "test/test_obsidian.sh"
+      - "test/visual/obsidian-callouts.spec.js"
     references:
       includes:
         - "_includes/obsidian/full-graph.html"
@@ -1353,6 +1447,8 @@ features:
       pr: null
       commit: "4bd3e36"
       issue: null
+    tests:
+      - "test/test_site_generation.sh"
     references:
       includes:
         - "_includes/components/info-section.html"
@@ -1373,6 +1469,9 @@ features:
       pr: 58
       commit: "02d0295"
       issue: null
+    tests:
+      - "test/test_core.sh"
+      - "test/visual/layouts.spec.js"
     references:
       page: "404.html"
       docs: "pages/_docs/features/smart-404.md"
@@ -1391,6 +1490,8 @@ features:
       pr: 34
       commit: "10ba722"
       issue: null
+    tests:
+      - na: "Build-time validation — scripts/bin/validate; CI fast-checks job"
     references:
       script: "scripts/bin/validate"
       config: ".github/config/frontmatter_schema.yml"
@@ -1410,6 +1511,9 @@ features:
       pr: null
       commit: "a8426a5"
       issue: null
+    tests:
+      - "test/visual/ui-refresh.spec.js"
+      - "test/visual/navbar-responsive.spec.js"
     references:
       includes:
         - "_includes/navigation/navbar.html"
@@ -1428,6 +1532,9 @@ features:
       pr: 57
       commit: "27550da"
       issue: null
+    tests:
+      - "test/visual/admin-layout.spec.js"
+      - "test/visual/admin-nav.spec.js"
     references:
       layout: "_layouts/admin.html"
       includes:
@@ -1448,6 +1555,8 @@ features:
       pr: 70
       commit: "bc41b0d"
       issue: null
+    tests:
+      - na: "Documentation entry point (AGENTS.md); no runtime test"
     references:
       file: "AGENTS.md"
       instructions_index: ".github/instructions/README.md"
@@ -1466,6 +1575,8 @@ features:
       pr: 71
       commit: "7f00e4d"
       issue: null
+    tests:
+      - "test/test_core.sh"
     references:
       data: "_data/roadmap.yml"
       page: "pages/roadmap.md"
@@ -1485,6 +1596,8 @@ features:
       pr: 39
       commit: "3c96620"
       issue: null
+    tests:
+      - "test/test_core.sh"
     references:
       script: "scripts/vendor-install.sh"
       manifest: "vendor-manifest.json"
@@ -1506,6 +1619,8 @@ features:
       pr: 38
       commit: "9a27ad7"
       issue: null
+    tests:
+      - "test/test_quality.sh"
     references:
       includes:
         - "_includes/content/seo.html"
@@ -1529,6 +1644,9 @@ features:
       pr: null
       commit: "5533f34"
       issue: null
+    tests:
+      - "test/visual/navbar-responsive.spec.js"
+      - "test/visual/ui-refresh.spec.js"
     references:
       scripts:
         - "assets/js/modules/"
@@ -1550,6 +1668,8 @@ features:
       pr: null
       commit: "0ef86c2"
       issue: null
+    tests:
+      - na: "DevContainer config (.devcontainer/devcontainer.json); validated by Codespaces, no unit test"
     references:
       config:
         - ".devcontainer/devcontainer.json"
@@ -1590,6 +1710,8 @@ features:
       pr: null
       commit: "06691f9"
       issue: null
+    tests:
+      - "test/test_site_generation.sh"
     references:
       collection: "pages/_notes/"
       layouts:
@@ -1610,6 +1732,8 @@ features:
       pr: 73
       commit: "31e042c"
       issue: null
+    tests:
+      - "test/test_obsidian.sh"
     references:
       plugin: "_plugins/obsidian_links.rb"
       includes:
@@ -1628,6 +1752,8 @@ features:
       pr: 33
       commit: "341cc67"
       issue: null
+    tests:
+      - "test/visual/ai-chat.spec.js"
     references:
       includes: ["_includes/components/ai-chat.html"]
       layouts: ["_layouts/root.html"]

--- a/pages/_docs/features/auto-hide-nav.md
+++ b/pages/_docs/features/auto-hide-nav.md
@@ -1,0 +1,57 @@
+---
+lastmod: 2026-06-30T00:00:00.000Z
+title: Auto-hide Navigation
+description: Smart navigation bar that hides on scroll down and reappears on scroll up for maximum content visibility on mobile and desktop.
+layout: default
+categories:
+    - docs
+    - features
+tags:
+    - ui
+    - navigation
+    - scroll
+    - mobile
+permalink: /docs/features/auto-hide-nav/
+difficulty: beginner
+estimated_reading_time: 4 minutes
+sidebar:
+    nav: docs
+---
+
+# Auto-hide Navigation
+
+The top navigation bar gets out of the way while you read: it slides up and
+hides as you scroll **down** the page, then reappears the moment you scroll
+**up**. This reclaims vertical space — especially valuable on small screens —
+without removing access to the menu.
+
+## Overview
+
+- **Hide on scroll down** — the navbar translates off-screen once you scroll
+  past a small threshold, so long-form content gets the full viewport.
+- **Show on scroll up** — any upward scroll brings the navbar straight back.
+- **Smooth CSS transitions** — the show/hide uses a CSS transform, not a layout
+  change, so it stays smooth and doesn't reflow the page.
+- **Mobile-optimised** — the behaviour is most useful on touch devices where
+  screen real estate is scarce.
+
+## How it works
+
+The behaviour is a small, dependency-free controller in
+[`assets/js/auto-hide-nav.js`](https://github.com/bamr87/zer0-mistakes/blob/main/assets/js/auto-hide-nav.js).
+It listens to scroll events passively, compares the current scroll position to
+the previous one, and toggles a CSS class on the navbar that drives the
+transform. Because the listener is passive and the visual change is a transform,
+scrolling stays jank-free.
+
+## Implementation
+
+| File | Role |
+| --- | --- |
+| `assets/js/auto-hide-nav.js` | Scroll-direction controller that toggles the navbar's hidden state. |
+| `_includes/navigation/navbar.html` | The navbar markup the controller targets. |
+
+## Related features
+
+- [Enhanced Sidebar Navigation](/docs/features/sidebar-navigation/)
+- [Keyboard Navigation](/docs/features/keyboard-navigation/)

--- a/pages/_docs/features/particles-background.md
+++ b/pages/_docs/features/particles-background.md
@@ -1,0 +1,56 @@
+---
+lastmod: 2026-06-30T00:00:00.000Z
+title: Particles Background
+description: Interactive particle animation background using particles.js for visual enhancement on landing and hero sections.
+layout: default
+categories:
+    - docs
+    - features
+tags:
+    - ui
+    - animation
+    - visual
+    - landing
+permalink: /docs/features/particles-background/
+difficulty: intermediate
+estimated_reading_time: 4 minutes
+sidebar:
+    nav: docs
+---
+
+# Particles Background
+
+An optional animated particle field that sits behind hero and landing content,
+adding subtle motion and depth. Particles drift, connect, and react to the
+cursor, and the whole effect is configured from a single JSON file.
+
+## Overview
+
+- **Configurable particle field** — count, size, speed, colour, and link
+  distance are all data-driven.
+- **Interactive** — particles respond to mouse hover and clicks.
+- **JSON configuration** — behaviour is read from
+  [`assets/particles.json`](https://github.com/bamr87/zer0-mistakes/blob/main/assets/particles.json),
+  so you can retune the look without touching JavaScript.
+- **Performance-conscious** — intended for landing/hero sections rather than
+  every page, so the animation cost is scoped to where it adds value.
+
+## How it works
+
+The vendored [`assets/js/particles.js`](https://github.com/bamr87/zer0-mistakes/blob/main/assets/js/particles.js)
+runtime renders onto a canvas mounted in the hero area; the initialiser
+(`assets/js/particles-source.js`) loads `assets/particles.json` and applies it.
+Because the configuration is external, a site can ship a calmer or denser field
+by editing the JSON alone.
+
+## Implementation
+
+| File | Role |
+| --- | --- |
+| `assets/js/particles.js` | Vendored particles.js renderer. |
+| `assets/js/particles-source.js` | Initialiser that loads the JSON config and mounts the canvas. |
+| `assets/particles.json` | Particle count, motion, colours, and interactivity. |
+
+## Related features
+
+- [Theme Color Modes](/docs/features/color-modes/)

--- a/pages/_docs/features/statistics-dashboard.md
+++ b/pages/_docs/features/statistics-dashboard.md
@@ -1,0 +1,57 @@
+---
+lastmod: 2026-06-30T00:00:00.000Z
+title: Statistics Dashboard
+description: Content statistics dashboard layout with metrics visualization for posts, categories, and tags across the site.
+preview: /images/previews/statistics-dashboard-feature.png
+layout: default
+categories:
+    - docs
+    - features
+tags:
+    - dashboard
+    - statistics
+    - metrics
+    - visualization
+permalink: /docs/features/statistics-dashboard/
+difficulty: intermediate
+estimated_reading_time: 4 minutes
+sidebar:
+    nav: docs
+---
+
+# Statistics Dashboard
+
+A ready-made dashboard that turns your content into metrics: how many posts you
+have, how they break down by category, and which tags you use most. It is built
+from a dedicated layout plus a set of modular include components, all fed by
+generated content statistics.
+
+## Overview
+
+- **Post count metrics** — total content across collections at a glance.
+- **Category distribution** — see where your writing concentrates.
+- **Tag cloud visualisation** — surface your most-used tags.
+- **Responsive card layout** — the panels reflow cleanly from mobile to desktop.
+
+## How it works
+
+The [`stats.html`](https://github.com/bamr87/zer0-mistakes/blob/main/_layouts/stats.html)
+layout composes the dashboard from the partials under `_includes/stats/`
+(header, overview, categories, tags, and metrics). The numbers come from the
+content-statistics data generated during the build, so the dashboard stays in
+sync with your actual content.
+
+## Implementation
+
+| File | Role |
+| --- | --- |
+| `_layouts/stats.html` | Dashboard page layout. |
+| `_includes/stats/stats-header.html` | Title and summary band. |
+| `_includes/stats/stats-overview.html` | Headline counts. |
+| `_includes/stats/stats-categories.html` | Category distribution. |
+| `_includes/stats/stats-tags.html` | Tag cloud. |
+| `_includes/stats/stats-metrics.html` | Detailed metric cards. |
+
+## Related features
+
+- [SEO & Sitemap Generation](/docs/seo/sitemap/)

--- a/scripts/validate-features.rb
+++ b/scripts/validate-features.rb
@@ -15,9 +15,10 @@
 #   - implemented:false without `removed_in:`
 #   - a reference path on an ACTIVE feature does not exist in the repo
 #   - missing/malformed `provenance:` block on an active feature (since PR B)
+#   - missing/unresolvable `tests:` linkage on an active feature (since PR C):
+#     every entry must be a real test path or `{na: reason}`
 #
 # WARNINGS (non-fatal unless FEATURES_STRICT=1):
-#   - missing `tests:` linkage             (backfilled in PR C)
 #   - header `# Version:` not tracking the gem version
 #   - id gaps (IDs are never reused, but gaps are worth a human glance)
 #
@@ -107,10 +108,18 @@ feats.each_with_index do |f, i|
   die "#{id}: provenance.pr must be an integer or null" unless prov['pr'].nil? || prov['pr'].is_a?(Integer)
   die "#{id}: provenance.issue must be an integer or null" unless prov['issue'].nil? || prov['issue'].is_a?(Integer)
 
-  # 3b. Test linkage (warn now, fatal once PR C backfills it).
+  # 3b. Test linkage is REQUIRED on every active feature (backfilled in PR C).
   tests = f['tests']
-  has_test = tests.is_a?(Array) && tests.any? { |t| t.is_a?(String) ? File.exist?(t) : (t.is_a?(Hash) && t['na']) }
-  warnings << "#{id}: no `tests:` entry (real path or `na:` + reason)" unless has_test
+  die "#{id}: missing/empty `tests:` (a real test path or `{na: reason}`)" unless tests.is_a?(Array) && !tests.empty?
+  tests.each do |t|
+    if t.is_a?(String)
+      die "#{id}: tests entry does not exist: #{t}" unless File.exist?(t)
+    elsif t.is_a?(Hash)
+      die "#{id}: tests `na:` must carry a non-empty reason" unless t['na'].is_a?(String) && !t['na'].strip.empty?
+    else
+      die "#{id}: tests entries must be a path string or `{na: reason}`"
+    end
+  end
 end
 
 # Sequential-id sanity (gaps allowed — never reuse an ID — but flagged).

--- a/test/visual/feature-coverage.spec.js
+++ b/test/visual/feature-coverage.spec.js
@@ -1,0 +1,66 @@
+// =============================================================================
+// feature-coverage.spec.js — regression coverage for registry features that
+// previously had no dedicated Playwright spec (PR C of the feature-registry
+// reconciliation). One focused assertion per feature so a renderer/JS
+// regression fails CI. Each `test()` names its ZER0-NNN id.
+// =============================================================================
+
+const { test, expect } = require('@playwright/test');
+const { waitForJekyll } = require('./fixtures');
+
+// A docs page that exercises TOC, fenced code blocks, and the reading chrome.
+const DOC = '/docs/features/code-copy/';
+
+test.describe('Feature coverage — interactive UI', () => {
+  test('ZER0-029 Back to Top button is present and scrolls to top', async ({ page }) => {
+    await waitForJekyll(page, DOC);
+    const btn = page.locator('#backToTopBtn');
+    await expect(btn).toBeAttached();
+    await page.evaluate(() => window.scrollTo(0, document.body.scrollHeight));
+    await expect(btn).toBeVisible();
+    await btn.click();
+    await expect.poll(() => page.evaluate(() => window.scrollY)).toBeLessThan(50);
+  });
+
+  test('ZER0-030 Code Copy injects a copy control on code blocks', async ({ page }) => {
+    await waitForJekyll(page, DOC);
+    await expect(page.locator('.highlight.has-copy-button, .code-block-header').first()).toBeAttached();
+  });
+
+  test('ZER0-037 Table of Contents renders on docs pages', async ({ page }) => {
+    await waitForJekyll(page, DOC);
+    await expect(page.locator('.bd-toc').first()).toBeAttached();
+  });
+
+  test('ZER0-010 Mobile TOC FAB toggle is present', async ({ page }) => {
+    await waitForJekyll(page, DOC);
+    await expect(page.locator('.bd-toc-toggle').first()).toBeAttached();
+  });
+
+  test('ZER0-009 Keyboard shortcuts modal opens on "?"', async ({ page }) => {
+    await waitForJekyll(page, DOC);
+    const modal = page.locator('#zer0-shortcuts-modal');
+    await expect(modal).toBeAttached();
+    await page.keyboard.press('Shift+Slash'); // "?"
+    await expect(modal).toBeVisible();
+    await page.keyboard.press('Escape');
+  });
+
+  test('ZER0-036 MathJax typesets equations on math pages', async ({ page }) => {
+    await waitForJekyll(page, '/docs/features/mathjax-math/');
+    // MathJax 3 injects an mjx-container (or the CHTML stylesheet) once loaded.
+    await expect
+      .poll(() => page.evaluate(() => !!document.querySelector('mjx-container') || !!window.MathJax), { timeout: 8000 })
+      .toBeTruthy();
+  });
+
+  test('ZER0-033 Auto-hide navigation is wired without errors', async ({ page }) => {
+    const errors = [];
+    page.on('console', (m) => m.type() === 'error' && errors.push(m.text()));
+    await waitForJekyll(page, DOC);
+    await expect(page.locator('nav.navbar, .navbar').first()).toBeAttached();
+    await page.evaluate(() => window.scrollTo(0, 600));
+    await page.evaluate(() => window.scrollTo(0, 0));
+    expect(errors.filter((e) => /auto-hide|navbar/i.test(e))).toEqual([]);
+  });
+});


### PR DESCRIPTION
## What & why

**PR C of 4** — stacked on #264 (base auto-retargets to `main` once #264 merges).

The registry recorded *what* each feature is but not *how it's tested*. This links every feature to a regression test and arms the gate to enforce it.

### Test linkage (all 58 active features)
- Added a top-level **`tests:`** block to every active entry — a real test path, or a justified `{na: reason}` for doc/CI-only features (CodeQL, dep-updates, PRD, DevContainer, …).
- Migrated the 3 legacy nested `references.tests` blocks (ZER0-016, 035, 044) up to the canonical top-level field.

### New coverage spec
- `test/visual/feature-coverage.spec.js` closes dedicated-coverage gaps for previously-untested user-visible behaviours: Back-to-Top (029), Code Copy (030), TOC (037), Mobile TOC FAB (010), keyboard shortcuts modal (009), MathJax (036), auto-hide nav (033). **All 7 pass** against the live site.

### Gate fully armed
- `scripts/validate-features.rb` now HARD-fails when an active feature lacks a resolvable `tests:` entry — completing the warn→fail flip. The registry gate now enforces **sync + schema + references + provenance + tests**.

### Doc-link reconciliation
- Added the 3 missing doc pages (auto-hide-nav, particles-background, statistics-dashboard) whose `docs:` URLs were 404ing.

## Test
```
./test/test_features.sh        # PASS — provenance 58/58, tests 58/58, 0 warnings
npx playwright test --project=smoke feature-coverage   # 7 passed
```

## Note
No `_sass/_includes/_layouts/assets` changes — this is tests + registry data + docs, so the visual-evidence gate does not apply.