### PR TITLE
feat(includes): config-driven favicon, GTM gating, og:image fallback fix, sidebar nav aliases

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -91,6 +91,13 @@ logo_link                : [ *url, *baseurl ] # URL to link the logo to, e.g. "/
 teaser                   : '/assets/images/favicon_gpt_computer_retro.png' # path of fallback teaser image, e.g. "/assets/images/500x300.png"
 info_banner              : '/assets/images/info-banner-mountain-wizard.png' # path of fallback teaser image, e.g. "/assets/images/500x300.png"
 
+# Favicon / browser identity — rendered by _includes/core/favicon.html.
+# All keys optional; with no block at all the theme still links /favicon.ico.
+# theme_color falls back to theme_color.main below when unset here.
+favicon:
+  ico                    : /favicon.ico
+  apple_touch            : /assets/images/favicon_gpt_computer_retro.png
+
 ## Preview Image Generation (AI-powered) #####################################
 # Settings for automatic preview image generation using AI
 # Used by: scripts/generate-preview-images.sh → scripts/lib/preview_generator.py
@@ -200,6 +207,10 @@ author:
 ## Site Analytics #############################################################
 
 google_analytics         : 'G-ZBDKNMC168'
+
+# Google Tag Manager container for THIS site. The GTM includes emit nothing
+# when this is unset, so consumer sites never inherit this container.
+google_tag_manager       : 'GTM-NN8P7RZ'
 
 # PostHog Analytics Configuration
 # https://posthog.com/docs/libraries/js

--- a/_data/features.yml
+++ b/_data/features.yml
@@ -2199,7 +2199,8 @@ features:
       pr: null
       commit: "a11e29f"
       issue: null
-    tests: []
+    tests:
+      - "test/test_core.sh"
     references:
       includes:
         - "_includes/core/favicon.html"

--- a/_data/features.yml
+++ b/_data/features.yml
@@ -2184,3 +2184,28 @@ features:
       - "Manifest-driven SHA change detection, pruning of deleted sources, and generated /fr<en-url> permalinks (GitHub Pages safe-mode friendly)"
       - "Markdown-safe segment translation: code, Liquid, wiki-links and URLs masked as placeholders and validated"
       - "Navbar language toggle with availability states, hreflang alternates, per-page html lang, machine-translation notice"
+
+  - id: ZER0-079
+    title: "Config-Driven Favicon and Browser Identity"
+    description: "Head include emitting favicon, SVG icon, Apple touch icon, web manifest, and theme-color tags from an optional favicon config block, with an explicit /favicon.ico fallback that works on baseurl deployments"
+    implemented: true
+    version: "1.28.0"
+    link: "/"
+    docs: "/docs/features/favicon/"
+    tags: [seo, branding, ui, configuration]
+    date: 2026-07-22
+    provenance:
+      introduced_in: "1.28.0"
+      pr: null
+      commit: "a11e29f"
+      issue: null
+    tests: []
+    references:
+      includes:
+        - "_includes/core/favicon.html"
+        - "_includes/core/head.html"
+      docs: "pages/_docs/features/favicon.md"
+    features:
+      - "Zero-config default: explicit /favicon.ico link on every page (fixes silent 404s and baseurl project sites)"
+      - "Optional SVG favicon, PNG sizes, apple-touch-icon, and web manifest links"
+      - "theme-color meta sourced from favicon.theme_color with fallback to theme_color.main design token"

--- a/_includes/README.md
+++ b/_includes/README.md
@@ -9,6 +9,7 @@ This directory has been reorganized for better maintainability and clarity. File
 Essential layout components that form the foundation of the site:
 
 - `head.html` - HTML document head with meta tags, scripts, and styles
+- `favicon.html` - Favicon / browser-identity tags (icon links, apple-touch, manifest, theme-color) driven by the optional `favicon:` config block
 - `header.html` - Main site header with navigation
 - `footer.html` - Site footer (if exists)
 - `branding.html` - Site branding and title display
@@ -34,8 +35,8 @@ All navigation-related components:
 Analytics and tracking integrations:
 
 - `google-analytics.html` - Google Analytics tracking
-- `google-tag-manager-head.html` - GTM head section
-- `google-tag-manager-body.html` - GTM body section
+- `google-tag-manager-head.html` - GTM head section (emits nothing unless `google_tag_manager:` is set in `_config.yml`)
+- `google-tag-manager-body.html` - GTM body section (same config gate)
 
 ### `components/`
 

