### PR TITLE
fix(ci): give the Dependabot label job an explicit GH_REPO

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -31,9 +31,16 @@ jobs:
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
 
+      # NOTE: this job deliberately does not check out the repo (it runs under
+      # pull_request_target, so the PR head is untrusted). Without a checkout
+      # `gh` has no git remote to infer the repository from and fails with
+      # "fatal: not a git repository" — GH_REPO gives it the target explicitly.
+      # Same class of gotcha as the `gh pr diff`/`gh pr merge` notes in
+      # auto-merge.yml.
       - name: Label patch/minor bumps for auto-merge
         if: steps.metadata.outputs.update-type != 'version-update:semver-major'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
           PR: ${{ github.event.pull_request.number }}
         run: gh pr edit "$PR" --add-label auto-merge


### PR DESCRIPTION
## Problem

The `label` job in `dependabot-auto-merge.yml` has been **failing on every Dependabot PR** since it was added. Currently red on #354, #368 and #369.

The job resolves Dependabot metadata fine, then dies on the very next step:

```
Run gh pr edit "$PR" --add-label auto-merge
failed to run git: fatal: not a git repository (or any of the parent directories): .git
##[error]Process completed with exit code 1.
```

([run 31317857019](https://github.com/bamr87/zer0-mistakes/actions/runs/31317857019/job/93255913391))

## Root cause

The job runs under `pull_request_target` and — correctly — never checks out the PR head, since that head is untrusted code. But that leaves `gh` with no git remote to infer the repository from, so `gh pr edit` shells out to git and fails.

`auto-merge.yml` already documents exactly this class of gotcha in two places:

> `gh pr diff --name-only` internally invokes git and fails without a repo

> Enable via the GraphQL mutation, NOT `gh pr merge --auto`: this `pull_request_target` job intentionally does not check out the (untrusted) PR, and `gh pr merge` shells out to git, failing with "not a git repository".

This job hit the same wall without carrying the workaround across.

## Fix

Set `GH_REPO: ${{ github.repository }}`. That is the documented way to point `gh` at a repository explicitly, and it needs no checkout — so the security posture is unchanged.

## Impact

Because the label never landed, the `auto-merge` fast path never engaged. Every Dependabot PR has been sitting open with a red check waiting on a human, which is the exact outcome this workflow exists to prevent.

## Validation

- `yaml.safe_load` parses the file.
- Change is a two-line env addition plus a comment; no logic, permissions, or trigger changes.
- Behaviour is verified by the next Dependabot PR labelling successfully (this workflow only runs for `github.actor == 'dependabot[bot]'`, so it cannot self-test on this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)