### PR TITLE
refactor(ci): consolidate workflows, drop redundant triggers and dead steps

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -5,243 +5,305 @@ This directory contains the CI/CD workflows for the zer0-mistakes Jekyll theme.
 ## Workflow Overview
 
 ```
-┌─────────────────────────────────────────────────────────────────┐
-│                        WORKFLOW TRIGGERS                         │
-├─────────────────────────────────────────────────────────────────┤
-│                                                                  │
-│  Push to main ──────► version-bump.yml ──────► Creates tag v*   │
-│                       (analyzes commits)                         │
-│                                                                  │
-│  Tag v* pushed ─────► release.yml ───────────► Publishes gem    │
-│                                               + GitHub release   │
-│                                                                  │
-│  Push/PR ───────────► ci.yml ────────────────► Tests + Quality  │
-│                                                                  │
-└─────────────────────────────────────────────────────────────────┘
+┌───────────────────────────────────────────────────────────────────────┐
+│                          WORKFLOW TRIGGERS                            │
+├───────────────────────────────────────────────────────────────────────┤
+│                                                                       │
+│  Pull request ──────► ci.yml, evidence-gate.yml, secret-scan.yml,    │
+│                       ai-content-review.yml*, codeql.yml*,           │
+│                       install-matrix.yml*, sync.yml* (path-filtered*)│
+│                                                                       │
+│  Push to main ──────► release.yml (release-please) ─► release PR     │
+│                       merge of release PR ─► tag + gem publish       │
+│                       ci.yml, test-latest.yml, sync.yml, …           │
+│                                                                       │
+│  Schedules ─────────► test-latest.yml (daily canary),                │
+│                       update-dependencies.yml, install-matrix.yml,   │
+│                       codeql.yml, issue-autopilot.yml,               │
+│                       giscus-digest.yml (weekly)                     │
+│                                                                       │
+└───────────────────────────────────────────────────────────────────────┘
 ```
 
-## Workflows
+## CI & Quality Gates
 
-### 1. `ci.yml` - Continuous Integration Pipeline
+### `ci.yml` — Comprehensive CI Pipeline
 
 **Triggers:** Push to `main`, Pull Requests, Manual dispatch
 
-The CI pipeline validates code quality, runs tests, builds the gem, and performs Docker integration testing. Uses `dorny/paths-filter` to detect changed files and skip heavy jobs on docs-only changes.
+Validates code quality, runs the full test suite, builds the gem, and performs
+Docker integration testing. Uses `dorny/paths-filter` (job `detect-changes`) to
+skip heavy jobs on docs-only changes.
 
-#### Jobs:
 | Job | Description | Condition | Timeout |
 |-----|-------------|-----------|---------|
-| `detect-changes` | Identifies code/docker/content changes | Always | 3 min |
-| `fast-checks` | Quick syntax validation | Code changes only | 5 min |
-| `quality-checks` | Linting, security audit, markdown checks | Always (covers docs PRs) | 10 min |
-| `test` | Full gate-parity suite: all non-Playwright theme suites (core, deployment, quality, installation, installer, site_generation, obsidian) + canonical script suites (`./scripts/bin/test`: lib unit, theme validate, integration, installer e2e) + Playwright smoke tier (and snapshots when CSS/layout changes) | Code changes only | 25 min |
+| `detect-changes` | Identifies code/docker/content/styling changes | Always | 3 min |
+| `quality-checks` | version.rb ↔ Gemfile.lock guard, linting, markdown checks, quick preflight validation (code changes) | Always — the single required check | 15 min |
+| `test` | Full gate-parity suite: all non-Playwright theme suites + canonical script suites (`./scripts/bin/test`) + Playwright smoke tier | Code changes only | 25 min |
+| `snapshots` | Playwright pixel-snapshot gate (9 theme skins, rendered in the jammy Playwright image) | Styling changes only | 30 min |
 | `build` | Gem build, validation, and install test | Code changes only | 10 min |
 | `integration` | Docker build + critical page accessibility | Code or Docker changes | 12 min |
 
-#### Job Dependency Graph:
+Job dependency graph:
+
 ```
-detect-changes → fast-checks → quality-checks → test → build
-                                              → integration
+detect-changes → quality-checks → test → build
+              → snapshots       → integration
 ```
 
-#### Manual Dispatch Options:
-- **test_scope**: `fast` (skips Playwright snapshot tier) or `standard`
-- **fix_markdown**: Auto-fix markdown formatting issues
+Manual dispatch options: **test_scope** (`fast` skips the snapshot tier) and
+**fix_markdown** (auto-fix markdown formatting).
 
-#### Path Filter Behavior:
-| Change Type | Jobs Run | Estimated Time |
-|-------------|----------|----------------|
-| Markdown/docs only | detect-changes, quality-checks | ~3 min |
-| Code changes (no styling) | All jobs; Playwright snapshot tier skipped | ~12 min |
-| Styling changes (`_sass/`, `assets/`, `_layouts/`, `_includes/`, `test/visual/`) | All jobs incl. Playwright snapshot tier | ~15 min |
-| Docker changes | detect-changes, quality-checks, integration | ~8 min |
+The `quality-checks` job must ALWAYS run (`if: always() && …`) — it is the
+single required status check on `main`, and a required-but-skipped check would
+deadlock docs-only PRs. `lint-workflows.yml` pins that invariant.
 
-#### Playwright tiers in the `test` job:
-- **Smoke** — runs on every code-change PR (CSS load, Bootstrap tokens, layout chrome, behavioral DOM, a11y component checks). Failures upload `test/visual-results/` as a `playwright-smoke` artifact (14-day retention).
-- **Snapshots** — path-filtered to styling changes; pixel screenshots of the homepage in each of the 9 theme skins. Failures upload as `playwright-snapshots`. Baselines live in `test/visual/snapshots/` (committed). Refresh with `./test/update-snapshots.sh` and commit.
+### `evidence-gate.yml` — Visual evidence gate
 
----
+**Triggers:** Pull Requests (all)
 
-### 2. `version-bump.yml` - Version Management
+Requires any PR that touches UI paths (`_sass/`, `_includes/`, `_layouts/`,
+`assets/css|js/`) to also ship a regression test (`test/visual/*.spec.js`) and
+before/after evidence (`test/visual/evidence/`). Opt out with the
+`skip-evidence` / `no-visual-change` label. Always reports a status so it can be
+a required check. See `.github/skills/visual-evidence/SKILL.md`.
 
