### PR TITLE
fix(i18n): normalise generated prose so translation runs keep CI green

### DIFF
--- a/.github/workflows/translate.yml
+++ b/.github/workflows/translate.yml
@@ -111,6 +111,24 @@ jobs:
           fi
           ruby scripts/translate.rb "${args[@]}"
 
+      # Guaranteed backstop for the one-paragraph-per-line rule that
+      # markdown-oneline.yml enforces. translate.rb already normalises the
+      # pages it writes, but it does so best-effort (it skips when python3 is
+      # missing). This step is the one that matters: it runs immediately before
+      # the files are committed, on a runner where python3 always exists.
+      #
+      # Without it, a provider that soft-wraps a translated paragraph lands
+      # wrapped prose in fr/**, the oneline check goes red on the translation
+      # PR, and — once merged — stays red on main for everyone.
+      - name: Normalise generated prose
+        if: steps.creds.outputs.found == 'true' && inputs.dry_run != true
+        run: |
+          set -euo pipefail
+          python3 tools/unwrap-prose.py --write fr _data/i18n 2>/dev/null || true
+          # Fail loudly if anything is still wrapped — a silent pass here would
+          # just move the failure to the PR's own CI run.
+          python3 tools/unwrap-prose.py --check fr _data/i18n
+
       # Open/update a PR instead of pushing to main directly (main is
       # protected). Stable branch → repeated runs update the same PR rather
       # than spawning new ones. NOTE: PRs opened with GITHUB_TOKEN do not

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Translation runs no longer break the `oneline` check.** `scripts/translate.rb`
+  writes whatever the provider returns, and a provider is free to soft-wrap a
+  translated paragraph across several lines — no prompt instruction reliably
+  prevents it. Wrapped prose then landed in `fr/**`, turned
+  `markdown-oneline.yml` red on the translation PR, and stayed red on `main`
+  after it merged. Two of the currently committed translations were in exactly
+  that state.
+  - `translate.rb` now normalises every page it writes through
+    `tools/unwrap-prose.py` — the same tool CI runs, so the rule has one source
+    of truth instead of a reimplementation that could drift. Best-effort: a
+    missing `python3` warns rather than failing an otherwise good run.
+  - `.github/workflows/translate.yml` runs the same tool as a guaranteed
+    backstop immediately before committing, then `--check`s its own work so a
+    silent failure cannot just move the breakage to the PR's CI run.
+  - The tool is resolved relative to `translate.rb` rather than `--root`;
+    `--root` points at the content tree being translated, so the previous
+    lookup missed the tool whenever the two differed.
+  - Unwrapped the two affected files, so `oneline` passes on `main` again.
+  - Regression test in `test/test_i18n.sh` backed by a new `stub-wrap`
+    provider that soft-wraps at 40 columns. Asserting "output is unwrapped"
+    against the plain stub would have passed whether or not normalisation ran.
+
 ### Added
 
 - **Theme propagation system — releases now reach the sites built on them.**

--- a/fr/docs/customization/author-profiles.md
+++ b/fr/docs/customization/author-profiles.md
@@ -175,9 +175,7 @@ Le thème est livré avec deux personas d'exemple (voir leurs profils sur `/auth
 
 ### Style artistique de prévisualisation par auteur
 
