### PR TITLE
fix(ci): secret scan matches added lines only

### DIFF
--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -46,8 +46,12 @@ jobs:
           fail=0
 
           echo "== Scanning diff (excluding this workflow file) =="
+          # Added lines only ('+' but not the '+++' file header): context lines,
+          # removals, and @@ hunk-header anchors would otherwise re-flag
+          # pre-existing text (e.g. the .env.example placeholder) on every PR
+          # that edits nearby.
           if git diff "$BASE...$HEAD" -- . ':(exclude).github/workflows/secret-scan.yml' \
-               | grep -nE "$pat"; then
+               | grep -E '^\+' | grep -v '^+++' | grep -nE "$pat"; then
             echo "::error::Possible credential found in the diff. Remove it and ROTATE the token."
             fail=1
           fi


### PR DESCRIPTION
## Problem

The **Secret scan** workflow greps the *entire* PR diff stream, so credential-shaped text that already exists on `main` re-triggers the scan whenever a PR edits nearby lines:

- as a **context line** (the 3 unchanged lines around a hunk), and
- as an **@@ hunk-header anchor** (git cites the nearest preceding non-comment line — in `.env.example` that is `CLAUDE_CODE_OAUTH_TOKEN=sk-ant-oat01-your-…-here`, whose placeholder tail matches the `sk-ant-[A-Za-z0-9_-]{24,}` shape).

PR #296 failed exactly this way ([failing run](https://github.com/bamr87/zer0-mistakes/actions/runs/29265231954/job/86868585775)) — both matches were non-added lines. Any future PR touching `.env.example` below line 38 would hit the same wall, including a PR that tries to *remove* a leaked secret (its `-` lines still match — a catch-22).

## Fix

Filter the diff to added lines only (`+` minus the `+++` file header) before matching, which is what the workflow's own header comment already promises ("only inspects what the PR adds"). One pipeline change plus an explanatory comment; the PR-body scan is untouched.

## Evidence

Verified locally with the exact CI pattern:

| Case | Old filter | New filter |
| --- | --- | --- |
| PR #296 real diff (placeholder as context + hunk header) | 2 false positives | 0 matches |
| Synthetic diff adding `+TOKEN=sk-ant-oat01-AAAA…1234` | caught | caught |
| Same secret on context/removed lines | flagged (wrong) | ignored (right) |

After merge, re-running #296's Secret scan picks this up (pull_request checks run the workflow from the merge ref) and goes green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