-**Triggers:** Push to `main` (with commit analysis), Manual dispatch
+### `secret-scan.yml` — Secret scan
 
-Handles both automatic and manual version bumping with semantic versioning.
+**Triggers:** Pull Requests (all)
 
-#### Automatic Mode (Push to main):
-1. Analyzes commits since last tag using `scripts/analyze-commits.sh`
-2. Determines bump type based on commit messages:
-   - `feat:` → minor bump
-   - `fix:` → patch bump
-   - `BREAKING CHANGE:` → major bump
-3. Updates version files and CHANGELOG.md
-4. Creates and pushes tag (triggers `release.yml`)
+Fails a PR if credential shapes (Anthropic/GitHub tokens, private keys) appear
+in the merge-base diff or PR body. Fork-safe (read-only `pull_request` event).
 
-#### Manual Mode (workflow_dispatch):
-| Input | Options | Description |
-|-------|---------|-------------|
-| `version_type` | `patch`, `minor`, `major`, `auto` | Version bump type |
-| `skip_tests` | `true`/`false` | Skip test execution |
-| `dry_run` | `true`/`false` | Preview without changes |
+### `lint-workflows.yml` — Workflow lint
 
-#### Skip Conditions:
-- Commits containing "chore: bump version"
-- Commits from github-actions bot
-- Changes only in: CHANGELOG.md, version.rb, workflows, docs
+**Triggers:** PR/push touching `.github/workflows/**` or `.github/actions/**`
 
----
+Runs `actionlint` over the workflow definitions, plus a guard that the
+`quality-checks` job in `ci.yml` keeps its always-runs invariant.
 
-### 3. `release.yml` - Gem Publishing & GitHub Releases
+### `codeql.yml` — CodeQL Security Scanning
 
-**Triggers:** Tag push (`v*`), Manual dispatch
+**Triggers:** Push/PR to `main` (code paths only), Weekly schedule
 
-Unified release workflow that publishes to RubyGems and creates GitHub releases.
+CodeQL analysis for Actions, JS/TS, Python, and Ruby. Path-filtered to files
+those analyzers can actually read (not data/content YAML).
 
-#### Jobs:
-| Job | Description | Condition |
-|-----|-------------|-----------|
-| `validate` | Version consistency, test suite | Always |
-| `build` | Build gem, generate install script | After validate |
-| `publish-gem` | Publish to RubyGems | Tag push or manual with publish_gem |
-| `github-release` | Create GitHub release with assets | After build |
+### `install-matrix.yml` — Installer matrix
 
-#### Manual Dispatch Options:
-| Input | Type | Description |
-|-------|------|-------------|
-| `tag` | string | Tag to release (e.g., `v0.8.0`) |
-| `publish_gem` | boolean | Publish to RubyGems |
-| `draft` | boolean | Create as draft release |
-| `prerelease` | boolean | Mark as prerelease |
+**Triggers:** PRs touching installer paths, Weekly schedule, Manual dispatch
 
-#### Environment Requirements:
-- **`production`** environment approval for RubyGems publishing
-- **`RUBYGEMS_API_KEY`** secret for gem publishing
+Validates the modular installer across OS × Ruby (`matrix`), the README
+`curl | bash` one-liner (`curl-bash-bootstrap`), and `install doctor`. No push
+trigger: `main` is protected, so every change already ran this on its PR.
 
----
+### `test-latest.yml` — Latest-dependency canary + Docker image publish
 
-### 4. `test-latest.yml` - Latest Dependency Canary
+**Triggers:** Push to `main` (code/docker paths), Daily schedule, Manual dispatch
 
-**Triggers:** Push/PR to `main`, Daily schedule, Manual dispatch
+Zero-pin strategy: builds the Docker image with the latest resolved
+dependencies (no lockfile), runs validation + Jekyll build + RSpec +
+HTMLProofer, and on success publishes an immutable image tag
+(`date-sha`) plus `:latest` to Docker Hub. Intended to **fail** when an
+upstream gem breaks (canary behavior). Deliberately not run on PRs — PR
+validation happens in `ci.yml` against the pinned lockfile.
 
-Builds with the latest resolved dependencies (no pins), runs a Docker-based validation + test suite, and publishes an immutable Docker tag on success.
+## Release & Dependencies
 
-Notes:
-- This workflow is intended to **fail** if RSpec or HTMLProofer fails (canary behavior).
+### `release.yml` — release-please pipeline
 
----
+**Triggers:** Push to `main`
 
-### 5. `update-dependencies.yml` - Automated Gemfile.lock Updates
+The canonical release flow. Conventional Commits drive
+[release-please](https://github.com/googleapis/release-please) (reusable
+workflows in `bamr87/.github`): it opens/updates a "chore(main): release X.Y.Z"
+PR that bumps `lib/jekyll-theme-zer0/version.rb`, `package.json`, and
+`CHANGELOG.md`. Merging that PR tags `vX.Y.Z`, creates the GitHub Release, and
+the `publish` job builds the gem and pushes it to RubyGems.
+`./scripts/bin/release` remains a manual fallback.
+
+Requires: `RUBYGEMS_API_KEY` secret (publish), shared workflow definitions in
+`bamr87/.github`, config in `release-please-config.json`.
+
+### `update-dependencies.yml` — Automated Gemfile.lock updates
 
 **Triggers:** Weekly schedule, Manual dispatch
 
-Runs `bundle update` and opens an automated PR for review.
+Runs `bundle update` and opens an automated PR for review. Complements
+`.github/dependabot.yml`, which only manages GitHub Actions versions.
 
----
+### `sync.yml` — Data-file mirrors
 
-### 6. `convert-notebooks.yml` - Notebook Conversion
+**Triggers:** Push to `main` / PRs touching `_data/backlog.yml`,
+`_data/roadmap.yml`, or their scripts
 
-**Triggers:** `.ipynb` changes (push/PR), Manual dispatch
+- `backlog`: `_data/backlog.yml` → GitHub Issues (`scripts/sync-backlog.rb`);
+  PRs validate the schema only.
+- `roadmap`: `_data/roadmap.yml` → README roadmap section; PRs fail if stale,
+  pushes regenerate via an automated PR.
 
