### PR TITLE
chore: adopt .editorconfig (standardization baseline)

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,51 @@
+# EditorConfig is awesome: https://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+# Markdown files
+[*.md]
+max_line_length = off
+trim_trailing_whitespace = false
+
+# YAML files
+[*.{yml,yaml}]
+indent_style = space
+indent_size = 2
+
+# JSON files
+[*.json]
+indent_style = space
+indent_size = 2
+
+# JavaScript/TypeScript
+[*.{js,jsx,ts,tsx}]
+indent_style = space
+indent_size = 2
+
+# Python
+[*.py]
+indent_style = space
+indent_size = 4
+max_line_length = 120
+
+# Shell scripts
+[*.sh]
+indent_style = space
+indent_size = 2
+
+# Makefiles
+[Makefile]
+indent_style = tab
+
+# Package files
+[{package.json,*.lock}]
+indent_style = space
+indent_size = 2


### PR DESCRIPTION
Adds the shared `.editorconfig` from the [bamr87 dash](https://github.com/bamr87/bamr87) so editors apply consistent charset/EOL/indentation across the mixed Ruby/JS/Sass/Shell codebase.

This is the pilot of the dash's standardization fan-out — `.editorconfig` was the *only* gap for this repo, so this brings it to full tier conformance. See [docs/STANDARDS.md](https://github.com/bamr87/bamr87/blob/feature/standardize-control-plane/docs/STANDARDS.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)