### PR TITLE
feat(ci): deploy the site via Actions so examples reach the live domain

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,115 @@
+# Feature: ZER0-015
+# GitHub Pages deployment for zer0-mistakes.com.
+#
+# Replaces the classic "deploy from a branch" Pages build. That builder runs a
+# single `jekyll build` with _config.yml, which is why nothing under examples/
+# could ever reach the live site: examples/ is in that config's `exclude:` list,
+# and each example is a SEPARATE Jekyll site with its own _config.yml,
+# collections, and skin — so it cannot simply be un-excluded and folded into the
+# main build.
+#
+# This workflow runs one build per site and stitches the results:
+#
+#   _site/                        <- the theme's own site (_config.yml)
+#   _site/examples/swerve-of-shore/  <- the example (_config.yml,_config_deploy.yml)
+#
+# Adding another example means adding it to the `example` matrix below.
+#
+# IMPORTANT: this only takes effect once the repository's Pages source is set to
+# "GitHub Actions" (Settings -> Pages -> Build and deployment -> Source). While
+# the source is still "Deploy from a branch", the classic builder keeps serving
+# the site and this workflow's deploy step is inert.
+name: Pages
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Never let two deploys race; let an in-flight one finish rather than shipping
+# a half-built tree.
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    name: Build site + examples
+    runs-on: ubuntu-latest
+    env:
+      # The github-pages gem's metadata plugin aborts the build without this
+      # when it cannot infer the repository from the git remote.
+      PAGES_REPO_NWO: ${{ github.repository }}
+      # The theme's SCSS contains multibyte characters; a non-UTF-8 default
+      # external encoding makes the Sass converter fail with
+      # "Invalid US-ASCII character".
+      LANG: C.UTF-8
+      LC_ALL: C.UTF-8
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.3'
+          bundler-cache: true
+
+      - name: Build the theme site
+        run: |
+          set -euo pipefail
+          bundle exec jekyll build --config _config.yml --destination _site
+
+      # Each example is its own Jekyll site. Build it with its own config and
+      # drop the result into the main site's tree at the path its baseurl
+      # expects. The root Gemfile resolves `theme: jekyll-theme-zer0` to this
+      # repository, so examples render against the current sources.
+      - name: Build examples
+        run: |
+          set -euo pipefail
+          for example in swerve-of-shore; do
+            src="examples/$example"
+            echo "::group::building $src"
+            bundle exec jekyll build \
+              --source "$src" \
+              --config "$src/_config.yml,$src/_config_deploy.yml" \
+              --destination "_site/examples/$example"
+            echo "::endgroup::"
+          done
+
+      # A missing example directory would deploy a site with dead nav links, so
+      # fail here rather than shipping it.
+      - name: Verify the stitched tree
+        run: |
+          set -euo pipefail
+          test -f _site/index.html || { echo "::error::theme site did not build"; exit 1; }
+          for example in swerve-of-shore; do
+            page="_site/examples/$example/index.html"
+            test -f "$page" || { echo "::error::$example did not build"; exit 1; }
+            echo "ok: $page"
+          done
+          # The custom domain lives in the repo root CNAME; Jekyll copies it into
+          # _site. Without it, an Actions deploy drops the custom domain.
+          test -f _site/CNAME || { echo "::error::CNAME missing from _site — custom domain would break"; exit 1; }
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: _site
+
+  deploy:
+    name: Deploy to Pages
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/_data/navigation/main.yml
+++ b/_data/navigation/main.yml
@@ -57,6 +57,12 @@
       url: /docs/docker/
     - title: Features
       url: /features/
+    # Live demo site, built by .github/workflows/pages.yml into
+    # /examples/swerve-of-shore/. Not part of this site's Jekyll build —
+    # examples/ is excluded from _config.yml — so this is an absolute path
+    # into the deployed tree rather than a page in site.html_pages.
+    - title: Example Site
+      url: /examples/swerve-of-shore/
     - title: Troubleshooting
       url: /docs/troubleshooting/
 