-Converts notebooks to Jekyll-friendly Markdown and (on push events) commits/pushes the converted artifacts.
+### `convert-notebooks.yml` — Notebook conversion
 
----
+**Triggers:** `.ipynb` changes under `pages/_notebooks/` (push/PR), Manual dispatch
 
-### 7. `codeql.yml` - CodeQL Security Scanning
+Converts notebooks to Jekyll-friendly Markdown. PRs get a dry-run preview;
+pushes to `main` open a `chore/convert-notebooks` PR with the converted files
+(CI on that PR validates them).
 
-**Triggers:** Push/PR to `main` (code file changes only), Weekly schedule
+### `deploy-chat-proxy.yml` — AI chat proxy deploy
 
-Runs CodeQL analysis for Actions, JS/TS, Python, and Ruby. Path-filtered on push/PR to skip when only docs/content change.
+**Triggers:** Push to `main` touching `templates/deploy/chat-proxy/`, Manual dispatch
 
----
+Deploys the AI-chat Cloudflare Worker via `wrangler-action`. Requires
+`CLOUDFLARE_API_TOKEN`, `CLOUDFLARE_ACCOUNT_ID`, `ANTHROPIC_API_KEY`.
+
+## Automation & AI Pipeline
+
+### `ai-content-review.yml` — Content & Docs Review
+
+**Triggers:** PRs touching `pages/**/*.md` or `docs/**`, Manual dispatch
+
+Two tiers plus docs validation: (1) deterministic SEO/quality checks
+(`scripts/content-review.rb`, fork-safe, posts a sticky comment); (2) the
+Claude Code content-reviewer agent (only when `ANTHROPIC_API_KEY` is set and
+content actually changed); (3) front-matter, internal-link, and markdownlint
+jobs (formerly `docs-validate.yml`).
+
+### `issue-autopilot.yml` — Issue autopilot
+
+**Triggers:** Weekly schedule, Manual dispatch, `autopilot:go` label
+
+One bounded pass of the autonomous issue pipeline: gate → triage (label/route
+open issues) → verify-close (close human issues already fixed on `main`,
+CI-gated) → resolve (one docs batch → one `auto:issue` PR). OFF by default
+behind `ISSUE_AUTOPILOT_ENABLED` (+ per-lane vars). See
+`docs/systems/continuous-evolution.md`.
+
+### `issue-pr-auto-merge.yml` — Issue PR auto-merge
+
+**Triggers:** `pull_request_target` on labeled/updated PRs
+
+Squash-merges same-repo `auto:issue` PRs once all checks are green, with a
+merge-time diff re-classification (docs/pages only — the smuggle guard). OFF by
+default behind `ISSUE_AUTOMERGE_ENABLED`.
+
+### `auto-merge.yml` — Auto-merge low-risk PRs
+
+**Triggers:** `pull_request_target` on labeled/updated PRs
+
+Enables GitHub native auto-merge for PRs labeled `auto-merge`, after a denylist
+check that blocks version/release/CI/plugin/script files. Required checks
+(including `evidence-gate`) remain the actual gate.
+
+### `ci-self-repair.yml` — CI self-repair
+
+**Triggers:** `workflow_run` completion of the Comprehensive CI Pipeline
+
+For failed PR runs where the PR opted in via the `auto-fix` label: runs Claude
+Code headless to diagnose and push a fix, bounded by a retry budget; otherwise
+drafts the PR with `agent-hold`. Never touches CODEOWNERS-protected paths.
+
+### `milestone-assign.yml` — Milestone assignment
+
+**Triggers:** `pull_request_target` (closed)
+
+Assigns merged PRs to the milestone when exactly one is open; otherwise no-op.
+
+### `giscus-digest.yml` — Giscus comment digest
+
+**Triggers:** Weekly schedule, Manual dispatch
+
+Read-only digest of Giscus-backed GitHub Discussions to the job summary.
 
 ## Gate Coverage — What Enforces What
 
-The "controls" contract for the Zer0-Mistake Quality Framework (roadmap v1.13):
-every quality gate a contributor can run locally must be enforced somewhere in
-CI, and warn-only gates must be temporary and tracked in the backlog.
+Every quality gate a contributor can run locally must be enforced somewhere in
+CI; warn-only gates must be temporary and tracked in the backlog.
 
 | Quality gate | Local command | CI enforcement | Trigger |
 |---|---|---|---|
-| Quick preflight (files, versions, YAML, config contract) | `./scripts/bin/validate --quick` | `ci.yml` → `fast-checks` | PR + push (code changes) |
+| version.rb ↔ Gemfile.lock consistency | `./scripts/bin/validate --quick` | `ci.yml` → `quality-checks` | PR + push (always) |
+| Quick preflight (files, versions, YAML, config contract) | `./scripts/bin/validate --quick` | `ci.yml` → `quality-checks` | PR + push (code changes) |
 | Lint (markdown, YAML), frontmatter | `markdownlint` / `yamllint` | `ci.yml` → `quality-checks` | PR + push (always) |
-| Theme suites (core, deployment, quality, installation, installer, site_generation, obsidian) | `./test/test_runner.sh --suites <list>` | `ci.yml` → `test` | PR + push (code changes) |
+| Theme suites (core, deployment, quality, installation, installer, site_generation, obsidian, features) | `./test/test_runner.sh --suites <list>` | `ci.yml` → `test` | PR + push (code changes) |
 | Script suites (lib unit, theme validate, integration, installer e2e) | `./scripts/bin/test` | `ci.yml` → `test` | PR + push (code changes) |
 | Playwright smoke tier | `./test/test_runner.sh --suites playwright` | `ci.yml` → `test` | PR + push (code changes) |
-| Playwright snapshot tier | `./test/test_runner.sh --suites playwright_snapshots` | `ci.yml` → `test` — ⚠ warn-only until baselines refresh (backlog T-013) | PR + push (styling changes) |
+| Playwright snapshot tier | `./test/test_runner.sh --suites playwright_snapshots` | `ci.yml` → `snapshots` | PR + push (styling changes) |
+| Visual evidence for UI changes | `.github/skills/visual-evidence/` | `evidence-gate.yml` | PR (always; self-scoping) |
 | Gem build + install | `./scripts/build` | `ci.yml` → `build` | PR + push (code changes) |
 | Docker boot + critical pages | `docker compose up` | `ci.yml` → `integration` | PR + push (code or docker changes) |
