### PR TITLE
fix(a11y): keep a single <main> landmark per page (#299)

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -86,8 +86,10 @@ layout: root
     <!-- ================================ -->
     <!-- MAIN CONTENT AREA               -->
     <!-- ================================ -->
-    <!-- Primary content section with scroll spy for table of contents navigation -->
-    <main class="bd-main order-1" data-bs-spy="scroll" data-bs-target="#TableOfContents" data-bs-offset="100" data-bs-smooth-scroll="true">
+    <!-- Primary content section with scroll spy for table of contents navigation.
+         Not a <main>: root.html already provides the single <main id="main-content">
+         landmark; a nested <main> here would duplicate it (issue #299). -->
+    <div class="bd-main order-1" data-bs-spy="scroll" data-bs-target="#TableOfContents" data-bs-offset="100" data-bs-smooth-scroll="true">
 
         {%- comment -%}
           Page introduction: title, breadcrumbs, metadata.
@@ -129,5 +131,5 @@ layout: root
               {% include content/backlinks.html %}
             {% endif %}
         </div>
-      </main>
+      </div>
     </div>

--- a/_layouts/news.html
+++ b/_layouts/news.html
@@ -78,7 +78,9 @@ source: "https://getbootstrap.com/docs/5.3/examples/blog/#"
   </div>
 </div>
 
-<main class="container">
+<!-- Not a <main>: root.html already provides the single <main id="main-content">
+     landmark; a nested <main> here would duplicate it (issue #299). -->
+<div class="container">
 
 {% if section_style == "magazine" %}
   <!-- ================================ -->
@@ -578,7 +580,7 @@ source: "https://getbootstrap.com/docs/5.3/examples/blog/#"
     </div>
   </section>
 
-</main>
+</div>
 
 <style>
   .hover-lift {

--- a/_layouts/root.html
+++ b/_layouts/root.html
@@ -98,8 +98,9 @@
         <!-- MAIN CONTENT AREA        -->
         <!-- ======================== -->
         <!-- Skip-link target: keep a single, consistent #main-content anchor site-wide.
-             Semantic <main> landmark (consistent with the default/section/news layouts)
-             so assistive tech, search engines, and AI content extractors can isolate the
+             This is the ONE <main> landmark per page — child layouts (default/section/
+             news) must use non-landmark wrappers (<div>) inside it (issue #299) — so
+             assistive tech, search engines, and AI content extractors can isolate the
              primary content from the surrounding header/nav/footer chrome. -->
         <main id="main-content">
             {{ content }}

--- a/_layouts/section.html
+++ b/_layouts/section.html
@@ -156,7 +156,9 @@ layout: root
     <!-- ================================ -->
     <!-- MAIN CONTENT AREA                -->
     <!-- ================================ -->
-    <main class="col-lg-9 col-xl-10 section-layout-main">
+    <!-- Not a <main>: root.html already provides the single <main id="main-content">
+         landmark; a nested <main> here would duplicate it (issue #299). -->
+    <div class="col-lg-9 col-xl-10 section-layout-main">
       
       <!-- Section Header -->
       <header class="section-header mb-4">
@@ -526,7 +528,7 @@ layout: root
         </div>
       </aside>
 
-    </main>
+    </div>
   </div>
 </div>
 

--- a/test/visual/core/styling.spec.js
+++ b/test/visual/core/styling.spec.js
@@ -86,7 +86,7 @@ test.describe('Layout chrome', { tag: '@critical' }, () => {
 
   test('default layout page exposes docs-layout regions', async ({ page }) => {
     await waitForJekyll(page, UI_ROUTES.faq);
-    await expect(page.locator('main.bd-main')).toBeVisible();
+    await expect(page.locator('.bd-main')).toBeVisible();
     await expect(page.locator('.bd-content')).toBeVisible();
   });
 });


### PR DESCRIPTION
Fixes #299

## Root cause

`root.html` renders the site-wide `<main id="main-content">` landmark around `{{ content }}`, but three child layouts each emitted their **own** `<main>` inside it:

- `_layouts/default.html` — `<main class="bd-main order-1" ...>` (the docs `bd-main` wrapper)
- `_layouts/news.html` — `<main class="container">`
- `_layouts/section.html` — `<main class="col-lg-9 col-xl-10 section-layout-main">`

Only `home.html` adds no inner `<main>`, which is why the homepage was the one page with a single landmark. Every other page rendered two nested `<main>` elements — invalid HTML (one non-hidden `<main>` per document) and a duplicate/nested main landmark for screen-reader navigation (WCAG 1.3.1 / ARIA landmark uniqueness).

## Fix (Option A from the issue)

Keep `root.html` as the single owner of the `<main>` landmark and demote the child-layout wrappers to non-landmark `<div>`s (same classes/attributes, tag only). Updated the `root.html` comment to state the invariant, and the one tag-coupled test locator in `test/visual/core/styling.spec.js` (`main.bd-main` → `.bd-main`).

## Verification (why the tag swap is safe)

- **CSS**: the only element-level `main` rule is the scroll-margin block in `_sass/core/_docs-code-examples.scss:460` (`main a, main button, ...`) — all *descendant* selectors, still matched via root's surviving `<main id="main-content">` ancestor. Everything else targeting these regions is class-based (`.bd-main*` in `_docs-layout.scss`, `.section-layout-main` in `_sass/layouts/_section.scss`, Bootstrap `.container`).
- **JS**: `navbar.js` uses `getElementById('main-content')` (root's main, untouched); `modules/navigation/config.js` uses `.bd-main` (class); `share-actions.js` falls back to `querySelector('main')`, which still resolves to root's main.
- **Scrollspy**: `data-bs-spy="scroll"` on `default.html`'s wrapper is tag-agnostic; attributes carried over unchanged.
- Grep confirms `_layouts/` + `_includes/` now contain exactly one `<main>` (root.html).

## Not touched / follow-up

- `test/fixtures/consumer-{gem,remote}/_layouts/*.html` are static consumer-override snapshots that carry copies of the old layout; they exercise override machinery, not landmark semantics, so left as-is.
- The issue's suggested regression gate (assert `count('//main') <= 1` per built page, e.g. in `test/test_quality.sh`'s a11y section) would be a good tiny follow-up once the fixtures are refreshed, otherwise they'd trip it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
