### PR TITLE
fix(ci): unbreak the production Pages build, frozen since 2026-08-05

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -21,9 +21,17 @@
 # the site and this workflow's deploy step is inert.
 name: Pages
 
+# Also builds (never deploys) on pull requests. Nothing else in CI runs
+# `jekyll build` against the PRODUCTION config — ci.yml only path-filters on
+# _config*.yml — so until now a change could break the real site and CI stayed
+# green. That is exactly how the deploy died silently twice in two days: #346
+# shipped a translated page whose layout aborts the build, and #349 fixed a
+# different instance of the same class. Building here on PRs makes that failure
+# visible before merge instead of after.
 on:
   push:
     branches: [main]
+  pull_request:
   workflow_dispatch:
 
 permissions:
@@ -32,10 +40,12 @@ permissions:
   id-token: write
 
 # Never let two deploys race; let an in-flight one finish rather than shipping
-# a half-built tree.
+# a half-built tree. Keyed by ref so PR builds queue against themselves rather
+# than against main's deploys; a superseded PR build is worth cancelling, a
+# half-finished deploy is not.
 concurrency:
-  group: pages
-  cancel-in-progress: false
+  group: pages-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   build:
@@ -105,6 +115,8 @@ jobs:
   deploy:
     name: Deploy to Pages
     needs: build
+    # PRs build only — a pull request must never publish to the live domain.
+    if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     environment:
       name: github-pages

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,9 +16,34 @@ file. Only `## [Unreleased]` describes work that has not shipped yet.
 
 ### Fixed
 
+- **GitHub Pages production deploy no longer fails at all — the site had been
+  frozen since 2026-08-05.** Three independent faults, each of which aborted the
+  whole production `jekyll build`, so nothing published after #346:
+  1. `_layouts/collection.html` sorted `site[page.collection]` without checking
+     it resolved. A page can select this layout in front matter while living
+     outside any collection, making that lookup `nil`; Liquid's `sort` then
+     raises `Cannot sort a null object.` and kills the *entire* build, not just
+     the page. It now falls back to an empty list.
+  2. `scripts/translate.rb` copied `layout: collection` into the flat `fr/**`
+     tree, which is exactly the misconfiguration above — `fr/docs/index.md` was
+     the page that took the site down. Collection-only layouts are now dropped
+     from generated translations so the `path: fr` default (`layout: default`)
+     applies, and the affected page is regenerated.
+  3. `CHANGELOG.md` is a published page (`/CHANGELOG/`), so its prose is parsed
+     as Liquid. Two entries quoted Liquid tags without a `raw` guard; one of
+     them genuinely executed `include_relative` on `_config.yml`, which in turn
+     tripped over a literal `mermaid` tag written inside a config comment.
+     Both entries are now guarded and the config comment no longer spells the
+     tag out.
+
+- **Production builds are now verified before merge.** `.github/workflows/pages.yml`
+  builds (never deploys) on pull requests. No other job ran `jekyll build`
+  against the production config, which is why all three faults above reached
+  `main` with CI green.
+
 - **GitHub Pages production deploy no longer fails on the translated config
   page.** The admin config utility `pages/_about/settings/config.md` embeds a
-  raw `_config.yml` dump via `{% include_relative _config.yml %}`, but the
+  raw `_config.yml` dump via {% raw %}`{% include_relative _config.yml %}`{% endraw %}, but the
   translation pipeline copied the page into `fr/about/settings/` without its
   sibling data file, so the production `github-pages` build died with
   `Could not locate the included file '_config.yml'`. The page is now excluded
@@ -256,7 +281,7 @@ file. Only `## [Unreleased]` describes work that has not shipped yet.
 ### Fixed
 
 - **Left-sidebar nav highlighted every item as "active".** `nav-tree.html`
-  used `{% assign is_active = page.url == item.url %}`, but Liquid `assign`
+  used {% raw %}`{% assign is_active = page.url == item.url %}`{% endraw %}, but Liquid `assign`
   does not evaluate `==` — it stored `page.url` (always truthy), so every link
   rendered with the active style. Replaced the three broken assigns
   (`is_active`, `child_active`, `gc_active`) with proper conditional assigns so

--- a/_config.yml
+++ b/_config.yml
@@ -482,7 +482,11 @@ plugins:
   # {% include_cached %} tag used by setup-banner.html and other includes to
   # collapse per-page renders of stable content into a single cached render.
   - jekyll-include-cache
-  # Note: jekyll-mermaid is NOT in GitHub Pages whitelist - it only provides {% mermaid %} Liquid tag
+  # Note: jekyll-mermaid is NOT in GitHub Pages whitelist - it only provides the
+  # `mermaid` Liquid tag. Do NOT write that tag with its Liquid braces anywhere in
+  # this file: github-pages filters the non-whitelisted gem out, so the tag never
+  # registers, and a literal occurrence here is parsed as a real tag and fails the
+  # build with "Unknown tag 'mermaid'".
   # Mermaid diagrams work without this plugin via client-side JavaScript (see _includes/components/mermaid.html)
   - jekyll-mermaid
 

