### PR TITLE
fix(layouts): guard collection layout against an unresolvable page.collection

### DIFF
--- a/_layouts/collection.html
+++ b/_layouts/collection.html
@@ -54,12 +54,22 @@ layout: default
 <!-- COLLECTION DATA PROCESSING -->
 <!-- ========================== -->
 <!-- Extract and sort collection entries based on page configuration -->
+<!--
+  `page.collection` is only populated for documents that actually live in a
+  collection directory. A plain page that merely declares `layout: collection`
+  (the translated copies under `fr/`, for example) leaves it nil, so
+  `site[page.collection]` resolves to nil and Jekyll's `sort` filter raises
+  "Cannot sort a null object" — aborting the *entire* site build, here and in
+  every downstream site consuming this theme. Guard the lookup instead.
+-->
 {% assign entries = site[page.collection] %}
-{% assign entries = entries | sort: page.sort_order %}
+{% if entries %}
+    {% assign entries = entries | sort: page.sort_order %}
 
-<!-- Handle reverse sorting if specified -->
-{% if page.sort_order == 'reverse' %}
-    {% assign entries = entries | reverse %}
+    <!-- Handle reverse sorting if specified -->
+    {% if page.sort_order == 'reverse' %}
+        {% assign entries = entries | reverse %}
+    {% endif %}
 {% endif %}
 
 <!-- ========================== -->


### PR DESCRIPTION
<!-- fleet-doctor key="bamr87/zer0-mistakes:.github/workflows/test-latest.yml" -->

## Problem

`TEST (Latest Dependencies)` (`.github/workflows/test-latest.yml`) is **failing** and flagged **cron-heavy** (20 runs / 171.5m over 14d, 65% scheduled).

The `failing` signal is real and new. The workflow was green on every run through `943f463c` (2026-08-05 07:01 UTC, scheduled), then went red on both runs since:

| run | trigger | sha | result |
|---|---|---|---|
| [31070571621](https://github.com/bamr87/zer0-mistakes/actions/runs/31070571621) | push | `3f4890ce` | failure |
| [31079349879](https://github.com/bamr87/zer0-mistakes/actions/runs/31079349879) | schedule | `76e37655` | failure |

Both die in the same place — job `Test Suite`, step **Run Jekyll Build Test**:

```
Liquid Exception: Liquid error (line 54): Cannot sort a null object. in /_layouts/collection.html
/usr/local/bundle/gems/jekyll-3.10.0/lib/jekyll/filters.rb:229:in `sort': Liquid::ArgumentError
```

This is *not* upstream dependency drift, so the `cron-heavy` "reduce the cadence" angle would have been the wrong call — the daily canary did exactly its job and caught a real regression on `main`.

## Root cause

Body line 54 of `_layouts/collection.html` is file line 58 (Liquid numbers the body after front matter):

```liquid
{% assign entries = site[page.collection] %}
{% assign entries = entries | sort: page.sort_order %}   <-- raises
```

`page.collection` is only populated by Jekyll for documents that actually live in a collection directory. For a **plain page** that merely declares `layout: collection` in its front matter it is nil — so `site[nil]` is nil, and `Jekyll::Filters#sort` raises on a nil input:

```ruby
raise ArgumentError, "Cannot sort a null object." if input.nil?
```

The regression entered with the i18n work between the last green build and the first red one. `303dfc54` ("chore(i18n): refresh machine-generated translations", #346) copied collection **index** pages into `fr/**` verbatim — preserving `layout: collection` while losing the collection membership that makes `page.collection` resolve. Two such pages exist today:

- `fr/docs/index.md` — `layout: collection`, sits under `fr/`, not in a collection
- `fr/docs/jekyll/collections.md` — same

The follow-up `3f4890ce` ("fix(i18n): exclude admin config page from translation to unbreak Pages deploy", #349) removed `fr/about/settings/config.md` for what looks like the same class of failure. That treated one symptom; the layout still hard-crashes on the next one.

## Fix

One guard in `_layouts/collection.html` — only sort/reverse when the collection actually resolves:

```liquid
{% assign entries = site[page.collection] %}
{% if entries %}
    {% assign entries = entries | sort: page.sort_order %}

    {% if page.sort_order == 'reverse' %}
        {% assign entries = entries | reverse %}
    {% endif %}
{% endif %}
```

The `{% for post in entries %}` grid below already renders nothing for a nil `entries`, so an unresolvable collection now yields an empty index rather than a fatal build error. No behaviour change for any page whose collection does resolve.

This is a genuine theme defect, not a CI workaround: **`jekyll-theme-zer0` is a published gem / remote theme.** A layout that raises `Liquid::ArgumentError` takes down the entire build of every downstream consumer (`it-journey`, the bamr87 dash, the sites in `_data/consumers.yml`) over one page with a mis-set `layout:`. Robustness against a nil collection belongs in the theme.

## Expected impact

- Unblocks `TEST (Latest Dependencies)` and the `main` Pages deploy.
- Stops the whack-a-mole of deleting individual `fr/**` files each time the translation pipeline emits another collection-index copy.
- Recovers ~8.6m per failed run; the canary runs daily and two runs are already lost.

## Follow-up (deliberately not in this PR)

The complementary fix belongs in the translation pipeline: `scripts/translate.rb` should either skip collection index pages or rewrite `layout: collection` -> `layout: default` for generated pages that land outside a collection, per `translation.instructions.md`. Keeping that separate leaves this PR as the one-hunk root-cause guard.

## Links

- Failing runs: [31079349879](https://github.com/bamr87/zer0-mistakes/actions/runs/31079349879) (schedule), [31070571621](https://github.com/bamr87/zer0-mistakes/actions/runs/31070571621) (push)
- Last green run: [30983423317](https://github.com/bamr87/zer0-mistakes/actions/runs/30983423317)
- Dash Actions analytics: https://bamr87.github.io/bamr87/actions/

---
🤖 Opened by the fleet doctor (`fleet-pulse.yml` in bamr87/bamr87) · Generated with [Claude Code](https://claude.com/claude-code)
