### PR TITLE
fix(ci): give convert-notebooks a pip cache dependency file

### DIFF
--- a/.github/workflows/convert-notebooks.yml
+++ b/.github/workflows/convert-notebooks.yml
@@ -15,12 +15,15 @@ on:
     paths:
       - 'pages/_notebooks/**.ipynb'
       - 'scripts/convert-notebooks.sh'
+      - 'scripts/requirements.txt'
       - '.github/workflows/convert-notebooks.yml'
   pull_request:
     branches: [ main ]
     paths:
       - 'pages/_notebooks/**.ipynb'
       - 'scripts/convert-notebooks.sh'
+      - 'scripts/requirements.txt'
+      - '.github/workflows/convert-notebooks.yml'
   workflow_dispatch:
     inputs:
       force_reconvert:
@@ -58,11 +61,12 @@ jobs:
         with:
           python-version: ${{ env.PYTHON_VERSION }}
           cache: 'pip'
+          cache-dependency-path: 'scripts/requirements.txt'
 
       - name: Install Jupyter and nbconvert
         run: |
           python -m pip install --upgrade pip
-          pip install jupyter nbconvert
+          pip install -r scripts/requirements.txt
 
       - name: Make Conversion Script Executable
         run: chmod +x scripts/convert-notebooks.sh

--- a/.github/workflows/convert-notebooks.yml
+++ b/.github/workflows/convert-notebooks.yml
@@ -13,14 +13,14 @@ on:
   push:
     branches: [ main ]
     paths:
-      - 'pages/_notebooks/**.ipynb'
+      - 'pages/_notebooks/**/*.ipynb'
       - 'scripts/convert-notebooks.sh'
       - 'scripts/requirements.txt'
       - '.github/workflows/convert-notebooks.yml'
   pull_request:
     branches: [ main ]
     paths:
-      - 'pages/_notebooks/**.ipynb'
+      - 'pages/_notebooks/**/*.ipynb'
       - 'scripts/convert-notebooks.sh'
       - 'scripts/requirements.txt'
       - '.github/workflows/convert-notebooks.yml'
@@ -66,7 +66,7 @@ jobs:
       - name: Install Jupyter and nbconvert
         run: |
           python -m pip install --upgrade pip
-          pip install -r scripts/requirements.txt
+          python -m pip install -r scripts/requirements.txt
 
       - name: Make Conversion Script Executable
         run: chmod +x scripts/convert-notebooks.sh

--- a/scripts/convert-notebooks.sh
+++ b/scripts/convert-notebooks.sh
@@ -339,7 +339,7 @@ clean_converted() {
                 rm -f "$md_file"
                 info "Removed: $md_file"
             fi
-            ((count++))
+            count=$((count + 1))
         fi
     done < <(find "$OUTPUT_DIR" -name "*.md" -print0 2>/dev/null)
     
@@ -364,7 +364,7 @@ list_notebooks() {
     else
         while IFS= read -r -d '' notebook_file; do
             echo "$notebook_file"
-            ((count++))
+            count=$((count + 1))
         done < <(find "$NOTEBOOKS_DIR" -name "*.ipynb" -print0 2>/dev/null)
     fi
     
@@ -400,7 +400,7 @@ main() {
         local count=0
         while IFS= read -r -d '' notebook_file; do
             convert_notebook "$notebook_file"
-            ((count++))
+            count=$((count + 1))
         done < <(find "$NOTEBOOKS_DIR" -name "*.ipynb" -print0 2>/dev/null)
         
         if [[ $count -eq 0 ]]; then

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -1,0 +1,11 @@
+# Python toolchain for repository automation scripts.
+#
+# Currently the notebook-conversion pipeline: scripts/convert-notebooks.sh and
+# .github/workflows/convert-notebooks.yml use nbconvert to render
+# pages/_notebooks/*.ipynb into Jekyll-compatible Markdown.
+#
+# This file also acts as the pip cache key for actions/setup-python in that
+# workflow (see `cache-dependency-path`). Keep it in sync with the toolchain the
+# scripts import; a missing file here makes `cache: pip` hard-fail the run.
+jupyter
+nbconvert


### PR DESCRIPTION
## Description

The "Convert Jupyter Notebooks to Markdown" workflow (`.github/workflows/convert-notebooks.yml`) was failing on **every push to `main` and every PR**. Two independent bugs were involved — the first masked the second:

### 1. `setup-python` pip cache had no dependency file (the visible failure)

The *Setup Python Environment* step used `cache: 'pip'`, but the repo had **no** `requirements.txt`/`pyproject.toml`, so the cache-restore step hard-failed before conversion could run:

```
##[error]No file in .../zer0-mistakes matched to [**/requirements.txt or **/pyproject.toml]
```

Fix:
- **Add `scripts/requirements.txt`** listing the notebook toolchain (`jupyter`, `nbconvert`) — the same packages the inline `pip install` used and that `scripts/convert-notebooks.sh` imports.
- **Point the cache at it** via `cache-dependency-path: 'scripts/requirements.txt'`.
- **Install from it** (`pip install -r scripts/requirements.txt`) so the cache key tracks the actual toolchain.
- **Path-filter parity**: add `scripts/requirements.txt` to both the `push:` and `pull_request:` triggers, and add the workflow file itself to the `pull_request:` paths (it was already on `push:`), keeping the workflow scoped to notebook/toolchain/workflow changes.

### 2. `convert-notebooks.sh` exited 1 on the first counted item (latent bug, unmasked by fix #1)

Once the workflow got past `setup-python`, the *List Notebooks* step died with exit code 1 right after echoing the first notebook. Under `set -euo pipefail`, `((count++))` returns exit status 1 when the pre-increment value is `0` (bash: `(( expr ))` exits non-zero when `expr` evaluates to `0`). Every counting loop starts at `count=0`, so the first increment tripped `set -e`.

Fix: replace all three `((count++))` occurrences with the `set -e`-safe `count=$((count + 1))`.

Scoped the requirements file under `scripts/` (next to the script that uses it) rather than repo root, so it doesn't imply the Jekyll theme is a Python project. Dependabot only manages GitHub Actions here, so no new pip update PRs are introduced. `scripts/convert-notebooks.sh` is not a CODEOWNERS-owned path (only `/scripts/bin/` and `/scripts/lib/` are).

Verified locally: `pip install -r scripts/requirements.txt` succeeds; `./scripts/convert-notebooks.sh --list` lists 5 notebooks and exits 0; `./scripts/convert-notebooks.sh --dry-run --verbose` iterates all 5, writes nothing, and exits 0.

This is a pre-existing CI failure, unrelated to feature-registry work.

## Type

- [x] `chore` / `ci`
- [x] `fix` — bug fix (script)

## Checklist

- [x] Conventional-commit title (`type(scope): subject`) — this drives the automated version bump
- [ ] `CHANGELOG.md` updated under `[Unreleased]` for user-visible changes — N/A (CI/tooling fix, not user-visible; CHANGELOG is release-please generated)
- [ ] `./scripts/bin/test` passes locally (10/10 suites) — N/A (no theme/lib code changed; workflow YAML + conversion script validated directly)
- [ ] Theme/layout/include/sass change → Jekyll build validated — N/A (no theme change)
- [x] No version bump (`lib/jekyll-theme-zer0/version.rb` untouched — releases are automated)
- [ ] Backlog task status updated in `_data/backlog.yml` (if implementing a task) — N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)