### PR TITLE
fix(security): close two DOM-XSS sinks (CodeQL js/xss-through-dom)

### DIFF
--- a/_includes/components/zer0-env-var.html
+++ b/_includes/components/zer0-env-var.html
@@ -57,6 +57,12 @@
         document.querySelector('#envTable tbody').appendChild(row);
     });
 
+    // Escape user-entered text before it is interpolated into innerHTML, so a
+    // key/value containing markup cannot inject script (DOM XSS).
+    const escapeHtml = (s) => String(s).replace(/[&<>"']/g, (c) => (
+        { '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c]
+    ));
+
     document.getElementById('submit').addEventListener('click', function() {
         const rows = document.querySelectorAll('#envTable tbody tr');
         let codeBlockText = '';
@@ -64,7 +70,7 @@
             const key = row.querySelector('td:nth-child(1) input').value;
             const value = row.querySelector('td:nth-child(2) input').value;
             sessionStorage.setItem(key, value);
-            codeBlockText += `<span class="nb">export </span><span class="nv">${key}</span><span class="o">=</span>${value}\n`;
+            codeBlockText += `<span class="nb">export </span><span class="nv">${escapeHtml(key)}</span><span class="o">=</span>${escapeHtml(value)}\n`;
         });
         document.getElementById('codeBlock').innerHTML = codeBlockText;
 

--- a/pages/posts.html
+++ b/pages/posts.html
@@ -287,11 +287,13 @@ keywords:
         <script>
           function goToPage(event) {
             event.preventDefault();
-            const pageNum = document.getElementById('page-jump').value;
+            // Coerce to an integer and bounds-check before building the URL, so a
+            // crafted input value cannot flow into location.href (DOM XSS).
+            const pageNum = parseInt(document.getElementById('page-jump').value, 10);
             const maxPages = {{ paginator.total_pages }};
-            if (pageNum >= 1 && pageNum <= maxPages) {
+            if (Number.isInteger(pageNum) && pageNum >= 1 && pageNum <= maxPages) {
               const basePath = '{{ "/posts/" | relative_url }}';
-              window.location.href = pageNum == 1 ? basePath : basePath + pageNum + '/';
+              window.location.href = pageNum === 1 ? basePath : basePath + pageNum + '/';
             }
             return false;
           }


### PR DESCRIPTION
## What & why

Surfaced by CodeQL while it scanned the feature-registry PR (#264) — two **pre-existing high-severity `js/xss-through-dom` alerts** in files unrelated to that work. Fixing them here in a focused PR clears the alerts (and unblocks the registry stack, whose CodeQL was failing on this pre-existing debt).

| File | Sink | Fix |
|---|---|---|
| `_includes/components/zer0-env-var.html:69` | user key/value → `innerHTML` | `escapeHtml()` both before interpolation |
| `pages/posts.html:294` | page-jump input → `location.href` | `parseInt` + `Number.isInteger` bounds check |

Behaviour is identical for valid input; only crafted input is neutralised — hence `skip-evidence` (no visual/behavioural change for legitimate use).