### PR TITLE
feat(analytics): wire posthog.html into head.html

### DIFF
--- a/_includes/core/head.html
+++ b/_includes/core/head.html
@@ -19,6 +19,7 @@
   - seo.html: SEO meta tags and Open Graph data
   - google-analytics.html: Google Analytics tracking
   - google-tag-manager-head.html: GTM head section
+  - posthog.html: PostHog product analytics (opt-in via site.posthog.enabled)
   
   Performance Notes:
   - Scripts loaded in head for immediate availability
@@ -126,6 +127,10 @@ window.MathJax = {
 <!-- Google Analytics tracking - Configured in _config.yml -->
 <!-- Only load in production AND when an ID is configured; the include also guards against dev hostnames -->
 {% if jekyll.environment == "production" and site.google_analytics %}{% include analytics/google-analytics.html %}{% endif %}
+
+<!-- PostHog analytics - Configured via the `posthog:` block in _config.yml -->
+<!-- Only load in production AND when explicitly enabled; the include itself also respects Do Not Track -->
+{% if jekyll.environment == "production" and site.posthog.enabled %}{% include analytics/posthog.html %}{% endif %}
 
 
 <!-- ================================ -->


### PR DESCRIPTION
## Summary

Wires the theme's existing `_includes/analytics/posthog.html` into `core/head.html` so PostHog product analytics actually loads. The snippet has shipped with the theme for a while but was **never included anywhere**, so `site.posthog.*` config did nothing.

## Change

One conditional include in `head.html`, mirroring the existing Google Analytics line:

```liquid
{% if jekyll.environment == "production" and site.posthog.enabled %}{% include analytics/posthog.html %}{% endif %}
```

- Loads **only** in production (`jekyll.environment == "production"`) **and** when a site explicitly opts in via `site.posthog.enabled`.
- `posthog.html` itself additionally respects Do Not Track and cookie-consent, so this is purely additive and inert for any site that doesn't set `posthog.enabled`.
- Also documents `posthog.html` in the head.html dependency comment.

No change to the theme's `_config.yml` PostHog defaults.

## Why

Consuming sites (e.g. it-journey.dev, which uses this theme via an unpinned `remote_theme`) can set a `posthog:` block in their own `_config.yml`, but nothing rendered because `head.html` never pulled the snippet in. This closes that gap.

## Verification

Built a downstream site (it-journey) in production against this `head.html` + the theme's `posthog.html`: the rendered pages now contain the PostHog init snippet with the site's configured key/host, gated correctly to production only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