-| Roadmap ↔ README ↔ version consistency | `./scripts/generate-roadmap.sh --check` / `--validate` | `sync.yml` → `roadmap` | PR (check) + push to main (regenerate) |
+| Roadmap ↔ README ↔ version consistency | `ruby scripts/generate-roadmap.rb --check` | `sync.yml` → `roadmap` | PR (check) + push to main (regenerate) |
 | Backlog schema | `ruby scripts/sync-backlog.rb --check` | `sync.yml` → `backlog` | PR (check) + push to main (sync issues) |
-| Docs front matter + internal links + markdownlint | `scripts/docs/lint-frontmatter.sh` / `check-links.sh` / `markdownlint` | `ai-content-review.yml` (Content & Docs Review) | PR (docs/content changes) |
-| Latest-dependency canary (unpinned build + HTMLProofer) | — | `test-latest.yml` | Daily schedule + PR/push |
-| Security scanning (CodeQL) | — | `codeql.yml` | PR + push (code changes) + weekly |
-| Installer cross-platform matrix | `test/test_install_*.sh` | `install-matrix.yml` | PR (installer paths) + manual |
-
-Known intentional gaps (tracked): snapshot tier warn-only (T-013), docs
-link-check warn-only (T-014), locale-independence guard not yet in CI (T-015).
+| Docs front matter + internal links + markdownlint | `scripts/docs/lint-frontmatter.sh` / `check-links.sh` / `markdownlint` | `ai-content-review.yml` | PR (docs/content changes) |
+| Secret shapes in diff/PR body | — | `secret-scan.yml` | PR (always) |
+| Workflow definitions (actionlint + invariants) | `actionlint` | `lint-workflows.yml` | PR + push (workflow changes) |
+| Latest-dependency canary (unpinned build + HTMLProofer) | — | `test-latest.yml` | Daily schedule + push to main |
+| Security scanning (CodeQL) | — | `codeql.yml` | PR + push (code paths) + weekly |
+| Installer cross-platform matrix | `./scripts/bin/test install` | `install-matrix.yml` | PR (installer paths) + weekly |
 
 ## Workflow Dependencies
 
 ```yaml
 # Required Secrets
-GITHUB_TOKEN       # Automatically provided
-RUBYGEMS_API_KEY   # Required for gem publishing
+GITHUB_TOKEN            # Automatically provided
+RUBYGEMS_API_KEY        # Gem publishing (release.yml → bamr87/.github publish)
+DOCKER_USERNAME/TOKEN   # Docker Hub publish (test-latest.yml)
+ANTHROPIC_API_KEY       # AI tiers (ai-content-review, ci-self-repair, autopilot)
+CLAUDE_CODE_OAUTH_TOKEN # Preferred Claude credential for the issue autopilot
+CLOUDFLARE_API_TOKEN    # Chat proxy deploy
+CLOUDFLARE_ACCOUNT_ID   # Chat proxy deploy
 
-# Required Environment
-production         # For publish-gem job approval gate
+# Opt-in repository variables (autonomous pipeline, all default OFF)
+ISSUE_AUTOPILOT_ENABLED / ISSUE_RESOLVE_ENABLED / ISSUE_AUTOCLOSE_ENABLED /
+ISSUE_VERIFY_CLOSE_ENABLED / ISSUE_AUTOMERGE_ENABLED
 ```
 
 ## Composite Actions Used
 
-All workflows use shared composite actions from `.github/actions/`:
+Shared composite actions live in `.github/actions/`:
 
-- `setup-ruby` - Ruby environment setup with bundler cache
-- `configure-git` - Git configuration for automated commits
-- `test-suite` - Comprehensive test execution
-- `quality-checks` - Code quality validation
+- `setup-ruby` — Ruby + non-frozen bundle install with caching (path-gem safe)
+- `quality-checks` — linting, markdown, and structure validation
+- `test-suite` — theme test suite execution
+- `playwright-tests` — Playwright tier runner with artifact upload
+- `configure-git` — git identity for automated commits
+- `claude-run` — the universal Claude Code step for the issue autopilot
 
-See [`.github/actions/README.md`](../actions/README.md) for action documentation.
+See [`.github/actions/README.md`](../actions/README.md).
 
 ## Local Development
 
-To test workflows locally before pushing:
-
 ```bash
 # Canonical preflight validation
-./scripts/validate --quick
-./scripts/validate --start-docker
-
-# Preview version bump
-./scripts/release patch --dry-run
-
-# Build gem locally
-./scripts/build
+./scripts/bin/validate --quick
 
 # Run tests
-./scripts/bin/test --verbose
+./scripts/bin/test
 
-# Analyze commits for version bump type
-./scripts/analyze-commits.sh HEAD~5..HEAD
+# Build gem locally
+./scripts/bin/build
+
+# Preview a manual release (fallback; release-please is canonical)
+./scripts/bin/release patch --dry-run
+
+# Lint the workflows themselves
+actionlint
+yamllint -c .github/config/.yamllint.yml .github/workflows/
 ```
 
 ## Troubleshooting
 
-### Version bump not triggering
-- Check that commit doesn't contain "chore: bump version"
-- Verify paths-ignore isn't matching your changes
-- Ensure commit author isn't "github-actions"
-
-### Release workflow not starting
-- Verify tag follows `v*` pattern (e.g., `v0.8.0`)
-- Check that version in `lib/jekyll-theme-zer0/version.rb` matches tag
+### Release PR not appearing
+- release-please only reacts to Conventional Commits (`feat:`, `fix:`, …) on `main`
+- Check the `release.yml` run for errors from the shared `bamr87/.github` workflows
 
 ### Gem publish failing
 - Verify `RUBYGEMS_API_KEY` secret is set
-- Check production environment approval
-- Ensure gem version doesn't already exist on RubyGems
+- A `version.rb` bump must re-lock `Gemfile.lock` and `package-lock.json` in the
+  same change — the frozen `bundle install` in the publish job fails otherwise
+  (the `quality-checks` guard should have caught this on the release PR)
 
 ### CI failures