--- a/_includes/analytics/google-tag-manager-body.html
+++ b/_includes/analytics/google-tag-manager-body.html
@@ -1,9 +1,18 @@
 {% comment %} Feature: ZER0-039 {% endcomment %}
+{%- comment -%}
+  Component:   google-tag-manager-body
+  Path:        _includes/analytics/google-tag-manager-body.html
+  Purpose:     Google Tag Manager noscript fallback (body section). Config-driven:
+               emits nothing unless the site sets a container ID.
+  Params:      none — reads `google_tag_manager: "GTM-XXXXXXX"` from _config.yml
+  Depends on:  google-tag-manager-head.html (loader)
+{%- endcomment -%}
+{%- if site.google_tag_manager -%}
 <!-- Google Tag Manager (noscript) -->
     <noscript>
-        <iframe src="https://www.googletagmanager.com/ns.html?id=GTM-NN8P7RZ" 
+        <iframe src="https://www.googletagmanager.com/ns.html?id={{ site.google_tag_manager }}"
                 height="0" width="0" style="display:none;visibility:hidden">
         </iframe>
     </noscript>
 <!-- End Google Tag Manager (noscript) -->
-<!-- source https://tagmanager.google.com/#/admin/accounts/6005859084/containers/58386588/install?containerDraftId=2 -->
+{%- endif -%}

--- a/_includes/analytics/google-tag-manager-body.html
+++ b/_includes/analytics/google-tag-manager-body.html
@@ -4,7 +4,7 @@
   Path:        _includes/analytics/google-tag-manager-body.html
   Purpose:     Google Tag Manager noscript fallback (body section). Config-driven:
                emits nothing unless the site sets a container ID.
-  Params:      none — reads `google_tag_manager: "GTM-XXXXXXX"` from _config.yml
+  Params:      none — reads `google_tag_manager: "<container-id>"` from _config.yml
   Depends on:  google-tag-manager-head.html (loader)
 {%- endcomment -%}
 {%- if site.google_tag_manager -%}

--- a/_includes/analytics/google-tag-manager-head.html
+++ b/_includes/analytics/google-tag-manager-head.html
@@ -5,7 +5,7 @@
   Purpose:     Google Tag Manager loader (head section). Config-driven: emits
                nothing unless the site sets a container ID, so consumer sites
                never inherit this theme's own GTM container.
-  Params:      none — reads `google_tag_manager: "GTM-XXXXXXX"` from _config.yml
+  Params:      none — reads `google_tag_manager: "<container-id>"` from _config.yml
   Depends on:  google-tag-manager-body.html (optional noscript counterpart)
   Notes:       Previously the container ID was hardcoded, silently enrolling
                every consumer site's production build into the theme owner's

--- a/_includes/analytics/google-tag-manager-head.html
+++ b/_includes/analytics/google-tag-manager-head.html
@@ -1,8 +1,17 @@
 {% comment %} Feature: ZER0-039 {% endcomment %}
-<!-- 
-  title: Google Tag Manager 
-  file: 
--->
+{%- comment -%}
+  Component:   google-tag-manager-head
+  Path:        _includes/analytics/google-tag-manager-head.html
+  Purpose:     Google Tag Manager loader (head section). Config-driven: emits
+               nothing unless the site sets a container ID, so consumer sites
+               never inherit this theme's own GTM container.
+  Params:      none — reads `google_tag_manager: "GTM-XXXXXXX"` from _config.yml
+  Depends on:  google-tag-manager-body.html (optional noscript counterpart)
+  Notes:       Previously the container ID was hardcoded, silently enrolling
+               every consumer site's production build into the theme owner's
+               GTM container. Set your own ID (or leave unset for no GTM).
+{%- endcomment -%}
+{%- if site.google_tag_manager -%}
 <script>
     // Skip GTM on local/dev hostnames even if a prod build is served locally (Docker/CI preview).
     (function () {
@@ -13,7 +22,8 @@
         new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
         j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
         'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-        })(window,document,'script','dataLayer','GTM-NN8P7RZ');
+        })(window,document,'script','dataLayer','{{ site.google_tag_manager }}');
     })();
     </script>
     <!-- End Google Tag Manager -->
