### PR TITLE
fix(test): repoint ZER0-003 to test_install_legacy_flags.sh (fixes red CI)

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -67,7 +67,7 @@ zer0-mistakes/
 │   ├── test_core.sh         # Core functionality tests
 │   ├── test_deployment.sh   # Deployment tests
 │   ├── test_quality.sh      # Code quality tests
-│   └── test_installation.sh # Installer tests
+│   └── test_installer.sh    # Modular installer tests
 ├── templates/               # Reusable content templates
 ├── docs/                    # Technical (MDX) documentation
 ├── _config.yml              # Production Jekyll configuration

--- a/.github/instructions/install.instructions.md
+++ b/.github/instructions/install.instructions.md
@@ -142,7 +142,7 @@ Use `log_info / log_success / log_warning / log_error` from `scripts/lib/common.
 | New profile | `./scripts/bin/install list-profiles` then `init --profile <slug> /tmp/test-<slug>` |
 | New deploy target | `./scripts/bin/install list-targets` then `deploy <target> /tmp/test-deploy-<target>` then verify generated YAML lints |
 | AI module | Test with `OPENAI_API_KEY` unset (must abort cleanly), with `ZER0_NO_AI=1` (must short-circuit), and with a mocked endpoint |
-| Anything | Run `./test/test_installation.sh` and ensure no new regressions |
+| Anything | Run `./test/test_installer.sh` and `./test/test_install_legacy_flags.sh` and ensure no new regressions |
 
 ## Bug patterns to avoid
 

--- a/.github/instructions/testing.instructions.md
+++ b/.github/instructions/testing.instructions.md
@@ -15,7 +15,7 @@ test/
 ├── test_core.sh           # Theme/Jekyll fundamentals
 ├── test_deployment.sh     # Build artifacts, gem packaging
 ├── test_quality.sh        # Lint, link check, frontmatter
-├── test_installation.sh   # install.sh end-to-end
+├── test_installer.sh      # Modular installer (profiles, deploy, AI)
 ├── test_obsidian.sh       # Obsidian plugin (Ruby + JS resolver)
 ├── test_playwright.sh     # Frontend (CSS, layout, behavior, snapshots)
 ├── update-snapshots.sh    # Refresh Linux snapshot baselines via Docker

--- a/README.md
+++ b/README.md
@@ -646,8 +646,8 @@ git commit -m "feat: add new component"
 ### Testing Commands
 
 ```bash
-# Quick validation
-./test/test_installation.sh
+# Quick validation (preflight)
+./scripts/validate --quick
 
 # Full test suite
 ./test/test_runner.sh --verbose

--- a/_data/features.yml
+++ b/_data/features.yml
@@ -1,7 +1,7 @@
 # zer0-mistakes Theme Features Registry
 # Comprehensive feature tracking for the zer0-mistakes Jekyll theme
 # Version: 1.25.0
-# Last Updated: 2026-07-03
+# Last Updated: 2026-07-08
 
 features:
   # ============================================================================
@@ -80,7 +80,7 @@ features:
       issue: null
     tests:
       - "test/test_installer.sh"
-      - "test/test_installation.sh"
+      - "test/test_install_legacy_flags.sh"
     references:
       script: "install.sh"
       cli: "scripts/bin/install"

--- a/docs/architecture/ui-components.md
+++ b/docs/architecture/ui-components.md
@@ -1628,7 +1628,7 @@ Routing lives in `test/test_runner.sh`. `--suites all` runs the six core suites;
 | `test_core.sh` | Theme file structure/syntax, Jekyll config + build process, core dependencies, basic integration |
 | `test_deployment.sh` | Local + remote install flows, Docker setup/serving, end-to-end deploy workflow (`--skip-docker`/`--skip-remote` honored) |
 | `test_quality.sh` | Security scanning, accessibility/WCAG, cross-platform compatibility, performance benchmarks |
-| `test_installation.sh` | Legacy `install.sh` CLI args, install modes (full/minimal), error handling, edge cases, upgrade + remote install |
+| `test_install_legacy_flags.sh` | Legacy `install.sh` flags (`-m`/`-f`/`--help`), install modes (full/minimal), error handling, and edge cases ported from the retired `test_installation.sh` |
 | `test_installer.sh` | Installer regression matrix — every install profile exits 0 with expected agent files + deploy artifacts (`--ai` tier needs `OPENAI_API_KEY`) |
 | `test_site_generation.sh` | Config-matrix generator: builds a site for each mode (full/minimal/remote_theme/gem) and validates generated content |
 | `test_obsidian.sh` | 3 layers: Ruby `obsidian_links.rb` unit tests, JS `obsidian-wiki-links.js` resolver tests, and a `jekyll build` smoke that asserts `assets/data/wiki-index.json` is well-formed |

--- a/features/features.yml
+++ b/features/features.yml
@@ -1,7 +1,7 @@
 # zer0-mistakes Theme Features Registry
 # Comprehensive feature tracking for the zer0-mistakes Jekyll theme
 # Version: 1.25.0
-# Last Updated: 2026-07-03
+# Last Updated: 2026-07-08
 
 features:
   # ============================================================================
@@ -80,7 +80,7 @@ features:
       issue: null
     tests:
       - "test/test_installer.sh"
-      - "test/test_installation.sh"
+      - "test/test_install_legacy_flags.sh"
     references:
       script: "install.sh"
       cli: "scripts/bin/install"


### PR DESCRIPTION
## Problem

The Comprehensive CI Pipeline on `main` went red in the **Quality Control → Run Quick Validator** step ([run 28968984024](https://github.com/bamr87/zer0-mistakes/actions/runs/28968984024)):

```
✗ ZER0-003: tests entry does not exist: test/test_installation.sh
##[error]Process completed with exit code 1.
```

## Root cause

The `[WIP]` retirement in #291 (commit 0e16b3b9) deleted `test/test_installation.sh` and ported its scenarios into `test/test_install_legacy_flags.sh`, but left the deleted file **still referenced** in several places. `scripts/validate-features.rb` hard-fails when an active feature's `tests:` entry doesn't resolve to a real path — and `ZER0-003` ("Modular AI-Powered Installer") still pointed at the deleted file.

## Fix

- **`features/features.yml` + `_data/features.yml`** — repoint `ZER0-003`'s `tests:` entry from the deleted `test/test_installation.sh` to its successor `test/test_install_legacy_flags.sh`; bump `# Last Updated`. The two registries are kept **byte-identical** per the sync contract enforced by the validator. *This alone turns the CI step green.*
- **Stale doc cleanup** (same defect; all non-CODEOWNERS paths) — `README.md`, `docs/architecture/ui-components.md`, `.github/instructions/install.instructions.md`, `.github/instructions/testing.instructions.md`, `.github/copilot-instructions.md`.

Remaining `test_installation.sh` mentions are intentional historical notes (the retirement comment in `test_runner.sh`, the "ported from" notes in `test_install_legacy_flags.sh`, the `_data/backlog.yml` task record, and the new doc row that cites "the retired test_installation.sh").

## Verification

- `ruby scripts/validate-features.rb` → **exit 0** ("Feature registry valid: 77 entries (75 active), refs resolved, master/_data in sync").
- Blocking `markdownlint "docs/**/*.md" --config .github/config/.markdownlint.json` → **passes**.
- Quality Control `./scripts/fix-markdown-format.sh --dry-run` → **exit 0**.

Completes the incomplete retirement started in #291.

🤖 Generated with [Claude Code](https://claude.com/claude-code)