--- a/_layouts/collection.html
+++ b/_layouts/collection.html
@@ -53,13 +53,25 @@ layout: default
 <!-- ========================== -->
 <!-- COLLECTION DATA PROCESSING -->
 <!-- ========================== -->
-<!-- Extract and sort collection entries based on page configuration -->
-{% assign entries = site[page.collection] %}
-{% assign entries = entries | sort: page.sort_order %}
+<!-- Extract and sort collection entries based on page configuration.
 
-<!-- Handle reverse sorting if specified -->
-{% if page.sort_order == 'reverse' %}
-    {% assign entries = entries | reverse %}
+     Jekyll sets page.collection automatically for a document inside a
+     collection, but a standalone page can also select this layout in its front
+     matter. When it does — or when it names a collection the site does not
+     declare — site[page.collection] is nil, and `sort` on nil raises
+     "Cannot sort a null object.", which aborts the ENTIRE build rather than
+     just this page. Resolve to an empty list instead so one misconfigured page
+     cannot take the site down. -->
+{% assign entries = site[page.collection] %}
+{% if entries %}
+    {% assign entries = entries | sort: page.sort_order %}
+
+    <!-- Handle reverse sorting if specified -->
+    {% if page.sort_order == 'reverse' %}
+        {% assign entries = entries | reverse %}
+    {% endif %}
+{% else %}
+    {% assign entries = "" | split: "" %}
 {% endif %}
 
 <!-- ========================== -->

--- a/fr/docs/index.md
+++ b/fr/docs/index.md
@@ -1,7 +1,6 @@
 ---
 title: Documentation
 author: Amr Abdel Eissa
-layout: collection
 description: Documentation utilisateur du thème Jekyll Zer0-Mistakes - guides d'installation,
   de fonctionnalités, de personnalisation et de déploiement.
 preview: "/images/previews/published-documentation-library.png"

--- a/scripts/translate.rb
+++ b/scripts/translate.rb
@@ -90,6 +90,14 @@ module Zer0Translate
     permalink redirect_from redirect_to aliases lang
     translation_of translation_source_url machine_translated translated_from_sha
   ].freeze
