### PR TITLE
ci: reduce Actions waste — fail-open detect-changes, no-op nightly guard, dead-lane cleanup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,19 +53,24 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 3
     outputs:
-      code: ${{ steps.filter.outputs.code }}
-      docker: ${{ steps.filter.outputs.docker }}
-      content: ${{ steps.filter.outputs.content }}
-      styling: ${{ steps.filter.outputs.styling }}
-      install: ${{ steps.filter.outputs.install }}
+      code: ${{ steps.check.outputs.code }}
+      docker: ${{ steps.check.outputs.docker }}
+      content: ${{ steps.check.outputs.content }}
+      styling: ${{ steps.check.outputs.styling }}
+      install: ${{ steps.check.outputs.install }}
       docs-only: ${{ steps.check.outputs.docs-only }}
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v7
 
+      # continue-on-error so a GitHub API outage degrades to a FULL run (the
+      # resolve step below fails open) instead of a red "Detect Changes" that
+      # blocks every open PR and wakes ci-self-repair — exactly what the
+      # 2026-07-16 pulls/*/files API incident did.
       - name: Filter Paths
         uses: dorny/paths-filter@v4
         id: filter
+        continue-on-error: true
         with:
           filters: |
             code:
@@ -111,10 +116,30 @@ jobs:
               - 'docker-compose*.yml'
               - 'Dockerfile'
 
-      - name: Check if docs-only
+      - name: Resolve filters (fail open) and check if docs-only
         id: check
+        env:
+          FILTER_OUTCOME: ${{ steps.filter.outcome }}
+          CODE: ${{ steps.filter.outputs.code }}
+          DOCKER: ${{ steps.filter.outputs.docker }}
+          CONTENT: ${{ steps.filter.outputs.content }}
+          STYLING: ${{ steps.filter.outputs.styling }}
+          INSTALL: ${{ steps.filter.outputs.install }}
         run: |
-          if [[ "${{ steps.filter.outputs.code }}" == "false" && "${{ steps.filter.outputs.docker }}" == "false" ]]; then
+          if [[ "$FILTER_OUTCOME" != "success" ]]; then
+            # paths-filter needs the pulls/*/files API; when it fails we cannot
+            # know what changed, so run EVERYTHING rather than skip gates.
+            echo "::warning::paths-filter failed (outcome: $FILTER_OUTCOME) — failing open: running the full pipeline."
+            CODE=true; DOCKER=true; CONTENT=true; STYLING=true; INSTALL=true
+          fi
+          {
+            echo "code=$CODE"
+            echo "docker=$DOCKER"
+            echo "content=$CONTENT"
+            echo "styling=$STYLING"
+            echo "install=$INSTALL"
+          } >> "$GITHUB_OUTPUT"
+          if [[ "$CODE" == "false" && "$DOCKER" == "false" ]]; then
             echo "docs-only=true" >> $GITHUB_OUTPUT
             echo "📄 Docs-only change detected — heavy jobs will be skipped"
           else

--- a/.github/workflows/deploy-chat-proxy.yml
+++ b/.github/workflows/deploy-chat-proxy.yml
@@ -19,8 +19,27 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
+      # Fail-safe gate: without the Cloudflare secrets, wrangler dies with
+      # "it's necessary to set a CLOUDFLARE_API_TOKEN" — which made EVERY run
+      # of this workflow a guaranteed failure (7/7 failures 2026-06-15 →
+      # 2026-07-07). Skip cleanly (with a notice) until the secrets exist.
+      - name: Check Cloudflare credentials
+        id: creds
+        env:
+          CF_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CF_ACCOUNT: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: |
+          if [ -z "$CF_TOKEN" ] || [ -z "$CF_ACCOUNT" ]; then
+            echo "::notice::CLOUDFLARE_API_TOKEN / CLOUDFLARE_ACCOUNT_ID not configured — skipping the chat-proxy deploy. Add both repo secrets to enable it."
+            echo "go=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "go=true" >> "$GITHUB_OUTPUT"
+          fi
+
       - uses: actions/checkout@v7
+        if: steps.creds.outputs.go == 'true'
 
       # Deploys the AI chat proxy Worker to Cloudflare and sets its secret.
       # Required GitHub Actions secrets:
@@ -30,6 +49,7 @@ jobs:
       # Optional (proxy-mode issue/PR creation): add GITHUB_TOKEN to the
       # `secrets:` list below and a CHAT_GITHUB_TOKEN repo secret mapped in env.
       - name: Deploy Worker to Cloudflare
+        if: steps.creds.outputs.go == 'true'
         uses: cloudflare/wrangler-action@v4
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}