-- Check individual job logs for specific errors
-- Run quick validation locally: `./scripts/validate --quick`
+- Run quick validation locally: `./scripts/bin/validate --quick`
 - Run tests locally: `./scripts/bin/test`
-- Validate gem: `./scripts/build && gem spec jekyll-theme-zer0-*.gem`
+- For snapshot failures, refresh baselines with `./test/update-snapshots.sh`

--- a/.github/workflows/ai-content-review.yml
+++ b/.github/workflows/ai-content-review.yml
@@ -46,7 +46,23 @@ jobs:
       pull-requests: write   # post the sticky review comment
     outputs:
       has_content: ${{ steps.review.outputs.has_content }}
+      ai_enabled: ${{ steps.ai-gate.outputs.enabled }}
     steps:
+      # Gate for the Claude Code tier — a step here rather than a separate job
+      # (secrets aren't readable in job-level `if:`, but a one-liner step doesn't
+      # justify its own runner).
+      - name: Check AI availability
+        id: ai-gate
+        env:
+          KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        run: |
+          if [ -n "$KEY" ]; then
+            echo "enabled=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::ANTHROPIC_API_KEY not set — skipping the Claude Code review tier."
+          fi
+
       - name: Checkout
         uses: actions/checkout@v7
         with:
@@ -99,32 +115,12 @@ jobs:
           if-no-files-found: ignore
 
   # ---------------------------------------------------------------------------
-  # Gate — is the Claude Code tier available? (secret present, not a fork PR)
-  # ---------------------------------------------------------------------------
-  gate:
-    name: Check AI availability
-    runs-on: ubuntu-latest
-    outputs:
-      ai_enabled: ${{ steps.check.outputs.enabled }}
-    steps:
-      - id: check
-        env:
-          KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-        run: |
-          if [ -n "$KEY" ]; then
-            echo "enabled=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "enabled=false" >> "$GITHUB_OUTPUT"
-            echo "::notice::ANTHROPIC_API_KEY not set — skipping Claude Code content review (deterministic tier still ran)."
-          fi
-
-  # ---------------------------------------------------------------------------
   # Tier 2 — Claude Code content-reviewer agent
   # ---------------------------------------------------------------------------
   ai-review:
     name: Claude Code content review
