### PR TITLE
fix(books): pin abc-demo permalink so its cover lands at /books/abc-demo/

### DIFF
--- a/pages/_books/abc-demo/index.md
+++ b/pages/_books/abc-demo/index.md
@@ -3,6 +3,11 @@ title: "The Zer0 Alphabet"
 subtitle: "A is for Anchor"
 layout: book-abc
 book: abc-demo
+# Without this, the `books` collection permalink (/:collection/:path/) resolves
+# :path to "abc-demo/index" and the cover lands at /books/abc-demo/index/,
+# leaving /books/abc-demo/ with no page. zer0-tales/index.md pins its own
+# permalink for the same reason.
+permalink: /books/abc-demo/
 series: abc-language
 audience: "Ages 1–4 (toddler board book)"
 art_style: crayon-primary


### PR DESCRIPTION
## Description

Fixes the nightly extended tier, red every day since Jul 22 (sticky issue #326).

The shell-suite matrix passes — the failure is three Playwright tests in `test/visual/features/book-abc.spec.js`, all timing out on:

```
waiting for locator('.abc-jump-link')
```

The element isn't missing. It renders fine in `_layouts/book-abc.html:75`. **The page just isn't at the URL the test asks for.**

## Root cause

The `books` collection permalink is `/:collection/:path/`, and `:path` for `pages/_books/abc-demo/index.md` resolves to `abc-demo/index`. So the cover built to `/books/abc-demo/index/` and `/books/abc-demo/` had no page at all:

```
built:      /books/abc-demo/index/index.html
test wants: /books/abc-demo/
```

The sibling book pins its own permalink (`zer0-tales/index.md:28`) and so was never affected — which is why exactly one book broke, and why this looked like flakiness rather than a config gap.

Pinning `abc-demo`'s permalink the same way puts the cover back. Added a comment so the next book author sees why it's there rather than assuming it's redundant.

## Verification — ran the spec, didn't just inspect

Built with the same config the Playwright job serves (`_config.yml,_config_dev.yml`), then ran the failing spec:

```
npx playwright test --config=test/playwright.config.js --project=smoke \
  test/visual/features/book-abc.spec.js

  ✓ renders one card per alphabet entry with the art-style skin (1.2s)
  ✓ planned plates show a placeholder, never a broken image (758ms)
  ✓ quick-jump links target the letter anchors (794ms)
  ✓ does not overflow the viewport horizontally on mobile (614ms)

  4 passed (5.3s)
```

Each assertion against the rebuilt page:

| Selector | Built page | Test expects |
|---|---|---|
| `.abc-jump-link` | 6, first `href="#letter-a"` | 6, `/#letter-a$/` |
| `.abc-letter-placeholder` | 6 | 6 |
| `.abc-letter-img` | 0 | 0 |
| `.abc-letter-glyph` | 6 | 6 |
| `.abc-board` | 1 | 1 |

*(Local note: this sandbox ships Chromium 1194 while the pinned `@playwright/test` 1.58.2 wants 1208, so I symlinked the available headless shell for the run rather than downloading browsers. That's a sandbox detail — CI installs its own.)*

## Scope

Closes the **book-abc half** of #326. That sticky issue also records an older `Visual snapshots (9 skins)` failure from Jul 22, which is a separate problem and is untouched here — worth leaving #326 open until that one's chased down too.

## Type

- [ ] `feat` — new feature
- [x] `fix` — bug fix
- [ ] `docs` — documentation only
- [ ] `refactor` / `perf` / `style`
- [ ] `test` — tests only
- [ ] `chore` / `ci`

## Checklist

- [x] Conventional-commit title (`type(scope): subject`)
- [ ] `CHANGELOG.md` updated under `[Unreleased]` — deliberately skipped; see note below
- [x] Jekyll build validated (`_config.yml,_config_dev.yml`) — page now builds to `/books/abc-demo/index.html`
- [x] No version bump (`lib/jekyll-theme-zer0/version.rb` untouched)
- [ ] Backlog task status updated in `_data/backlog.yml` — n/a

On the CHANGELOG box: #344 is currently repairing that file, and adding an `[Unreleased]` entry here would collide with it. The Conventional Commit title means release-please picks this up regardless. Happy to add one if you'd rather.

## Verification

- `./scripts/validate --quick` passes.
- `python3 tools/unwrap-prose.py --check` passes under the exact CI invocation.
- Diff is 5 lines in one file.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HGVMZnU6MV32kESizd7H2B)_