+{%- endif -%}

--- a/_includes/content/seo.html
+++ b/_includes/content/seo.html
@@ -37,17 +37,23 @@
   {%- assign assets_prefix = site.preview_images.assets_prefix | default: '/assets' -%}
   {%- assign auto_prefix = site.preview_images.auto_prefix | default: true -%}
 
+  {%- comment -%}
+    Guard with truthiness AND blank: in Liquid 4 `nil != blank` is TRUE, so a
+    bare `!= blank` check on an unset variable takes the branch and assigns a
+    nil seo_image — og:image was silently dropped on every page without a
+    page.header image, defeating the site.og_image fallback entirely.
+  {%- endcomment -%}
   {%- if page_teaser_image contains '://' -%}
     {%- comment -%} External URL - use as-is {%- endcomment -%}
-  {%- elsif auto_prefix and page_teaser_image != blank -%}
+  {%- elsif auto_prefix and page_teaser_image and page_teaser_image != blank -%}
     {%- unless page_teaser_image contains assets_prefix -%}
       {%- assign page_teaser_image = assets_prefix | append: page_teaser_image -%}
     {%- endunless -%}
   {%- endif -%}
 
-  {%- if page_large_image != blank -%}
+  {%- if page_large_image and page_large_image != blank -%}
     {%- assign seo_image = page_large_image | absolute_url | escape -%}
-  {%- elsif page_teaser_image != blank -%}
+  {%- elsif page_teaser_image and page_teaser_image != blank -%}
     {%- assign seo_image = page_teaser_image | absolute_url | escape -%}
   {%- endif -%}
 

--- a/_includes/core/favicon.html
+++ b/_includes/core/favicon.html
@@ -1,0 +1,46 @@
+{% comment %} Feature: ZER0-079 {% endcomment %}
+{%- comment -%}
+  Component:   favicon
+  Path:        _includes/core/favicon.html
+  Purpose:     Emit the browser-identity tags (favicon, SVG icon, Apple touch
+               icon, web manifest, theme-color) for every page. Before this
+               include existed, sites relied on the browser's implicit
+               /favicon.ico probe — which silently 404s on sites without the
+               file and never works for baseurl (project-page) deployments.
+  Params:      none — reads the optional `favicon:` block in _config.yml:
+
+               favicon:
+                 ico         : /favicon.ico                    # legacy .ico (default)
+                 svg         : /assets/images/favicon.svg      # scalable icon (optional)
+                 png         : /assets/images/favicon-32.png   # PNG icon (optional)
+                 png_size    : 32x32                           # sizes attr for png (optional)
+                 apple_touch : /assets/images/apple-touch.png  # iOS home-screen icon (optional)
+                 manifest    : /site.webmanifest               # PWA manifest (optional)
+                 theme_color : "#0d1117"                       # browser chrome color (optional)
+
+               With NO config at all this still emits the explicit
+               /favicon.ico link (every consumer site carries one at root),
+               and theme_color falls back to site.theme_color.main so the
+               mobile address bar matches the site's design tokens.
+  Notes:       Page-invariant — safe to render via include_cached. All paths
+               run through relative_url so baseurl deployments resolve.
+{%- endcomment -%}
+{%- assign _fav = site.favicon -%}
+{%- assign _fav_ico = _fav.ico | default: '/favicon.ico' -%}
+<link rel="icon" href="{{ _fav_ico | relative_url }}" sizes="32x32">
+{%- if _fav.svg %}
+<link rel="icon" type="image/svg+xml" href="{{ _fav.svg | relative_url }}">
+{%- endif %}
+{%- if _fav.png %}
+<link rel="icon" type="image/png" href="{{ _fav.png | relative_url }}"{% if _fav.png_size %} sizes="{{ _fav.png_size }}"{% endif %}>
+{%- endif %}
+{%- if _fav.apple_touch %}
+<link rel="apple-touch-icon" href="{{ _fav.apple_touch | relative_url }}">
+{%- endif %}
+{%- if _fav.manifest %}
+<link rel="manifest" href="{{ _fav.manifest | relative_url }}">
+{%- endif %}
+{%- assign _fav_theme_color = _fav.theme_color | default: site.theme_color.main -%}
+{%- if _fav_theme_color %}
+<meta name="theme-color" content="{{ _fav_theme_color }}">
+{%- endif %}