--- a/examples/swerve-of-shore/_config_deploy.yml
+++ b/examples/swerve-of-shore/_config_deploy.yml
@@ -1,0 +1,26 @@
+# =============================================================================
+# Deployment overrides for the Swerve of Shore example
+# =============================================================================
+# Layered over _config.yml by .github/workflows/pages.yml, which builds this
+# example into the main site's output at /examples/swerve-of-shore/.
+#
+# Two differences from _config.yml:
+#
+#   1. The theme resolves to this repository's sources rather than the
+#      published remote theme, so the example demonstrates the theme as it
+#      exists on main — not as it was at the last gem release.
+#   2. url/baseurl point at the live domain and the subpath the workflow
+#      publishes to, so every `relative_url` resolves correctly.
+#
+# Not used for local development — that is _config_dev.yml (port 4010).
+# =============================================================================
+
+remote_theme             : false
+theme                    : "jekyll-theme-zer0"
+
+url                      : "https://zer0-mistakes.com"
+baseurl                  : "/examples/swerve-of-shore"
+
+environment              : "production"
+show_drafts              : false
+future                   : false


### PR DESCRIPTION
## Description

The example site added in #339 was never reachable at zer0-mistakes.com, and nothing linked to it. Both follow from the same cause.

**zer0-mistakes.com is built by GitHub's classic "deploy from a branch" Pages builder** — one `jekyll build` with `_config.yml`. `examples/` sits in that config's `exclude:` list, so nothing under it is ever emitted. There's no deploy workflow, no `gh-pages` branch, and no nav entry, because there was nothing to link to.

It can't simply be un-excluded either: each example is a **separate** Jekyll site with its own `_config.yml`, its own `series` collection, and its own skin. Folded into the main build, that collection wouldn't be declared and its entries wouldn't render at all.

One classic build can't produce two differently-configured sites. So this moves deployment to Actions and runs one build per site:

```
_site/                           theme site   (_config.yml)
_site/examples/swerve-of-shore/  the example  (+ _config_deploy.yml)
```

Adding a second example means adding it to the `example` loop.

## What's here

- **`.github/workflows/pages.yml`** — builds both sites, stitches them, deploys. CODEOWNERS-owned, so this needs your review.
- **`examples/swerve-of-shore/_config_deploy.yml`** — points the example at the live domain and its subpath, and resolves the theme to *this repository's sources* rather than the published gem, so the demo shows the theme as it is on `main` rather than as of the last release.
- **Nav entry under Docs → Example Site.** Deliberately an absolute path: the target isn't in `site.html_pages` (examples/ is excluded from this site's build), so the theme's usual existence-guard pattern doesn't apply.

The build job verifies the stitched tree before upload — theme index, each example index, and **CNAME**. That last check matters: an Actions deploy without `CNAME` in `_site` silently drops the custom domain.

## ⚠️ Requires a repo setting change

**This is inert until you switch Settings → Pages → Build and deployment → Source from "Deploy from a branch" to "GitHub Actions".** Until then the classic builder keeps serving the site exactly as it does now, and this workflow's deploy step does nothing.

That also makes it safe to merge and flip separately — nothing changes for the live site until you throw the switch.

## Verification

Ran the workflow's exact sequence locally:

| Step | Result |
|---|---|
| Theme site build (`_config.yml`) | ✅ 84s |
| Example build into subpath | ✅ 8s |
| `_site/index.html` | ✅ |
| `_site/examples/swerve-of-shore/index.html` | ✅ |
| `_site/CNAME` | ✅ `zer0-mistakes.com` |

Served the stitched tree and checked routes:

```
200  /
200  /examples/swerve-of-shore/
200  /examples/swerve-of-shore/series/ulysses/
```

Nav link on the theme site resolves to `/examples/swerve-of-shore/`, which exists in the deployed tree. Example assets resolve through the subpath (`/examples/swerve-of-shore/assets/css/main.css`, `user-overrides.css`) and are present on disk. Screenshotted the example at its deployed path — wordmark, hero images, cards, and nav all render correctly through the `/examples/swerve-of-shore` baseurl.

`./scripts/validate --quick` passes; workflow, deploy config, and navigation YAML all parse.

## Type

- [x] `feat` — new feature
- [ ] `fix` — bug fix
- [ ] `docs` — documentation only
- [ ] `refactor` / `perf` / `style`
- [ ] `test` — tests only
- [ ] `chore` / `ci`

## Checklist

- [x] Conventional-commit title (`type(scope): subject`)
- [ ] `CHANGELOG.md` updated under `[Unreleased]` — skipped deliberately; the Conventional Commit title means release-please picks it up, and #344 just finished repairing that file
- [x] Jekyll build validated — both sites, plus the stitched tree
- [x] No version bump (`lib/jekyll-theme-zer0/version.rb` untouched)
- [ ] Backlog task status updated in `_data/backlog.yml` — n/a

---
_Generated by [Claude Code](https://claude.ai/code/session_01HGVMZnU6MV32kESizd7H2B)_