--- a/.github/workflows/install-matrix.yml
+++ b/.github/workflows/install-matrix.yml
@@ -32,6 +32,7 @@ jobs:
   matrix:
     name: ${{ matrix.os }} · ruby-${{ matrix.ruby }}
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 20
     strategy:
       fail-fast: false
       matrix:
@@ -39,6 +40,12 @@ jobs:
         # Ruby 3.2+ required: Bundler 2.7.x (pinned in Gemfile.lock) needs >= 3.2.0.
         # Ruby 2.7 / 3.0 / 3.1 are EOL upstream; project floor moved with Bundler.
         ruby: ['3.2', '3.3']
+        exclude:
+          # Floor-version (3.2) coverage on Linux is enough — the installer has
+          # no OS-specific Ruby-version code paths, and macOS runner minutes
+          # bill at 10x. macOS validates the current Ruby only.
+          - os: macos-latest
+            ruby: '3.2'
 
     steps:
       - uses: actions/checkout@v7
@@ -90,6 +97,7 @@ jobs:
   curl-bash-bootstrap:
     name: curl|bash bootstrap (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 10
     strategy:
       fail-fast: false
       matrix:
@@ -117,6 +125,7 @@ jobs:
   doctor:
     name: doctor (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 10
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/issue-autopilot.yml
+++ b/.github/workflows/issue-autopilot.yml
@@ -53,6 +53,14 @@ concurrency:
 jobs:
   # --------------------------------------------------------------------------
   gate:
+    # The `issues: [labeled]` trigger fires for EVERY label applied to any
+    # issue — including the area:*/priority:*/autopilot:* labels this pipeline
+    # itself applies during triage — and each firing booted a runner just so
+    # the gate step could say "not autopilot:go" (the 2026-07-13 triage pass
+    # alone produced a burst of ~10 such runs). Skip at the JOB level (no
+    # runner boot) unless it's the one label we act on. The step-level check
+    # below stays as defense in depth.
+    if: github.event_name != 'issues' || github.event.label.name == 'autopilot:go'
     runs-on: ubuntu-latest
     outputs:
       go: ${{ steps.check.outputs.go }}

--- a/.github/workflows/issue-pr-auto-merge.yml
+++ b/.github/workflows/issue-pr-auto-merge.yml
@@ -14,6 +14,13 @@
 #
 # OFF by default behind ISSUE_AUTOMERGE_ENABLED. Add `autopilot:needs-human` to
 # force manual review. Runs via pull_request_target but never checks out PR code.
+#
+# STATE (2026-07): the ISSUE_AUTOMERGE_ENABLED repo variable is NOT set, so the
+# job skipped on all 59 runs in the 6/29–7/13 analytics window — every PR event
+# booted a run record for nothing. The workflow is therefore DISABLED in the
+# Actions UI (`gh workflow disable issue-pr-auto-merge.yml`). To turn the lane
+# on: set the repo variable ISSUE_AUTOMERGE_ENABLED=true AND re-enable with
+# `gh workflow enable issue-pr-auto-merge.yml`.
 # =============================================================================
 name: 🤝 Issue PR Auto-Merge
 

--- a/.github/workflows/nightly-extended.yml
+++ b/.github/workflows/nightly-extended.yml
@@ -37,9 +37,45 @@ env:
   NODE_VERSION: '20'
 
 jobs:
+  # The suites run against PINNED deps (Gemfile.lock), so an unchanged main
+  # cannot produce a new result — re-running nightly on idle days was pure
+  # green burn (~11 min/night; the 6/29–7/13 analytics window shows 100%
+  # success). Upstream-dependency drift is NOT this workflow's job: the daily
+  # test-latest.yml canary covers that with unpinned deps. Manual dispatches
+  # always run.
+  preflight:
+    name: Skip if main is unchanged
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    permissions:
+      actions: read     # list this workflow's own runs (workflow-level block has no `actions` scope)
+    outputs:
+      go: ${{ steps.check.outputs.go }}
+    steps:
+      - name: Compare HEAD with the last green nightly
+        id: check
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "manual dispatch — always run."
+            echo "go=true" >> "$GITHUB_OUTPUT"; exit 0
+          fi
+          last=$(gh api "repos/$GITHUB_REPOSITORY/actions/workflows/nightly-extended.yml/runs?status=success&branch=main&per_page=1" \
+                   --jq '.workflow_runs[0].head_sha // empty' 2>/dev/null || true)
+          if [ -n "$last" ] && [ "$last" = "$GITHUB_SHA" ]; then
+            echo "::notice::main unchanged since the last green nightly ($last) — skipping the extended tier."
+            echo "go=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "main moved (last green: ${last:-none}, now: $GITHUB_SHA) — running."
+            echo "go=true" >> "$GITHUB_OUTPUT"
+          fi
+
   extended-suites:
     name: Extended shell + Playwright smoke
     runs-on: ubuntu-latest
+    needs: preflight
+    if: needs.preflight.outputs.go == 'true'
     timeout-minutes: 45
     steps:
       - name: Checkout Repository
@@ -77,6 +113,8 @@ jobs:
   snapshots:
     name: Visual snapshots (9 skins)
     runs-on: ubuntu-latest
+    needs: preflight
+    if: needs.preflight.outputs.go == 'true'
     timeout-minutes: 30
     steps:
       - name: Checkout Repository
@@ -101,7 +139,9 @@ jobs:
     name: File sticky issue on failure
     runs-on: ubuntu-latest
     needs: [extended-suites, snapshots]
-    if: always() && contains(needs.*.result, 'failure')
+    # Only the test jobs' failures are signal (a preflight hiccup or a skipped
+    # night must not file the sticky issue).
+    if: always() && (needs.extended-suites.result == 'failure' || needs.snapshots.result == 'failure')
     timeout-minutes: 5
     steps:
       - name: Create or update the sticky failure issue

--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -50,7 +50,8 @@ jobs:
   update-gems:
     name: Update Gemfile.lock
     runs-on: ubuntu-latest
-    
+    timeout-minutes: 15
+
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v7

--- a/test/ui-audit/sweep.mjs
+++ b/test/ui-audit/sweep.mjs
@@ -48,7 +48,14 @@ async function main() {
   // the article layout even as content changes.
   const probe = await browser.newPage();
   try {
-    await probe.goto(`${BASE_URL}/`, { waitUntil: 'domcontentloaded' });
+    // Non-fatal: the discovered article route is a nice-to-have. A cold-start
+    // timeout here killed the ENTIRE 2026-07-13 audit run (per-route gotos
+    // below are try/caught; this probe wasn't). Longer timeout to absorb the
+    // server's first-hit warm-up, and swallow failures — the sweep still
+    // audits every static ROUTE and records per-route errors as findings.
+    await probe
+      .goto(`${BASE_URL}/`, { waitUntil: 'domcontentloaded', timeout: 60000 })
+      .catch(() => null);
     const article = await probe
       .locator('a[href^="/posts/"]')
       .first()


### PR DESCRIPTION
Full audit + refactor of the Actions suite against the 6/29–7/13 analytics window (26 workflows, ~600 runs, 1104 total min, 147 wasted, 17 failures, 5 flagged). Owner's diagnosis — workflows "running without need" — confirmed in four places; three failure clusters root-caused from logs.

**Not touched (already in flight today):** release-drift fix (#312), Gemfile.lock bumps (#300), preview-plugin removal (#311), theme fixes (#305–#310). The 2026-07-16 "Detect Changes"/"Visual evidence gate" failures were GitHub's `pulls/*/files` API incident — this PR makes ci.yml survive the next one instead of re-fixing the last one.

## Changes (each with evidence)

| Workflow | Change | Evidence |
|---|---|---|
| `ci.yml` | detect-changes **fails open**: `continue-on-error` on dorny/paths-filter + a resolve step that forces all filters `true` when the filter step didn't succeed | paths-filter depends on the `pulls/*/files` API; the 7/16 incident failed every open PR's pipeline at minute 1 and each red run also woke `ci-self-repair` (81 runs/14d). Outage now = one full pipeline run, not a blocked repo |
| `nightly-extended.yml` | preflight job skips both heavy jobs when main's HEAD equals the last **green** nightly's `head_sha` (manual dispatch always runs); sticky-issue filer now keys on the two test jobs only | 100% success across the window (64 min of pure green burn, `cron-heavy` flag). The suites run against **pinned** deps — an unchanged main cannot produce a new result; upstream drift is covered by the daily zero-pin `test-latest.yml` canary. Cadence stays nightly, so active days keep same-day detection |
| `install-matrix.yml` | matrix `exclude: macos-latest + ruby '3.2'` (10 jobs → 9); `timeout-minutes` on all three jobs (20/10/10) | 100% success in window; installer has no OS-specific Ruby-version code paths, floor-Ruby stays covered on ubuntu, and macOS minutes bill at 10x. Timeouts cap a hung macOS job (previously unbounded → 360-min default) |
| `deploy-chat-proxy.yml` | secret-presence gate: notice + clean skip when `CLOUDFLARE_API_TOKEN`/`CLOUDFLARE_ACCOUNT_ID` are unset; `timeout-minutes: 10` | **7/7 runs failed since 2026-06-15**, all identically: `✘ [ERROR] In a non-interactive environment, it's necessary to set a CLOUDFLARE_API_TOKEN…` at `wrangler secret bulk`. It was a guaranteed-red workflow |
| `ui-audit.yml` → `test/ui-audit/sweep.mjs` | article-discovery probe `goto` made non-fatal (`.catch(() => null)`) with a 60 s budget | The only run in the window (7/13, its first scheduled run) died with `page.goto: Timeout 30000ms exceeded … at main (sweep.mjs:51)`. Every per-route `goto` is try/caught and recorded as a finding — the probe was the single uncaught navigation, so one cold-start timeout threw away the whole 30-min-budget audit |
| `issue-autopilot.yml` | job-level `if` on `gate`: skip (no runner boot) for every `issues: labeled` event that isn't `autopilot:go` | The trigger fires for EVERY label on any issue — including the `area:*`/`priority:*`/`autopilot:*` labels the pipeline itself applies during triage (self-feedback). 7/13 shows a burst of ~10 runs in one second (`cancel-heavy` flag, 42% success from cancellations). The step-level check stays as defense in depth |
| `issue-pr-auto-merge.yml` | header documents the disabled state; workflow **disabled in the Actions UI** (`gh workflow disable`) | Job is gated on `vars.ISSUE_AUTOMERGE_ENABLED == 'true'` — that variable is **not set** (repo vars: `ISSUE_AUTOPILOT/RESOLVE/AUTOCLOSE/VERIFY_CLOSE_ENABLED` only). All 59 runs in the window skipped; 4 `pull_request_target` types booted a run record per PR event for nothing. Re-enable: set the var **and** `gh workflow enable issue-pr-auto-merge.yml` |
| `update-dependencies.yml` | `timeout-minutes: 15` | only unbounded scheduled job left; `bundle update` against rubygems can hang |

## Verdicts for the rest (audited, no change needed)

**keep:** `test-latest.yml` (zero-pin canary, 97.7% effective — its cost is its design), `codeql.yml` (100% effective), `secret-scan.yml` + `evidence-gate.yml` (required gates, ~0.3 min/run; evidence-gate must always run to be a required check), `sync.yml` (backlog→Issues / roadmap→README, 100% success, purpose is real), `ai-content-review.yml` (95% effective), `release.yml` (7/16 failure is the release-drift issue #312 addresses), `lint-workflows.yml`, `claude.yml` (skips are free; Dependabot owns its action pins), `auto-merge.yml` (skipped runs are run-records only, and the `synchronize` trigger is load-bearing — it re-verifies the protected-path denylist and strips the label if a later commit smuggles risky files), `ci-self-repair.yml` (4.6 min/14d; `workflow_run` can't filter on conclusion at trigger level — the 17% "effectiveness" is skip-accounting, not waste), `convert-notebooks.yml` (the `flaky` flag is stale: root cause was setup-python's pip cache pointing at a missing requirements file, fixed 7/1 in #271 / `6d18337`; green since).

## Owner decisions (NOT implemented)

1. **`milestone-assign.yml` — retire or feed it.** There are currently **zero open milestones**, so all 17 runs/14d boot a runner to print "Found 0 open milestone(s) — skipping". Either create the next-version milestone (it then does real work) or delete the workflow.
2. **`giscus-digest.yml` — keep weekly, or make manual-only.** Costs ~0.1 min/wk, succeeds, but its only output is a job summary nobody is known to read. The file's own comment says removing the `schedule:` block makes it manual-only.
3. **`issue-pr-auto-merge.yml` — intended state?** You enabled the four other autopilot vars but not `ISSUE_AUTOMERGE_ENABLED`, so docs PRs from the resolve lane wait for a human — which may be deliberate. If you want the full hands-off loop: set the var and `gh workflow enable issue-pr-auto-merge.yml`; if not, consider deleting the file.
4. **`test-latest.yml` push-trigger scope** (flagging only, not recommending): every main push matching its paths (incl. `lib/**`, i.e. every release version bump) runs the ~13-min Docker canary and republishes the image. If per-push image freshness isn't needed, schedule-only would save ~100 min/14d — but that changes publish semantics, so it's your call.

## Estimated savings

- **Hard minutes:** ~55–75 min/14d — nightly no-op skips (~45–65 on quiet stretches like 7/2–7/5 and 7/9–7/12), install-matrix macOS trim (~4 real min ≈ 40 billed-equivalent), deploy-chat-proxy red runs (~1), issue-pr-auto-merge + autopilot label-churn boots (~5).
- **Incident class:** the 7/16 API outage cost a blocked repo + a stack of red runs + self-repair wakeups; that class now degrades to full-pipeline runs.
- **Signal quality:** 17 guaranteed-or-stale failures/window → ~0; ~70 skipped-run records/14d gone; the weekly UI audit now survives cold starts instead of wasting its whole budget.

**Label note:** `no-visual-change` — this PR touches only workflow YAML and test tooling (`test/ui-audit/sweep.mjs`); nothing under `_sass/`, `_includes/`, `_layouts/`, or `assets/` — zero rendered-site effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