--- a/_includes/core/head.html
+++ b/_includes/core/head.html
@@ -87,6 +87,10 @@ window.MathJax = {
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 
+<!-- Favicon + browser identity (config-driven via `favicon:`; explicit
+     /favicon.ico fallback so baseurl deployments resolve) — page-invariant, cached. -->
+{% include_cached core/favicon.html %}
+
 <!-- ================================ -->
 <!-- SEO SUPPLEMENT                  -->
 <!-- ================================ -->

--- a/_includes/navigation/sidebar-config.html
+++ b/_includes/navigation/sidebar-config.html
@@ -28,6 +28,8 @@
   Notes:       `nav: auto` picks the best mode for the page's collection —
                a curated _data/navigation/<collection>.yml wins, then the
                live "collection" folder tree, then post "categories".
+               Legacy mode names ("tree", "dynamic", "searchCats") from
+               pre-1.x sidebars are aliased to "auto" for backward compat.
 {%- endcomment -%}
 
 {%- comment -%} 1. Visibility: page.sidebar wins; featured/breaking posts default off {%- endcomment -%}
@@ -59,6 +61,14 @@
   {%- elsif site.sidebar.nav -%}
     {%- assign sidebar_nav = site.sidebar.nav -%}
   {%- endif -%}
+{%- endif -%}
+
+{%- comment -%} 3b. Legacy mode names from pre-1.x sidebars ("tree", "dynamic",
+     "searchCats") no longer exist; consumer configs still carry them, which
+     used to silently disable the sidebar (no data file matches those names).
+     Treat them as "auto" so those sites get the best available mode. {%- endcomment -%}
+{%- if sidebar_nav == "tree" or sidebar_nav == "dynamic" or sidebar_nav == "searchCats" -%}
+  {%- assign sidebar_nav = "auto" -%}
 {%- endif -%}
 
 {%- comment -%} 4. "auto" → concrete mode based on the page's collection {%- endcomment -%}

--- a/features/README.md
+++ b/features/README.md
@@ -83,4 +83,4 @@ diff -q features/features.yml _data/features.yml   # must report no difference
 
 ## Feature Count
 
-Current count: **78 features** (as of 2026-07-17, gem v1.26.0)
+Current count: **79 features** (as of 2026-07-22, gem v1.27.0)

--- a/features/features.yml
+++ b/features/features.yml
@@ -2199,7 +2199,8 @@ features:
       pr: null
       commit: "a11e29f"
       issue: null
-    tests: []
+    tests:
+      - "test/test_core.sh"
     references:
       includes:
         - "_includes/core/favicon.html"

--- a/features/features.yml
+++ b/features/features.yml
@@ -2184,3 +2184,28 @@ features:
       - "Manifest-driven SHA change detection, pruning of deleted sources, and generated /fr<en-url> permalinks (GitHub Pages safe-mode friendly)"
       - "Markdown-safe segment translation: code, Liquid, wiki-links and URLs masked as placeholders and validated"
       - "Navbar language toggle with availability states, hreflang alternates, per-page html lang, machine-translation notice"
+
+  - id: ZER0-079
+    title: "Config-Driven Favicon and Browser Identity"
+    description: "Head include emitting favicon, SVG icon, Apple touch icon, web manifest, and theme-color tags from an optional favicon config block, with an explicit /favicon.ico fallback that works on baseurl deployments"
+    implemented: true
+    version: "1.28.0"
+    link: "/"
+    docs: "/docs/features/favicon/"
+    tags: [seo, branding, ui, configuration]
+    date: 2026-07-22
+    provenance:
+      introduced_in: "1.28.0"
+      pr: null
+      commit: "a11e29f"
+      issue: null
+    tests: []
+    references:
+      includes:
+        - "_includes/core/favicon.html"
+        - "_includes/core/head.html"
+      docs: "pages/_docs/features/favicon.md"
+    features:
+      - "Zero-config default: explicit /favicon.ico link on every page (fixes silent 404s and baseurl project sites)"
+      - "Optional SVG favicon, PNG sizes, apple-touch-icon, and web manifest links"
+      - "theme-color meta sourced from favicon.theme_color with fallback to theme_color.main design token"

--- a/pages/_about/settings/_config.yml
+++ b/pages/_about/settings/_config.yml
@@ -92,6 +92,13 @@ logo_link                : [ *url, *baseurl ] # URL to link the logo to, e.g. "/
 teaser                   : '/assets/images/favicon_gpt_computer_retro.png' # path of fallback teaser image, e.g. "/assets/images/500x300.png"
 info_banner              : '/assets/images/info-banner-mountain-wizard.png' # path of fallback teaser image, e.g. "/assets/images/500x300.png"
 
+# Favicon / browser identity — rendered by _includes/core/favicon.html.
+# All keys optional; with no block at all the theme still links /favicon.ico.
+# theme_color falls back to theme_color.main below when unset here.
+favicon:
+  ico                    : /favicon.ico
+  apple_touch            : /assets/images/favicon_gpt_computer_retro.png
+
 ## Preview Image Generation (AI-powered) #####################################
 # Settings for automatic preview image generation using AI
 # Used by: scripts/generate-preview-images.sh → scripts/lib/preview_generator.py
@@ -201,6 +208,10 @@ author:
 ## Site Analytics #############################################################
 
 google_analytics         : 'G-ZBDKNMC168'
+
+# Google Tag Manager container for THIS site. The GTM includes emit nothing
+# when this is unset, so consumer sites never inherit this container.
+google_tag_manager       : 'GTM-NN8P7RZ'
 
 # PostHog Analytics Configuration
 # https://posthog.com/docs/libraries/js

--- a/pages/_docs/features/favicon.md
+++ b/pages/_docs/features/favicon.md
@@ -1,0 +1,69 @@
+---
+title: Favicon & Browser Identity
+description: Config-driven favicon, Apple touch icon, web manifest, and theme-color tags emitted on every page, with a zero-config /favicon.ico fallback.
+lastmod: 2026-07-22T00:00:00.000Z
+layout: default
+categories:
+    - docs
+    - features
+tags:
+    - seo
+    - branding
+    - configuration
+permalink: /docs/features/favicon/
+difficulty: beginner
+estimated_reading_time: 4 minutes
+sidebar:
+    nav: docs
+---
+
+# Favicon & Browser Identity
+
+The theme emits the browser-identity tags — favicon, scalable SVG icon, Apple touch icon, web manifest, and `theme-color` — from `_includes/core/favicon.html`, included in the document head on every page.
+
+## Why explicit tags matter
+
+Before this include existed, sites relied on the browser's *implicit* `/favicon.ico` probe. That fails silently in three ways:
+
+- A site without a root `favicon.ico` shows the browser's generic globe and logs a 404 on every visit.
+- Project-page deployments with a `baseurl` never resolve `/favicon.ico` at the domain root.
+- There is no way to supply an SVG icon, an iOS home-screen icon, or a PWA manifest implicitly.
+
+## Zero-config behavior
+
+With no configuration at all, every page links `/favicon.ico` explicitly (resolved through `relative_url`, so `baseurl` sites work), and `theme-color` falls back to your `theme_color.main` design token so the mobile address bar matches the site's palette.
+
+Keep a `favicon.ico` at your site root — a 32×32 icon is enough.
+
+## Full configuration
+
+All keys are optional. Add a `favicon:` block to `_config.yml`:
+
+```yaml
+favicon:
+  ico         : /favicon.ico                    # legacy .ico (default)
+  svg         : /assets/images/favicon.svg      # scalable icon, preferred by modern browsers
+  png         : /assets/images/favicon-32.png   # PNG icon
+  png_size    : 32x32                           # sizes attribute for the png entry
+  apple_touch : /assets/images/apple-touch.png  # iOS home-screen icon (180×180 or larger)
+  manifest    : /site.webmanifest               # PWA manifest
+  theme_color : "#0d1117"                       # browser chrome color (falls back to theme_color.main)
+```
+
+Which renders:
+
+```html
+<link rel="icon" href="/favicon.ico" sizes="32x32">
+<link rel="icon" type="image/svg+xml" href="/assets/images/favicon.svg">
+<link rel="icon" type="image/png" href="/assets/images/favicon-32.png" sizes="32x32">
+<link rel="apple-touch-icon" href="/assets/images/apple-touch.png">
+<link rel="manifest" href="/site.webmanifest">
+<meta name="theme-color" content="#0d1117">
+```
+
+## Recommendations
+
+- **SVG first.** A square SVG icon stays crisp at every size and can honor `prefers-color-scheme`. Keep the `.ico` as the legacy fallback.
+- **Reuse your brand mark.** If your `logo` is already a square SVG, point `favicon.svg` at the same file.
+- **Apple touch icons don't scale down well from tiny sources.** Use at least a 180×180 PNG.
+- **Remote-theme consumers**: this include ships with the theme — you only carry the icon *assets* and the optional `favicon:` block in your own repository.

--- a/pages/_docs/features/favicon.md
+++ b/pages/_docs/features/favicon.md
@@ -1,6 +1,7 @@
 ---
-title: Favicon & Browser Identity
+title: Favicon and Browser Identity Setup
 description: Config-driven favicon, Apple touch icon, web manifest, and theme-color tags emitted on every page, with a zero-config /favicon.ico fallback.
+keywords: [favicon, browser identity, apple touch icon, web manifest, theme color, svg favicon, jekyll theme]
 lastmod: 2026-07-22T00:00:00.000Z
 layout: default
 categories:

--- a/test/test_core.sh
+++ b/test/test_core.sh
@@ -689,6 +689,78 @@ test_giscus_comments() {
     return 0
 }
 
+test_favicon_wiring() {
+    log_info "Validating favicon include, head wiring, and analytics config gates..."
+
+    cd "$PROJECT_ROOT"
+
+    local include="$PROJECT_ROOT/_includes/core/favicon.html"
+    local head="$PROJECT_ROOT/_includes/core/head.html"
+    local failed=0
+
+    # 1. Favicon include exists and emits the explicit /favicon.ico default —
+    #    the implicit browser probe 404s on baseurl deployments.
+    if [[ -f "$include" ]]; then
+        if grep -qF 'rel="icon"' "$include" && grep -qF "default: '/favicon.ico'" "$include"; then
+            log_success "favicon include emits rel=icon with /favicon.ico default"
+        else
+            log_error "favicon include is missing the rel=icon /favicon.ico default"
+            failed=1
+        fi
+    else
+        log_error "Missing include: _includes/core/favicon.html"
+        failed=1
+    fi
+
+    # 2. head.html renders the include on every page.
+    if grep -qE 'include(_cached)?[[:space:]]+core/favicon\.html' "$head"; then
+        log_success "head.html includes core/favicon.html"
+    else
+        log_error "head.html does not include core/favicon.html"
+        failed=1
+    fi
+
+    # 3. The theme site carries the root favicon.ico the default points at.
+    if [[ -f "$PROJECT_ROOT/favicon.ico" ]]; then
+        log_success "root favicon.ico exists"
+    else
+        log_error "root favicon.ico is missing"
+        failed=1
+    fi
+
+    # 4. GTM includes must be config-gated — a hardcoded container ID would
+    #    silently enroll every consumer site into this theme's GTM container.
+    local gtm
+    for gtm in "_includes/analytics/google-tag-manager-head.html" "_includes/analytics/google-tag-manager-body.html"; do
+        if grep -qF 'if site.google_tag_manager' "$PROJECT_ROOT/$gtm"; then
+            log_success "$gtm gates on site.google_tag_manager"
+        else
+            log_error "$gtm is not gated on site.google_tag_manager"
+            failed=1
+        fi
+        if grep -qE "GTM-[A-Z0-9]{6,}" "$PROJECT_ROOT/$gtm"; then
+            log_error "$gtm hardcodes a GTM container ID"
+            failed=1
+        else
+            log_success "$gtm has no hardcoded GTM container ID"
+        fi
+    done
+
+    # 5. Legacy sidebar nav modes must alias to auto, not silently disable.
+    if grep -qF 'searchCats' "$PROJECT_ROOT/_includes/navigation/sidebar-config.html"; then
+        log_success "sidebar-config aliases legacy nav modes (tree/dynamic/searchCats)"
+    else
+        log_error "sidebar-config no longer aliases legacy nav modes"
+        failed=1
+    fi
+
+    if [[ "$failed" -ne 0 ]]; then
+        return 1
+    fi
+    log_success "Favicon and analytics wiring is valid"
+    return 0
+}
+
 # Regression for issue #219: the reusable component-showcase include must not
 # hardcode absolute demo links (e.g. /docs/, /pages/, /docs/customization/).
 # Such links 404 on any consumer site that lacks those exact routes, making the
@@ -797,6 +869,7 @@ run_core_tests() {
     log_info "=== VALIDATION TESTS ==="
     run_test "Liquid Template Validation" "test_liquid_templates" "validation"
     run_test "Giscus Comments Configuration" "test_giscus_comments" "validation"
+    run_test "Favicon and Analytics Wiring" "test_favicon_wiring" "validation"
     run_test "Showcase Demo Links (no absolute 404 hazards)" "test_showcase_demo_links" "validation"
     run_test "Sass Compilation" "test_sass_compilation" "validation"
     run_test "JavaScript Syntax" "test_javascript_syntax" "validation"


### PR DESCRIPTION
## Description

Cross-repo review of the core site chrome (favicon, navbar/sidebars, SEO head tags) across the five zer0-mistakes sites (theme + lifehacker.dev, it-journey, year-of-ai.github.io, bashconsultants) surfaced four theme-level defects. This PR fixes them at the source:

1. **Favicon / browser identity (ZER0-079, new)** — the theme emitted no `<link rel="icon">` at all; sites depended on the browser's implicit `/favicon.ico` probe, which 404s on sites without the file (lifehacker.dev had none) and never works for `baseurl` deployments. New `_includes/core/favicon.html` emits favicon / SVG icon / apple-touch / manifest / `theme-color` tags from an optional `favicon:` config block, with a zero-config `/favicon.ico` default and `theme-color` falling back to the `theme_color.main` design token. Docs: `pages/_docs/features/favicon.md`.
2. **GTM container hardcoded (`GTM-NN8P7RZ`)** — every consumer site's production build silently loaded this theme's own Google Tag Manager container (bashconsultants had to shadow the include with an empty file to opt out). Both GTM includes are now gated on a `google_tag_manager:` config key; the theme site keeps its container via `_config.yml`.
3. **og:image fallback never emitted** — in Liquid 4 `nil != blank` is TRUE, so `content/seo.html`'s unset `page_large_image` always won the branch and assigned a nil `seo_image`. Every page without a `page.header` image lost its `og:image`/`twitter:image`, defeating the `site.og_image` fallback on all sites. Verified before/after in built HTML.
4. **Legacy sidebar nav modes silently disable sidebars** — consumer configs still carry pre-1.x mode names (`tree`, `dynamic`, `searchCats`) that match no data file and no built-in mode. `sidebar-config.html` now aliases them to `auto`.

Companion consumer-side PRs: bamr87/lifehacker.dev, bamr87/it-journey, year-of-ai/year-of-ai.github.io, bamr87/bashconsultants (same branch name).

Follow-up candidates surfaced by the review (not in this PR, to keep it reviewable): upstreaming bashconsultants' PostHog privacy hardening (GPC honor, opt-out-by-default until consent, in-memory persistence, geoip disable — its override is explicitly marked "keep in sync with theme"), and it-journey's vendored giscus include which can likely be retired now that the upstream Liquid-in-comment bug is fixed.

## Type

- [x] `feat` — new feature
- [x] `fix` — bug fix
- [ ] `docs` — documentation only
- [ ] `refactor` / `perf` / `style`
- [x] `test` — tests only
- [ ] `chore` / `ci`

## Checklist

- [x] Conventional-commit title (`type(scope): subject`) — this drives the automated version bump
- [ ] `CHANGELOG.md` updated under `[Unreleased]` for user-visible changes — changelog is release-please-generated from the conventional commits in this PR (no `[Unreleased]` section exists)
- [x] `./test/test_core.sh` passes locally (16/16, including the new `Favicon and Analytics Wiring` validation test); full Docker-based suite not runnable in this environment
- [x] Theme/layout/include/sass change → Jekyll build validated (`bundle exec jekyll build --config '_config.yml,_config_dev.yml'` — Docker unavailable here; also validated production-env builds with the GTM key set and unset, a build with a legacy `sidebar.nav: tree` config, and a consumer build of lifehacker.dev against this branch)
- [x] No version bump (`lib/jekyll-theme-zer0/version.rb` untouched — releases are automated)
- [ ] Backlog task status updated in `_data/backlog.yml` (not implementing a backlog task)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JrhTG57oDiATRiSsC2nK6h

---
_Generated by [Claude Code](https://claude.ai/code/session_01JrhTG57oDiATRiSsC2nK6h)_