+  # Layouts that only work for a document INSIDE a Jekyll collection. The
+  # translated tree is deliberately flat — fr/** are plain pages, not collection
+  # documents — so Jekyll never sets `page.collection` there and these layouts
+  # have nothing to enumerate. `collection` is worse than useless: it sorts
+  # site[page.collection], which is nil for a plain page, and a nil sort aborts
+  # the whole Jekyll build. Drop the key so the `path: <lang>` front-matter
+  # default in _config.yml (layout: default) applies instead.
+  COLLECTION_ONLY_LAYOUTS = %w[collection].freeze
 
   DEFAULT_CONFIG = {
     "enabled" => false,
@@ -1073,6 +1081,7 @@ module Zer0Translate
         key = "fm:#{field}"
         fm[field] = fm_masker.unmask(translated[key]) if translated.key?(key)
       end
+      fm.delete("layout") if COLLECTION_ONLY_LAYOUTS.include?(fm["layout"].to_s)
       fm["lang"] = job.lang
       fm["permalink"] = "/#{job.lang}#{job.url}"
       fm["translation_of"] = file.rel_path

--- a/test/test_i18n.sh
+++ b/test/test_i18n.sh
@@ -118,6 +118,28 @@ title: Excluded
 Should never be translated.
 MD
 
+  # Source doc using a collection-only layout. Valid here (it IS a collection
+  # document) but not once copied into the flat translated tree — see
+  # test_collection_layout_dropped.
+  cat > "$sandbox/pages/_docs/index.md" <<'MD'
+---
+title: Docs Index
+layout: collection
+---
+
+Browse the docs.
+MD
+
+  # Same, with an ordinary layout that must survive translation untouched.
+  cat > "$sandbox/pages/_docs/guide.md" <<'MD'
+---
+title: Guide
+layout: default
+---
+
+A guide.
+MD
+
   cat > "$sandbox/_data/ui-text.yml" <<'YAML'
 en:
   search_label: "Search"
@@ -219,6 +241,32 @@ test_generation() {
     grep -q 'GENERATED FILE' "$sandbox/_data/i18n/fr.yml"
 }
 
+# ---------------------------------------------------------------------------
+# Collection-only layouts must not survive into the translated tree.
+#
+# fr/** are plain pages, not collection documents, so Jekyll never sets
+# `page.collection` there. _layouts/collection.html sorts site[page.collection];
+# for a plain page that is nil, and a nil sort aborts the ENTIRE Jekyll build.
+# That is exactly how fr/docs/index.md froze the production deploy for two days,
+# so this asserts the layout key is dropped (letting the `path: fr` front-matter
+# default apply) while ordinary layouts pass through untouched.
+test_collection_layout_dropped() {
+  log_info "Test: collection-only layouts are dropped from translations"
+  build_sandbox
+  run_translate >/dev/null
+
+  local idx="$sandbox/fr/docs/index.md"
+  local guide="$sandbox/fr/docs/guide.md"
+
+  assert "collection-layout page is still translated" test -f "$idx"
+  # test -f first: a bare `! grep <missing-file>` passes vacuously.
+  assert "layout: collection is dropped from the translation" \
+    bash -c "test -f '$idx' && ! grep -q '^layout: collection\$' '$idx'"
+  assert "no layout key is left behind at all" \
+    bash -c "test -f '$idx' && ! grep -q '^layout:' '$idx'"
+  assert "ordinary layout survives translation" grep -q '^layout: default$' "$guide"
+}
+
 test_incremental() {
   log_info "Test: incremental runs skip unchanged sources"
   local out
@@ -285,6 +333,7 @@ main() {
   log_info "i18n translation pipeline tests"
   test_generation
   test_prose_normalisation
+  test_collection_layout_dropped
   test_incremental
   test_check_and_dry_run
   test_prune


### PR DESCRIPTION
## Description

**zer0-mistakes.com has not published anything since #346 (2026-08-05.)** The Actions deploy from #353 surfaced it loudly on its very first run — the classic builder had been failing the same way, silently, for two days.

The tell: `/fr/` and `/fr/docs/` 404 on the live site while `fr/**` is *not* in `_config.yml`'s `exclude:`. Pages that exist in the repo and aren't excluded can only be missing from the live site if the build never finished.

Three independent faults, each fatal to the whole build. Jekyll aborts on the first error, so each was hidden behind the last — I only found #2 and #3 by fixing #1 and rebuilding.

**1. `_layouts/collection.html` sorted `site[page.collection]` unguarded.**
A page can select this layout in front matter while living outside any collection, which makes the lookup `nil`; Liquid's `sort` then raises `Cannot sort a null object.` and takes down the **entire** build, not just that page. Now falls back to an empty list. This is a theme-level footgun — any consumer could hit it.

**2. `scripts/translate.rb` copied `layout: collection` into the flat `fr/**` tree** — precisely the misconfiguration above. `fr/docs/index.md` was the page that killed the site. Collection-only layouts are now dropped from generated translations so the `path: fr` front-matter default (`layout: default`) applies, and the affected page is regenerated.

**3. `CHANGELOG.md` is a published page** (`/CHANGELOG/` is live), so its prose is parsed as Liquid. Two entries quoted Liquid tags without a `{% raw %}` guard. One of them genuinely executed `include_relative` on `_config.yml`, which then tripped over a literal `mermaid` tag written inside a config comment — `jekyll-mermaid` isn't on the GitHub Pages whitelist, so that tag never registers. Both entries are guarded and the comment no longer spells the tag out.

Fault 3 is quietly ironic: the entry that broke the build is the one documenting #349, the *previous* fix for this same class of failure.

### Why CI stayed green through all of it

Nothing ran `jekyll build` against the production config. `ci.yml` only path-filters on `_config*.yml`. So `pages.yml` now builds — never deploys — on pull requests too, and the next such failure shows up before merge instead of after. Concurrency is keyed by ref so PR builds queue against themselves; a superseded PR build is cancelled, a deploy never is.

This is the one piece beyond the immediate fix. It's here because the same class of breakage reached `main` twice in two days, and without it the third time is silent too. Drop that commit if you'd rather keep it out.

## Type

- [ ] `feat` — new feature
- [x] `fix` — bug fix
- [ ] `docs` — documentation only
- [ ] `refactor` / `perf` / `style`
- [ ] `test` — tests only
- [ ] `chore` / `ci`

## Checklist

- [x] Conventional-commit title (`type(scope): subject`) — this drives the automated version bump
- [x] `CHANGELOG.md` updated under `[Unreleased]` for user-visible changes
- [x] Jekyll build validated — see Verification below
- [x] No version bump (`lib/jekyll-theme-zer0/version.rb` untouched — releases are automated)
- [ ] Backlog task status updated in `_data/backlog.yml` (not a backlog task)

## Verification

Ran the workflow's exact sequence locally on **jekyll 3.10.0** — the `github-pages` pin CI actually uses, not the Docker dev image:

| Step | Result |
|---|---|
| Theme site (`_config.yml`) | builds, **72s** (was: aborted) |
| Example (`_config.yml,_config_deploy.yml`) | builds into subpath, 6s |
| Verify: theme index / example index / CNAME | all pass |
| `/fr/docs/` | renders, real title, 218KB, no empty-collection stub |
| `test_i18n.sh` | **56 passed, 0 failed** |

**Non-behavioural for real collection pages:** `/docs/` renders **92** cards after the guard; the live `/docs/` page renders **92**. Identical.

**The regression test genuinely catches the bug** — reverted just the one-line generator fix and re-ran:

```
against UNFIXED generator:  ✗ layout: collection is dropped   ✗ no layout key left behind   → Failed: 2
against FIXED generator:    ✓ layout: collection is dropped   ✓ no layout key left behind   → Failed: 0
```

## Note on scope

`.github/workflows/` and `CHANGELOG.md` are CODEOWNERS-owned, so this needs your review — it can't and shouldn't auto-merge.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HGVMZnU6MV32kESizd7H2B)_