### PR TITLE
fix(ci): prefer CLAUDE_CODE_OAUTH_TOKEN over ANTHROPIC_API_KEY in all AI workflows

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -136,7 +136,7 @@ Deploys the AI-chat Cloudflare Worker via `wrangler-action`. Requires `CLOUDFLAR
 
 **Triggers:** PRs touching `pages/**/*.md` or `docs/**`, Manual dispatch
 
-Two tiers plus docs validation: (1) deterministic SEO/quality checks (`scripts/content-review.rb`, fork-safe, posts a sticky comment); (2) the Claude Code content-reviewer agent (only when `ANTHROPIC_API_KEY` is set and content actually changed); (3) front-matter, internal-link, and markdownlint jobs (formerly `docs-validate.yml`).
+Two tiers plus docs validation: (1) deterministic SEO/quality checks (`scripts/content-review.rb`, fork-safe, posts a sticky comment); (2) the Claude Code content-reviewer agent (only when a Claude credential — `CLAUDE_CODE_OAUTH_TOKEN` preferred, `ANTHROPIC_API_KEY` as fallback — is set and content actually changed); (3) front-matter, internal-link, and markdownlint jobs (formerly `docs-validate.yml`).
 
 ### `issue-autopilot.yml` — Issue autopilot
 
@@ -206,8 +206,10 @@ Every quality gate a contributor can run locally must be enforced somewhere in C
 GITHUB_TOKEN            # Automatically provided
 RUBYGEMS_API_KEY        # Gem publishing (release.yml → bamr87/.github publish)
 DOCKER_USERNAME/TOKEN   # Docker Hub publish (test-latest.yml)
-ANTHROPIC_API_KEY       # AI tiers (ai-content-review, ci-self-repair, autopilot)
-CLAUDE_CODE_OAUTH_TOKEN # Preferred Claude credential for the issue autopilot
+CLAUDE_CODE_OAUTH_TOKEN # Preferred Claude credential — all AI tiers (claude.yml,
+                        # ai-content-review, ci-self-repair, ui-audit, autopilot)
+ANTHROPIC_API_KEY       # Fallback Claude credential — same AI tiers, used only
+                        # when CLAUDE_CODE_OAUTH_TOKEN is absent
 CLOUDFLARE_API_TOKEN    # Chat proxy deploy
 CLOUDFLARE_ACCOUNT_ID   # Chat proxy deploy
 

--- a/.github/workflows/ai-content-review.yml
+++ b/.github/workflows/ai-content-review.yml
@@ -4,8 +4,9 @@ name: Content & Docs Review
 # Reviews changed Markdown content and docs on pull requests:
 #   1. Deterministic SEO + quality checks (scripts/content-review.rb) — always
 #      runs, no secrets required, works on fork PRs.
-#   2. Claude Code content-reviewer agent — runs only when ANTHROPIC_API_KEY is
-#      configured, for editorial/consistency/polish review.
+#   2. Claude Code content-reviewer agent — runs only when a Claude credential
+#      is configured (CLAUDE_CODE_OAUTH_TOKEN preferred, ANTHROPIC_API_KEY as
+#      fallback), for editorial/consistency/polish review.
 #   3. Docs front matter, internal links, and markdownlint (formerly the
 #      separate docs-validate.yml).
 # See .github/instructions/content-review.instructions.md for the contract.
@@ -54,13 +55,14 @@ jobs:
       - name: Check AI availability
         id: ai-gate
         env:
+          OAUTH: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           KEY: ${{ secrets.ANTHROPIC_API_KEY }}
         run: |
-          if [ -n "$KEY" ]; then
+          if [ -n "$OAUTH" ] || [ -n "$KEY" ]; then
             echo "enabled=true" >> "$GITHUB_OUTPUT"
           else
             echo "enabled=false" >> "$GITHUB_OUTPUT"
-            echo "::notice::ANTHROPIC_API_KEY not set — skipping the Claude Code review tier."
+            echo "::notice::No CLAUDE_CODE_OAUTH_TOKEN or ANTHROPIC_API_KEY set — skipping the Claude Code review tier."
           fi
 
       - name: Checkout
@@ -148,10 +150,16 @@ jobs:
       - name: Run content-reviewer agent (headless)
         id: agent
         env:
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           BASE_REF: origin/${{ github.base_ref }}
         run: |
           set +e
+          # House convention: OAuth wins when both are set — drop the API key
+          # entirely so an empty-string secret never triggers empty-key auth.
+          if [ -n "${CLAUDE_CODE_OAUTH_TOKEN:-}" ]; then
+            unset ANTHROPIC_API_KEY
+          fi
           read -r -d '' PROMPT <<EOF
           Use the content-reviewer subagent to review the Markdown content files
           changed on this branch versus ${BASE_REF}. Follow

--- a/.github/workflows/ci-self-repair.yml
+++ b/.github/workflows/ci-self-repair.yml
@@ -114,10 +114,16 @@ jobs:
       - name: Run Claude self-repair (headless)
         if: steps.gate.outputs.go == 'true' && steps.budget.outputs.exhausted == 'false'
         env:
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
         run: |
-          if [ -z "${ANTHROPIC_API_KEY:-}" ]; then
-            echo "::notice::ANTHROPIC_API_KEY not set — skipping self-repair (PR will be gated)."; exit 0
+          if [ -z "${CLAUDE_CODE_OAUTH_TOKEN:-}" ] && [ -z "${ANTHROPIC_API_KEY:-}" ]; then
+            echo "::notice::No CLAUDE_CODE_OAUTH_TOKEN or ANTHROPIC_API_KEY set — skipping self-repair (PR will be gated)."; exit 0
+          fi
+          # House convention: OAuth wins when both are set — drop the API key
+          # entirely so an empty-string secret never triggers empty-key auth.
+          if [ -n "${CLAUDE_CODE_OAUTH_TOKEN:-}" ]; then
+            unset ANTHROPIC_API_KEY
           fi
           set +e
           PROMPT="$(cat .github/prompts/ci-self-repair.prompt.md)

--- a/.github/workflows/ui-audit.yml
+++ b/.github/workflows/ui-audit.yml
@@ -7,7 +7,8 @@
 #   1. Deterministic sweep (no tokens): serve the site, walk the critical
 #      routes at mobile/tablet/desktop, capture screenshots + axe + console
 #      errors + overflow + broken internal links → test/ui-audit/output/.
-#   2. Claude Code ui-auditor agent (only when ANTHROPIC_API_KEY is set):
+#   2. Claude Code ui-auditor agent (only when a Claude credential is set —
+#      CLAUDE_CODE_OAUTH_TOKEN preferred, ANTHROPIC_API_KEY as fallback):
 #      reads the sweep output and the component contract
 #      (docs/architecture/ui-components.md) and writes a prioritized findings
 #      report. The agent is read-only — it never edits files or posts.
@@ -47,13 +48,14 @@ jobs:
       - name: Check AI availability
         id: ai-gate
         env:
+          OAUTH: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           KEY: ${{ secrets.ANTHROPIC_API_KEY }}
         run: |
-          if [ -n "$KEY" ]; then
+          if [ -n "$OAUTH" ] || [ -n "$KEY" ]; then
             echo "enabled=true" >> "$GITHUB_OUTPUT"
           else
             echo "enabled=false" >> "$GITHUB_OUTPUT"
-            echo "::notice::ANTHROPIC_API_KEY not set — sweep runs, agent tier skipped."
+            echo "::notice::No CLAUDE_CODE_OAUTH_TOKEN or ANTHROPIC_API_KEY set — sweep runs, agent tier skipped."
           fi
 
       - name: Checkout
@@ -107,9 +109,15 @@ jobs:
       - name: Run ui-auditor agent (headless, read-only)
         if: steps.ai-gate.outputs.enabled == 'true'
         env:
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
         run: |
           set +e
+          # House convention: OAuth wins when both are set — drop the API key
+          # entirely so an empty-string secret never triggers empty-key auth.
+          if [ -n "${CLAUDE_CODE_OAUTH_TOKEN:-}" ]; then
+            unset ANTHROPIC_API_KEY
+          fi
           read -r -d '' PROMPT <<'EOF'
           Use the ui-auditor subagent to review the UI/UX sweep in
           test/ui-audit/output/ against docs/architecture/ui-components.md.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Installer spec default `ai.provider` is now `auto` (was `openai`); the AI
   wizard records the provider that actually served the run.
+- **CI workflows now honor `CLAUDE_CODE_OAUTH_TOKEN`** — `ui-audit.yml`,
+  `ai-content-review.yml`, and `ci-self-repair.yml` previously gated their
+  Claude Code agent tier on `ANTHROPIC_API_KEY` alone, silently ignoring a
+  configured OAuth token. They now follow the same house convention as
+  `claude.yml` / `issue-autopilot.yml`: `CLAUDE_CODE_OAUTH_TOKEN` preferred,
+  `ANTHROPIC_API_KEY` used only when it's absent.
 
 ### Fixed
 


### PR DESCRIPTION
## Description

Audited every workflow under `.github/workflows/` for how it authenticates to Claude, and fixed the ones that didn't follow the repo's documented house convention (`CLAUDE_CODE_OAUTH_TOKEN` preferred, `ANTHROPIC_API_KEY` as fallback — see `claude.yml`'s header comment and `.github/actions/claude-run/action.yml`).

**Findings:**
- `claude.yml`, `issue-autopilot.yml` (via the `claude-run` composite action), and `translate.yml` (via `scripts/translate.rb`'s own precedence) already implemented OAuth-first correctly — no changes needed.
- `ui-audit.yml`, `ai-content-review.yml`, and `ci-self-repair.yml` gated their Claude Code agent tier on `ANTHROPIC_API_KEY` alone and never read `CLAUDE_CODE_OAUTH_TOKEN` at all — a configured OAuth token was silently ignored in these three workflows.
- `deploy-chat-proxy.yml` deploys a Cloudflare Worker that calls the Anthropic Messages API directly (not via Claude Code). Its `worker.js` already implements OAuth-first precedence, but the OAuth modes are documented as a personal, Cloudflare-Access-gated credential deliberately not used for the shared CI deploy — left unchanged as that's an intentional security boundary, not an oversight.

**Changes:**
- `ui-audit.yml`, `ai-content-review.yml`, `ci-self-repair.yml`: the availability-check steps now treat either `CLAUDE_CODE_OAUTH_TOKEN` or `ANTHROPIC_API_KEY` as "AI enabled"; the agent-invocation steps now export both env vars and `unset ANTHROPIC_API_KEY` whenever the OAuth token is present, matching the same trick already used in `.github/actions/claude-run/action.yml`.
- `.github/workflows/README.md`: updated the secrets table and the content-review description to reflect OAuth-first across all AI tiers, not just the issue autopilot.
- `CHANGELOG.md`: noted the fix under `[Unreleased] → Changed`.

## Type

- [x] `fix` — bug fix

## Checklist

- [x] Conventional-commit title (`type(scope): subject`) — this drives the automated version bump
- [x] `CHANGELOG.md` updated under `[Unreleased]` for user-visible changes
- [ ] `./scripts/bin/test` passes locally (10/10 suites) — not run; changes are workflow-only YAML/shell, validated with `actionlint`-equivalent YAML parsing (actionlint itself unavailable in this sandbox)
- [ ] Theme/layout/include/sass change → Jekyll build validated — N/A, no theme files touched
- [x] No version bump (`lib/jekyll-theme-zer0/version.rb` untouched — releases are automated)
- [ ] Backlog task status updated in `_data/backlog.yml` — N/A, not tracked as a backlog task


---
_Generated by [Claude Code](https://claude.ai/code/session_01B5iE63BzzbfHZ9jyEmYVug)_