-    needs: [deterministic-review, gate]
-    if: ${{ github.event_name == 'pull_request' && needs.gate.outputs.ai_enabled == 'true' && needs.deterministic-review.outputs.has_content == 'true' }}
+    needs: deterministic-review
+    if: ${{ github.event_name == 'pull_request' && needs.deterministic-review.outputs.ai_enabled == 'true' && needs.deterministic-review.outputs.has_content == 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:

--- a/.github/workflows/ci-self-repair.yml
+++ b/.github/workflows/ci-self-repair.yml
@@ -19,7 +19,10 @@ name: CI self-repair
 
 on:
   workflow_run:
-    workflows: ["Comprehensive CI Pipeline", "TEST (Latest Dependencies)"]
+    # Only PR-triggered runs are repairable (see the job `if` below), and ci.yml
+    # is the only PR-scoped candidate — test-latest.yml no longer runs on
+    # pull_request, so watching it here would never fire.
+    workflows: ["Comprehensive CI Pipeline"]
     types: [completed]
 
 permissions:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ env:
   # These are used for backwards compatibility testing
   # The test-latest.yml workflow uses actual latest versions
   RUBY_VERSION: '3.3'
-  NODE_VERSION: '18'
+  NODE_VERSION: '20'
   # Required for jekyll-github-metadata gem during CI builds
   # Uses repository variable if set, otherwise falls back to github.repository
   PAGES_REPO_NWO: ${{ vars.PAGES_REPO_NWO || github.repository }}
@@ -51,8 +51,6 @@ jobs:
   detect-changes:
     name: Detect Changes
     runs-on: ubuntu-latest
-    # Always run on dispatch; filter on push/PR
-    if: github.event_name == 'workflow_dispatch' || github.event_name == 'push' || github.event_name == 'pull_request'
     timeout-minutes: 3
     outputs:
       code: ${{ steps.filter.outputs.code }}
@@ -112,48 +110,25 @@ jobs:
             echo "🔧 Code/docker changes detected — running full pipeline"
           fi
 
-  # Fast feedback job for quick validation
-  fast-checks:
-    name: Fast Checks
-    runs-on: ubuntu-latest
-    needs: detect-changes
-    # Skip on docs-only changes (no Ruby/gem code changed)
-    if: |
-      always() &&
-      needs.detect-changes.result == 'success' &&
-      (needs.detect-changes.outputs.code == 'true' || github.event_name == 'workflow_dispatch')
-    timeout-minutes: 5
-
-    steps:
-      - name: Checkout Repository
-        uses: actions/checkout@v7
-
-      - name: Setup Ruby Environment
-        uses: ./.github/actions/setup-ruby
-        with:
-          ruby-version: ${{ env.RUBY_VERSION }}
-          install-system-deps: false
-
-      - name: Run Quick Validator
-        run: ./scripts/bin/validate --quick
-
-  # Quality control checks — always runs (covers markdown linting)
+  # Quality control checks — always runs (covers markdown linting). Also hosts
+  # the quick validator for code changes (formerly its own fast-checks job —
+  # merged here since both jobs did a full Ruby setup and ran sequentially).
   quality-checks:
     name: Quality Control
     runs-on: ubuntu-latest
-    needs: [detect-changes, fast-checks]
+    needs: detect-changes
     # Always run quality checks (markdown lint is relevant for docs-only PRs)
     if: always() && needs.detect-changes.result == 'success' && !cancelled()
-    timeout-minutes: 10
+    timeout-minutes: 15
 
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v7
 
       # Always-running guard: version.rb must equal the gem version pinned in
-      # Gemfile.lock. Lives in this job (not the path-filtered fast-checks) so it
-      # gates every PR — including release PRs that bump version.rb without
-      # re-locking, the drift that left the lock at 1.19.1 vs version.rb 1.19.0.
+      # Gemfile.lock. Runs unconditionally (not path-filtered) so it gates every
+      # PR — including release PRs that bump version.rb without re-locking, the
+      # drift that left the lock at 1.19.1 vs version.rb 1.19.0.
       # Pure bash (no Ruby setup needed); mirrors validate_version_consistency
       # in scripts/bin/validate.
       - name: Version ↔ Gemfile.lock consistency
@@ -177,17 +152,22 @@ jobs:
           check-markdown: true
           fix-formatting: ${{ inputs.fix_markdown }}
 
+      # Quick preflight validation — code changes only (Ruby + gems are already
+      # set up by the quality-checks composite above).
+      - name: Run Quick Validator
+        if: needs.detect-changes.outputs.code == 'true' || github.event_name == 'workflow_dispatch'
+        run: ./scripts/bin/validate --quick
+
   # Comprehensive testing across Ruby versions
   test:
     name: Test Suite (Ruby ${{ matrix.ruby }})
     runs-on: ubuntu-latest
-    needs: [detect-changes, fast-checks, quality-checks]
+    needs: [detect-changes, quality-checks]
     # Skip when only docs/content changed
     if: |
       always() &&
       needs.detect-changes.outputs.code == 'true' &&
-      needs.fast-checks.result == 'success' &&
-      (needs.quality-checks.result == 'success' || needs.quality-checks.result == 'skipped')
+      needs.quality-checks.result == 'success'
     timeout-minutes: 25
     strategy:
       fail-fast: false
@@ -311,7 +291,7 @@ jobs:
   build:
     name: Build & Validate
     runs-on: ubuntu-latest
-    needs: [detect-changes, test, quality-checks]
+    needs: [detect-changes, test]
     # Skip when only docs/content changed
     if: |
       always() &&

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -5,6 +5,10 @@ name: CodeQL Security Scanning
 permissions:
   contents: read
 
+# Path scope: the analyzable languages (js/ts/rb/py) plus the Actions
+# definitions for the `actions` language. Deliberately NOT '**.yml' — data/
+# content/config YAML contains nothing CodeQL analyzes, and that glob used to
+# fan out all four language analyses on every _data/_config change.
 on:
   push:
     branches: [ "main" ]
@@ -13,8 +17,6 @@ on:
       - '**.ts'
       - '**.rb'
       - '**.py'
-      - '**.yml'
-      - '**.yaml'
       - '_plugins/**'
       - 'scripts/**'
       - 'lib/**'
@@ -27,8 +29,6 @@ on:
       - '**.ts'
       - '**.rb'
       - '**.py'
-      - '**.yml'
-      - '**.yaml'
       - '_plugins/**'
       - 'scripts/**'
       - 'lib/**'

--- a/.github/workflows/convert-notebooks.yml
+++ b/.github/workflows/convert-notebooks.yml
@@ -166,86 +166,8 @@ jobs:
           
           if [[ "${{ steps.check_changes.outputs.has_changes }}" == "true" ]]; then
             echo "" >> $GITHUB_STEP_SUMMARY
-            echo "✅ **Converted files committed and pushed**" >> $GITHUB_STEP_SUMMARY
+            echo "✅ **Converted files committed to the chore/convert-notebooks PR**" >> $GITHUB_STEP_SUMMARY
           elif [[ "${{ github.event_name }}" != "pull_request" ]]; then
             echo "" >> $GITHUB_STEP_SUMMARY
             echo "ℹ️ **No new conversions needed**" >> $GITHUB_STEP_SUMMARY
           fi
-
-  validate-converted:
-    name: Validate Converted Markdown
-    needs: convert-notebooks
-    runs-on: ubuntu-latest
-    if: github.event_name != 'pull_request'
-    timeout-minutes: 5
-    permissions:
-      contents: read
-
-    steps:
-      - name: Checkout Repository (after conversion)
-        uses: actions/checkout@v7
-        with:
-          ref: ${{ github.ref_name }}
-
-      - name: Setup Ruby Environment
-        uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: '3.3'
-          bundler-cache: true
-
-      - name: Validate Converted Markdown
-        run: |
-          echo "::group::Checking Converted Markdown Files"
-          
-          # Check if converted markdown files exist
-          if compgen -G "pages/_notebooks/*.md" > /dev/null; then
-            echo "✅ Found converted markdown files:"
-            ls -lh pages/_notebooks/*.md
-            
-            # Validate front matter
-            echo ""
-            echo "Validating front matter..."
-            for file in pages/_notebooks/*.md; do
-              if head -n 1 "$file" | grep -q "^---$"; then
-                echo "✅ $file has front matter"
-              else
-                echo "⚠️  $file missing front matter"
-              fi
-            done
-          else
-            echo "ℹ️ No converted markdown files found"
-          fi
-          
-          echo "::endgroup::"
-
-      - name: Check for Broken Images
-        run: |
-          echo "::group::Checking for Broken Image References"
-          
-          if compgen -G "pages/_notebooks/*.md" > /dev/null; then
-            for file in pages/_notebooks/*.md; do
-              echo "Checking $file..."
-              
-              # Extract image paths from markdown
-              grep -oP '!\[.*?\]\(\K[^)]+' "$file" | while read -r img_path; do
-                # Remove leading slash and check if file exists
-                img_file="${img_path#/}"
-                if [[ ! -f "$img_file" ]]; then
-                  echo "⚠️  Missing image: $img_path (referenced in $file)"
-                fi
-              done || true
-            done
-          fi
-          
-          echo "::endgroup::"
-
-      - name: Summary
-        if: always()
-        run: |
-          echo "### Validation Summary" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "**Markdown Files:**" >> $GITHUB_STEP_SUMMARY
-          find pages/_notebooks -name "*.md" -type f | wc -l >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "**Image Files:**" >> $GITHUB_STEP_SUMMARY
-          find assets/images/notebooks -type f 2>/dev/null | wc -l || echo "0" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/install-matrix.yml
+++ b/.github/workflows/install-matrix.yml
@@ -6,20 +6,10 @@ name: Install Matrix
 #   - curl-bash-bootstrap:  the README one-liner (curl | bash) remote install
 #   - doctor:               the `install doctor` environment diagnostic
 # Triggered on PRs that touch installer code or weekly to catch drift.
+# (No push trigger: main is protected, so every change already ran this matrix
+# on its PR; the weekly schedule catches environment/tooling drift.)
 
 on:
-  push:
-    branches: [main]
-    paths:
-      - install.sh
-      - scripts/bin/install
-      - scripts/lib/install/**
-      - scripts/platform/**
-      - templates/profiles/**
-      - templates/deploy/**
-      - test/test_install_*.sh
-      - test/lib/install_test_utils.sh
-      - .github/workflows/install-matrix.yml
   pull_request:
     paths:
       - install.sh

--- a/.github/workflows/lint-workflows.yml
+++ b/.github/workflows/lint-workflows.yml
@@ -50,10 +50,12 @@ jobs:
       - name: Guard — "Quality Control" must always run
         run: |
           # Quality Control is the SINGLE required status check on `main` and holds
-          # the version.rb<->Gemfile.lock consistency guard. It must run even when
-          # fast-checks is skipped (docs-only PRs) — a required-but-skipped check
-          # would deadlock the repo's highest-volume PR type. This pins that
-          # invariant so a future edit can't silently re-introduce the deadlock.
+          # the version.rb<->Gemfile.lock consistency guard. It must run even on
+          # docs-only PRs (where the code-path-filtered jobs are skipped) — a
+          # required-but-skipped check would deadlock the repo's highest-volume PR
+          # type. This pins that invariant so a future edit can't silently
+          # re-introduce the deadlock (e.g. by re-splitting a path-filtered
+          # fast-checks job out of quality-checks and gating on it).
           # See .github/instructions/version-control.instructions.md (Release model).
           python3 - <<'PY'
           import sys, yaml
@@ -64,9 +66,9 @@ jobs:
           if not cond:
               problems.append("quality-checks job or its `if:` is missing")
           if 'always()' not in cond:
-              problems.append("`if:` must contain always() so it runs when fast-checks is skipped")
+              problems.append("`if:` must contain always() so it runs on docs-only PRs")
           if 'fast-checks' in cond:
-              problems.append("`if:` must NOT gate on fast-checks result")
+              problems.append("`if:` must NOT gate on a path-filtered job's result")
           if problems:
               print("::error file=.github/workflows/ci.yml::Quality Control always-runs "
                     "invariant broken: " + "; ".join(problems))

--- a/.github/workflows/test-latest.yml
+++ b/.github/workflows/test-latest.yml
@@ -22,28 +22,15 @@ permissions:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  cancel-in-progress: false
 
+# NOTE: deliberately NOT triggered on pull_request — PRs are validated by ci.yml
+# against the pinned (merge-relevant) dependencies. Running the whole zero-pin
+# Docker pipeline per PR duplicated that gate at ~2x the cost, and a latest-deps
+# failure is upstream drift, not something a PR author can act on. This canary
+# runs on main pushes + the daily schedule instead.
 on:
   push:
-    branches: [main]
-    paths:
-      - '_layouts/**'
-      - '_includes/**'
-      - '_sass/**'
-      - '_plugins/**'
-      - 'assets/**'
-      - 'lib/**'
-      - '*.gemspec'
-      - 'Gemfile*'
-      - 'Rakefile'
-      - 'scripts/**'
-      - 'test/**'
-      - '_config*.yml'
-      - 'docker/**'
-      - 'docker-compose*.yml'
-      - 'Dockerfile'
-  pull_request:
     branches: [main]
     paths:
       - '_layouts/**'
@@ -186,15 +173,7 @@ jobs:
           fi
           echo "💾 Saving image: $IMAGE_ID"
           docker save -o /tmp/jekyll-image.tar $IMAGE_ID
-      
-      - name: Restore Original Gemfile
-        if: always()
-        run: |
-          if [ -f Gemfile.original ]; then
-            mv Gemfile.original Gemfile
-            echo "✅ Restored original Gemfile"
-          fi
-          
+
       - name: Upload Docker Image Artifact
         uses: actions/upload-artifact@v7
         with:

--- a/README.md
+++ b/README.md
@@ -757,11 +757,11 @@ All workflows live under [`.github/workflows/`](.github/workflows/).
 
 | # | Workflow | File | Trigger | Purpose |
 |---|----------|------|---------|---------|
-| 1 | **Comprehensive CI Pipeline** | [`ci.yml`](.github/workflows/ci.yml) | push / PR / dispatch | Detect changes → fast checks → quality control → matrix test suite → integration tests → build & validate |
-| 2 | **TEST (Latest Dependencies)** | [`test-latest.yml`](.github/workflows/test-latest.yml) | daily schedule / push / PR / dispatch | Zero-pin Docker build with bleeding-edge gems; tests then promotes passing images to Docker Hub |
+| 1 | **Comprehensive CI Pipeline** | [`ci.yml`](.github/workflows/ci.yml) | push / PR / dispatch | Detect changes → quality control (incl. quick preflight) → matrix test suite → integration tests → build & validate |
+| 2 | **TEST (Latest Dependencies)** | [`test-latest.yml`](.github/workflows/test-latest.yml) | daily schedule / push / dispatch | Zero-pin Docker build with bleeding-edge gems; tests then promotes passing images to Docker Hub |
 | 3 | **Release** | [`release.yml`](.github/workflows/release.yml) | push to `main` | release-please opens a release PR from Conventional Commits; merging it tags `vX.Y.Z` and publishes the gem to [RubyGems](https://rubygems.org/gems/jekyll-theme-zer0) |
 | 4 | **Update Dependencies** | [`update-dependencies.yml`](.github/workflows/update-dependencies.yml) | weekly schedule | Refreshes `Gemfile.lock` to latest compatible versions and opens an automated PR |
-| 5 | **CodeQL Security Scanning** | [`codeql.yml`](.github/workflows/codeql.yml) | push / PR on code paths + weekly | Static security analysis across Ruby, JavaScript/TypeScript, Python, Actions, and YAML |
+| 5 | **CodeQL Security Scanning** | [`codeql.yml`](.github/workflows/codeql.yml) | push / PR on code paths + weekly | Static security analysis across Ruby, JavaScript/TypeScript, Python, and Actions |
 | 6 | **Content & Docs Review** | [`ai-content-review.yml`](.github/workflows/ai-content-review.yml) | PR on docs/content | Deterministic SEO/quality review + optional Claude agent + docs front matter, internal-link, and markdownlint checks |
 | 7 | **Convert Jupyter Notebooks** | [`convert-notebooks.yml`](.github/workflows/convert-notebooks.yml) | push to `pages/_notebooks/**.ipynb` | Auto-converts `.ipynb` → Jekyll-friendly Markdown with extracted images |
 | 8 | **Sync** | [`sync.yml`](.github/workflows/sync.yml) | push affecting `_data/backlog.yml` or `_data/roadmap.yml` | Mirrors the backlog to GitHub Issues and regenerates the README roadmap section |

--- a/docs/development/testing.md
+++ b/docs/development/testing.md
@@ -25,7 +25,7 @@ asset checks.
 # otherwise falls back to local bundle exec.
 ./scripts/validate
 
-# Fast host-only checks used by CI fast-checks
+# Fast host-only checks used by the CI quality-checks job
 ./scripts/validate --quick
 
 # Start Docker if needed and include optional test layers

--- a/docs/systems/continuous-evolution.md
+++ b/docs/systems/continuous-evolution.md
@@ -118,7 +118,7 @@ whether or not the cloud-routine runtime can delegate to named subagents.
 
 The implement loop verifies **before** opening a PR, but local-green ≠ CI-green.
 `.github/workflows/ci-self-repair.yml` closes that gap: on a **failed** CI run
-(`Comprehensive CI Pipeline` / `TEST (Latest Dependencies)`) for a PR that opted
+(`Comprehensive CI Pipeline`) for a PR that opted
 in via the **`auto-fix`** label, it runs Claude Code headless
 ([`/ci-self-repair`](../../.github/prompts/ci-self-repair.prompt.md)) to diagnose
 and fix the failing check **by root cause**, verify locally, and push — bounded by


### PR DESCRIPTION
## Description

Full review of the 19 workflows under `.github/workflows/` with consolidation of redundant jobs, removal of obsolete steps, and trigger cleanup. Net effect: fewer runners and less wall-clock per PR, no loss of gate coverage.

**Per-PR compute reductions**

- **`test-latest.yml`**: dropped the `pull_request` trigger. Every code PR was running the entire zero-pin Docker pipeline (~30 min: fresh dependency resolution + image build + Jekyll/RSpec/HTMLProofer) *in addition to* full CI. PRs merge against the pinned lockfile — that's what `ci.yml` validates — and a latest-deps failure is upstream drift a PR author can't act on. The canary keeps its daily schedule, main-push, and dispatch triggers (image publishing is unaffected; it was already main-only). Also removed the dead `Restore Original Gemfile` step — `Gemfile.original` is never created anywhere.
- **`ci.yml`**: merged the `fast-checks` job into `quality-checks`. Both did a full checkout + Ruby setup + bundle install and ran strictly back-to-back; the quick validator (`./scripts/bin/validate --quick`) is now a step inside Quality Control, gated on code changes. One fewer runner and one fewer serialization hop per PR. The Quality Control always-runs invariant (single required check; must not gate on path-filtered jobs) is preserved and still pinned by the `lint-workflows.yml` guard. Also: removed the always-true `if:` on `detect-changes`, simplified `build`'s `needs`, bumped EOL Node 18 → 20.
- **`ai-content-review.yml`**: folded the `gate` job — a whole runner whose only work was `[ -n "$KEY" ]` — into `deterministic-review` as a step output.
- **`codeql.yml`**: removed `**.yml` / `**.yaml` from the path triggers. Those globs fanned out all four language analyses on every `_data`/`_config`/content YAML change, none of which CodeQL analyzes. Workflow/action definitions stay explicitly covered for the `actions` language.
- **`install-matrix.yml`**: dropped the push-to-main trigger. `main` is protected, so every change already ran the 10-job matrix on its PR; the weekly schedule still catches environment drift.

**Obsolete/dead code removed**

- **`convert-notebooks.yml`**: deleted the `validate-converted` job. Since conversion switched to opening a `chore/convert-notebooks` PR, this job checked out `main` — which never contains the new conversions — so it validated pre-existing files. The conversion PR's own CI is the real gate. (It also used `bundler-cache: true`, the known-broken frozen-mode path for this path-gem repo.)
- **`ci-self-repair.yml`**: removed `TEST (Latest Dependencies)` from the `workflow_run` watch list — self-repair only acts on PR-triggered runs, which test-latest no longer produces.

**Docs brought back in sync**

- **`.github/workflows/README.md`**: rewritten. It documented the deleted `version-bump.yml`, described `release.yml` as the pre-release-please pipeline, and omitted roughly half the current workflows (evidence-gate, secret-scan, auto-merge, issue-autopilot, etc.). Now covers all 19 with an updated gate-coverage table.
- Updated stale `fast-checks` / test-latest-on-PR references in the root `README.md`, `docs/development/testing.md`, and `docs/systems/continuous-evolution.md`.

**Kept as-is (reviewed, deliberate):** `update-dependencies.yml` (complements Dependabot, which only manages Actions), `sync.yml`, `secret-scan.yml`, `evidence-gate.yml`, `auto-merge.yml`, `issue-pr-auto-merge.yml`, `milestone-assign.yml`, `giscus-digest.yml`, `deploy-chat-proxy.yml`, `release.yml`, `issue-autopilot.yml`.

## Type

- [ ] `feat` — new feature
- [ ] `fix` — bug fix
- [ ] `docs` — documentation only
- [x] `refactor` / `perf` / `style`
- [ ] `test` — tests only
- [x] `chore` / `ci`

## Checklist

- [x] Conventional-commit title (`type(scope): subject`) — this drives the automated version bump
- [ ] `CHANGELOG.md` updated under `[Unreleased]` for user-visible changes — N/A: CI-infrastructure only, no user-visible theme change
- [x] Workflow definitions validated: `actionlint` clean (same ignore set as the `lint-workflows.yml` gate), all YAML parses, yamllint findings reduced (129 → 120, none introduced), Quality Control always-runs invariant verified
- [ ] Theme/layout/include/sass change → Jekyll build validated — N/A: no theme files touched
- [x] No version bump (`lib/jekyll-theme-zer0/version.rb` untouched — releases are automated)
- [ ] Backlog task status updated in `_data/backlog.yml` — N/A: not a backlog task

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QxcNbtQ4q4Cgvx4yqD8fZF

---
_Generated by [Claude Code](https://claude.ai/code/session_01QxcNbtQ4q4Cgvx4yqD8fZF)_