### PR TITLE
ci(release): release-please bumps Gemfile.lock + package-lock.json with version.rb

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,11 @@ name: Release
 
 # Standardized release pipeline — replaces the bespoke version-bump.yml +
 # release.yml. Conventional Commits drive release-please, which opens a release
-# PR (bumps lib/jekyll-theme-zer0/version.rb + package.json + CHANGELOG.md).
+# PR (bumps lib/jekyll-theme-zer0/version.rb + package.json + package-lock.json
+# + Gemfile.lock + CHANGELOG.md in one commit — `component` in
+# release-please-config.json activates the ruby strategy's Gemfile.lock
+# updater, so the lockfile moves with version.rb and the CI
+# "Version ↔ Gemfile.lock consistency" gate is green on the first run).
 # Merging that PR tags vX.Y.Z, creates the GitHub Release, and publish.yml
 # builds the gem (via scripts/build) and pushes it to RubyGems.
 #

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -3,11 +3,15 @@
   "packages": {
     ".": {
       "release-type": "ruby",
+      "component": "jekyll-theme-zer0",
+      "include-component-in-tag": false,
       "version-file": "lib/jekyll-theme-zer0/version.rb",
       "changelog-path": "CHANGELOG.md",
       "bump-minor-pre-major": false,
       "extra-files": [
-        { "type": "json", "path": "package.json", "jsonpath": "$.version" }
+        { "type": "json", "path": "package.json", "jsonpath": "$.version" },
+        { "type": "json", "path": "package-lock.json", "jsonpath": "$.version" },
+        { "type": "json", "path": "package-lock.json", "jsonpath": "$.packages[\"\"].version" }
       ]
     }
   }


### PR DESCRIPTION
Fixes the deterministic release-PR CI failure tracked in **bamr87/bamr87#25** (Actions review: `zer0-mistakes/ci` — release-please version.rb ↔ Gemfile.lock drift fails every release PR).

## Root cause

release-please's `ruby` strategy **already ships a `GemfileLock` updater** ([`src/strategies/ruby.ts`](https://github.com/googleapis/release-please/blob/main/src/strategies/ruby.ts)) that rewrites the `jekyll-theme-zer0 (x.y.z)` PATH spec line in `Gemfile.lock` — but it is wired as `gemName: this.component || ''`, and [`GemfileLock.updateContent`](https://github.com/googleapis/release-please/blob/main/src/updaters/ruby/gemfile-lock.ts) **returns the content unchanged when `gemName` is empty**.

Our `release-please-config.json` set no `component`, so every release PR bumped `lib/jekyll-theme-zer0/version.rb` while `Gemfile.lock` stayed behind. The always-on `Version ↔ Gemfile.lock consistency` gate in `ci.yml` (correctly) red-failed every `chore(main): release …` PR until a human ran `bundle lock` and re-pushed — producing the re-push → cancel churn behind the 134 wasted minutes and 65.6 % success rate in the issue.

## Fix (config-only)

`release-please-config.json`:

- **`"component": "jekyll-theme-zer0"`** — activates the built-in Gemfile.lock updater, so the lockfile version moves **in the same release-please commit** as `version.rb`. Release PRs are green on the first CI run.
- **`"include-component-in-tag": false`** — keeps tags `vX.Y.Z` (no `jekyll-theme-zer0/v…` prefix) and keeps the release PR title `chore(main): release X.Y.Z`, so the `publish.yml` chain and existing tag history are untouched.
- **`package-lock.json` added to `extra-files`** (`$.version` + `$.packages[""].version`) — the npm lockfile version moves in the same commit too, so the shared `relock` job in `bamr87/.github/release-please.yml` becomes a pure no-op backstop instead of pushing a second "sync lockfiles" commit that cancels the first CI run.

Plus a comment update in `.github/workflows/release.yml` documenting the new atomic bump.

## Verified

- `component` / `include-component-in-tag` validated against the release-please config JSON schema (jsonschema pass).
- `GemfileLock` regex simulated against this repo's real `Gemfile.lock`: rewrites exactly one line — the `    jekyll-theme-zer0 (1.26.0)` PATH spec (the `jekyll-theme-zer0!` DEPENDENCIES line is untouched).
- Both JSONPaths tested with `jsonpath-plus` (the library release-please uses) against this repo's real `package-lock.json`: exactly one match each (`1.26.0`).
- Traced `buildRelease` in release-please `base.ts`: with the component-suffixed branch, the post-merge component checks pass and the release/tag is still created as `vX.Y.Z`.
- `actionlint` + YAML parse clean on `release.yml`; `python3 -m json.tool` clean on the config.

## One-time side effect to be aware of

With a single package, release-please defaults `separate-pull-requests` to true, so once this merges the release branch is renamed `release-please--branches--main` → `release-please--branches--main--components--jekyll-theme-zer0`. The currently open release PR #290 (old branch) will be orphaned — **close it after merging this**; release-please will open a fresh, fully-lock-synced release PR on the next push to `main`.

## Label

`no-visual-change` — CI/release-config-only change; no `_sass/`, `_includes/`, `_layouts/`, or asset files touched, so there is no visual surface to evidence.

Refs bamr87/bamr87#25

🤖 Generated with [Claude Code](https://claude.com/claude-code)