-Un auteur IA peut également posséder un **style artistique distinct** pour ses bannières de prévisualisation générées. Ajoutez un bloc `preview:` à l'auteur et le
-[générateur d'images de prévisualisation](⟦81⟧)
-utilisera ces paramètres **au lieu de** la configuration `preview_images` à l'échelle du site (`_config.yml`) — mais uniquement pour les articles qui définissent `author: <that key>`. Tout autre article conserve le style par défaut.
+Un auteur IA peut également posséder un **style artistique distinct** pour ses bannières de prévisualisation générées. Ajoutez un bloc `preview:` à l'auteur et le [générateur d'images de prévisualisation](⟦81⟧) utilisera ces paramètres **au lieu de** la configuration `preview_images` à l'échelle du site (`_config.yml`) — mais uniquement pour les articles qui définissent `author: <that key>`. Tout autre article conserve le style par défaut.
 
 ```yaml
 cassandra:

--- a/fr/posts/2024-06-17-wizard-topples-capitalist-dominance-ingeniously.md
+++ b/fr/posts/2024-06-17-wizard-topples-capitalist-dominance-ingeniously.md
@@ -205,8 +205,7 @@ Avant de déclarer un projet « de niveau Merlin », vérifiez :
 
 **Q : L'audit d'équité a signalé un écart de parité important. Que faire maintenant ?** Ne livrez pas. Documentez l'écart, enquêtez sur les causes profondes (biais des données d'entraînement, proxys de caractéristiques, biais d'étiquetage) et envisagez des mesures d'atténuation comme la repondération, l'optimisation des seuils ou la suppression complète du modèle. « Nous savions et avons livré quand même » est pire que « nous n'avons rien trouvé ».
 
-**Q : Le diagramme Mermaid ne s'affiche pas sur mon fork du thème.**
-Assurez-vous que le front matter de la page contient `mermaid: true`. Le thème Zer0-Mistakes ne charge le bundle Mermaid que lorsque cet indicateur est défini—voir [`_includes/components/mermaid.html`](⟦11⟧/blob/main/_includes/components/mermaid.html) pour l'implémentation.
+**Q : Le diagramme Mermaid ne s'affiche pas sur mon fork du thème.** Assurez-vous que le front matter de la page contient `mermaid: true`. Le thème Zer0-Mistakes ne charge le bundle Mermaid que lorsque cet indicateur est défini—voir [`_includes/components/mermaid.html`](⟦11⟧/blob/main/_includes/components/mermaid.html) pour l'implémentation.
 
 **Q : Le script SEC EDGAR renvoie une erreur 403.** EDGAR exige un `User-Agent` descriptif avec une adresse e-mail de contact. Mettez à jour le dictionnaire `UA` dans l'extrait ci-dessus et évitez de surcharger l'API—restez sous 10 requêtes/seconde.
 

--- a/scripts/translate.rb
+++ b/scripts/translate.rb
@@ -367,6 +367,42 @@ module Zer0Translate
     end
   end
 
+  # Test-only variant of StubProvider that soft-wraps its output, reproducing
+  # the one thing a real provider does that no prompt can reliably prevent.
+  # Exists so the prose-normalisation pass has something to actually fix —
+  # asserting "output is unwrapped" against the plain stub would pass whether
+  # or not normalisation ran.
+  class WrappingStubProvider
+    WRAP_AT = 40
+
+    def name = "stub-wrap"
+
+    def translate(segments, target_lang, _context)
+      segments.to_h { |key, text| [key, wrap("#{text} [#{target_lang}]")] }
+    end
+
+    private
+
+    # Greedy wrap on spaces. Never splits a line that has no space past the
+    # column (a long URL or placeholder token stays intact).
+    def wrap(text)
+      out = []
+      line = +""
+      text.split(" ").each do |word|
+        if line.empty?
+          line << word
+        elsif line.length + 1 + word.length > WRAP_AT
+          out << line
+          line = +word
+        else
+          line << " " << word
+        end
+      end
+      out << line unless line.empty?
+      out.join("\n")
+    end
+  end
+
   class ClaudeProvider
     ENDPOINT = URI("https://api.anthropic.com/v1/messages")
     API_VERSION = "2023-06-01"
@@ -762,6 +798,9 @@ module Zer0Translate
       @url_builder = UrlBuilder.new(@site_config)
       @manifest = Manifest.new(@root)
       @stats = Hash.new(0)
+      # Absolute paths of every markdown file this run wrote, for the
+      # prose-normalisation pass in `run`.
+      @written_pages = []
     end
 
     def run
@@ -790,6 +829,7 @@ module Zer0Translate
 
       translator = build_translator
       execute(plan, translator)
+      normalize_prose(@written_pages)
       prune(sources, languages)
       @manifest.save(source_lang, languages)
       summary
@@ -922,6 +962,7 @@ module Zer0Translate
       provider =
         case provider_name
         when "stub" then StubProvider.new
+        when "stub-wrap" then WrappingStubProvider.new
         when "claude"
           ClaudeProvider.new(
             model: @options[:model] || ENV["TRANSLATE_MODEL"] || @config["model"],
@@ -946,6 +987,45 @@ module Zer0Translate
         label = job.type == :page ? job.source.rel_path : "ui-text"
         Log.error "[#{job.lang}] #{label}: #{e.message}"
         @stats[:failed] += 1
+      end
+    end
+
+    # Generated pages must satisfy the repo's one-paragraph-per-line rule, which
+    # CI enforces via .github/workflows/markdown-oneline.yml. The provider is
+    # free to soft-wrap a translated paragraph across several lines — nothing in
+    # the prompt can guarantee otherwise — so normalise deterministically after
+    # the fact rather than hoping the model complies.
+    #
+    # tools/unwrap-prose.py is the single source of truth for the rule (it is
+    # what CI runs), so shell out to it instead of reimplementing the classifier
+    # here and letting the two drift.
+    #
+    # Best-effort by design: a missing python3 should not fail an otherwise good
+    # translation run. The Translate workflow runs the same tool as a guaranteed
+    # backstop before committing, so the only cost of skipping here is a local
+    # run leaving wrapped prose for that step to fix.
+    def normalize_prose(paths)
+      paths = paths.select { |p| File.file?(p) }
+      return if paths.empty?
+
+      # Resolve the tool relative to THIS script, not to --root. translate.rb
+      # and tools/ ship together; --root points at the content tree being
+      # translated, which is a different thing (and is a throwaway sandbox
+      # under test).
+      tool = File.expand_path("../tools/unwrap-prose.py", __dir__)
+      tool = File.join(@root, "tools", "unwrap-prose.py") unless File.file?(tool)
+      unless File.file?(tool)
+        Log.warn "tools/unwrap-prose.py not found — skipping prose normalisation"
+        return
+      end
+
+      ok = system("python3", tool, "--write", *paths,
+                  out: File::NULL, err: File::NULL)
+      if ok
+        Log.info "Normalised prose in #{paths.size} generated page(s)"
+      else
+        Log.warn "prose normalisation skipped (python3 unavailable or tool failed); " \
+                 "run: python3 tools/unwrap-prose.py --write"
       end
     end
 
@@ -1007,6 +1087,7 @@ module Zer0Translate
       abs = File.join(@root, out_rel)
       FileUtils.mkdir_p(File.dirname(abs))
       File.write(abs, "#{fm.to_yaml}---\n\n#{body_out.sub(/\A\n+/, '')}")
+      @written_pages << abs
     end
 
     def translate_ui_text(job, translator)

--- a/test/test_i18n.sh
+++ b/test/test_i18n.sh
@@ -128,6 +128,45 @@ YAML
 run_translate() { ruby "$TRANSLATE" --root "$sandbox" "$@"; }
 
 # ---------------------------------------------------------------------------
+# Generated prose must satisfy the repo's one-paragraph-per-line rule that
+# .github/workflows/markdown-oneline.yml enforces.
+#
+# Uses the stub-wrap provider, which soft-wraps at 40 columns the way a real
+# model does. Against the plain stub this would pass whether or not
+# normalisation ran, which is why the wrapping variant exists.
+test_prose_normalisation() {
+  log_info "Test: generated prose is normalised to one paragraph per line"
+  build_sandbox
+
+  local unwrap="$REPO_ROOT/tools/unwrap-prose.py"
+  if ! command -v python3 >/dev/null 2>&1 || [[ ! -f "$unwrap" ]]; then
+    log_info "  (skipped: python3 or tools/unwrap-prose.py unavailable)"
+    return 0
+  fi
+
+  run_translate --provider stub-wrap >/dev/null
+
+  local post="$sandbox/fr/posts/2026-01-15-hello-world.md"
+  assert "translation is generated with the wrapping provider" test -f "$post"
+
+  # The whole-tree check: nothing the run wrote may still be wrapped.
+  assert "generated pages pass the oneline check" python3 "$unwrap" --check "$sandbox/fr"
+
+  # Proof the fixture is meaningful rather than vacuous. The provider wraps at
+  # 40 columns, so a prose line longer than that can only exist if
+  # normalisation rejoined it.
+  assert "a wrapped paragraph was rejoined past the 40-col wrap point" \
+    awk 'BEGIN{fm=0} /^---$/{fm++; next} fm>=2 && /\[fr\]$/ && length($0)>40 {found=1} END{exit !found}' "$post"
+
+  # Normalisation must not have touched anything structural on its way through.
+  assert "code fence content survives normalisation" \
+    grep -q '^echo "do not translate me"' "$post"
+  assert "liquid output tag survives normalisation" grep -qF '{{ site.title }}' "$post"
+  assert "no placeholder tokens leak after normalisation" \
+    bash -c "test -f '$post' && ! grep -q '⟦' '$post'"
+}
+
+# ---------------------------------------------------------------------------
 test_generation() {
   log_info "Test: full generation with stub provider"
   build_sandbox
@@ -245,6 +284,7 @@ test_theme_wiring() {
 main() {
   log_info "i18n translation pipeline tests"
   test_generation
+  test_prose_normalisation
   test_incremental
   test_check_and_dry_run
   test_prune


### PR DESCRIPTION
## Description

Fixes the recurring conflict between the translation pipeline and the `oneline` check, at the source. Split out of #339 at the maintainer's request.

**`oneline` is currently red on `main`.** Two committed translations carry soft-wrapped prose:

```
fr/docs/customization/author-profiles.md
fr/posts/2024-06-17-wizard-topples-capitalist-dominance-ingeniously.md
```

`scripts/translate.rb` writes whatever the provider returns, and a provider is free to wrap a translated paragraph across several lines — no prompt instruction reliably prevents it. That prose lands in `fr/**`, turns `markdown-oneline.yml` red on the translation PR, and stays red on `main` once merged. Unwrapping the files by hand fixes it until the next translation run puts it back.

## Approach

Two options were on the table: teach the pipeline to emit unwrapped prose, or exclude `fr/**` from the check. This takes the first — excluding generated alternates would mean the rule quietly stops applying to a growing share of the repo's Markdown.

- **`translate.rb` normalises every page it writes** through `tools/unwrap-prose.py`. That tool is what CI runs, so shelling out to it keeps one source of truth for the rule rather than a Ruby reimplementation free to drift from the Python classifier. Best-effort: a missing `python3` warns rather than failing an otherwise good run.

- **`translate.yml` runs the same tool as a guaranteed backstop** immediately before the files are committed, on a runner where `python3` always exists, then `--check`s its own work. Without that second call a silent failure would just relocate the breakage to the PR's own CI run. `.github/workflows/` is CODEOWNERS-owned, so this needs your review.

- **The tool is resolved relative to `translate.rb`** via `__dir__`, not `--root`. `--root` points at the content tree being translated — a different thing, and a throwaway sandbox under test. The first draft of this fix looked the tool up under `--root` and silently skipped normalisation whenever the two differed; the new test caught it.

- **Unwrapped the two affected files**, so `oneline` passes on `main` again.

## Testing

New `test_prose_normalisation` in `test/test_i18n.sh`, backed by a `stub-wrap` provider that soft-wraps at 40 columns.

The existing `stub` provider never wraps, so asserting "output is unwrapped" against it would pass whether or not normalisation ran. The test also asserts that a rejoined prose line **exceeds** the 40-column wrap point — only possible if the pass actually did something — and that fences, Liquid tags, and placeholder tokens survive it.

```
test/test_i18n.sh: 52 passed, 0 failed
```

## Interaction with #339

#339 contains the same two-file unwrap as a stopgap. Whichever merges first, the other's change to those files is identical output from the same tool, so it resolves to a no-op rather than a conflict. Once this lands, #339 no longer carries the caveat that its fix gets reverted by the next translation run.

## Type

- [ ] `feat` — new feature
- [x] `fix` — bug fix
- [ ] `docs` — documentation only
- [ ] `refactor` / `perf` / `style`
- [ ] `test` — tests only
- [ ] `chore` / `ci`

## Checklist

- [x] Conventional-commit title (`type(scope): subject`)
- [x] `CHANGELOG.md` updated under `[Unreleased]`
- [ ] `./scripts/bin/test` passes locally (10/10 suites) — the relevant suite (`test/test_i18n.sh`) passes 52/52
- [x] Theme/layout/include/sass change → n/a, no theme files touched
- [x] No version bump (`lib/jekyll-theme-zer0/version.rb` untouched)
- [ ] Backlog task status updated in `_data/backlog.yml` — n/a, no backlog task

## Verification

- `test/test_i18n.sh` — 52 passed, 0 failed.
- `python3 tools/unwrap-prose.py --check` under the exact CI invocation — passes.
- `./scripts/validate --quick` — passes.
- `ruby -c scripts/translate.rb`, `bash -n test/test_i18n.sh` — clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HGVMZnU6MV32kESizd7H2B)_